### PR TITLE
ci: make project-automation workflow continue on error

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   project-automation:
     runs-on: ubuntu-latest
+    continue-on-error: true  # Don't fail the workflow if project board updates fail
     steps:
       - name: Move issue to Ready when labeled with priority
         if: github.event_name == 'issues' && github.event.action == 'labeled'
+        continue-on-error: true
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/ultimo-rs/projects/1
@@ -18,6 +20,7 @@ jobs:
 
       - name: Move issue to In Progress when assigned
         if: github.event_name == 'issues' && github.event.action == 'assigned'
+        continue-on-error: true
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/ultimo-rs/projects/1
@@ -25,6 +28,7 @@ jobs:
 
       - name: Move PR to Review when opened
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        continue-on-error: true
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/ultimo-rs/projects/1
@@ -32,6 +36,7 @@ jobs:
 
       - name: Move PR to Done when merged
         if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+        continue-on-error: true
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/ultimo-rs/projects/1


### PR DESCRIPTION
Stops the **Project Automation** workflow from showing a red ❌ on every issue/PR event.

## Root cause
The workflow uses the default `GITHUB_TOKEN`, which **cannot write to an org-level project** (`orgs/ultimo-rs/projects/1`) — runs fail with *"Resource not accessible by integration."*

## This change
Adds `continue-on-error` at the job and step level (cherry-picked from the original `feature/websocket-phase-2` commit). The workflow no longer fails CI.

## ⚠️ Follow-up needed for it to actually work
`continue-on-error` only silences the failure — the project board still won't auto-update. To make the automation functional, create a PAT with **project** scope (classic) or fine-grained org-project write, store it as a repo secret (e.g. `ADD_TO_PROJECT_PAT`), and swap `github-token: ${{ secrets.GITHUB_TOKEN }}` → that secret. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)