### PR TITLE
chore: release v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3407,7 +3407,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3415,6 +3415,7 @@ dependencies = [
  "criterion",
  "diesel",
  "futures-util",
+ "getrandom 0.3.4",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
@@ -3438,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/ultimo-cli/CHANGELOG.md
+++ b/ultimo-cli/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/ultimo/CHANGELOG.md
+++ b/ultimo/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.2.1...ultimo-v0.2.2) - 2026-06-04
+
+### Added
+
+- session management (cookies + secure sessions, in-memory store) — closes #3 ([#43](https://github.com/ultimo-rs/ultimo/pull/43))
+- testing utilities (TestClient, assertions, middleware/DB helpers, fixtures) — closes #4 ([#37](https://github.com/ultimo-rs/ultimo/pull/37))
+
+### Fixed
+
+- *(router)* static routes beat params regardless of order; add raw_body (#21, #22) ([#45](https://github.com/ultimo-rs/ultimo/pull/45))


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `ultimo-cli`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `ultimo`

<blockquote>

## [0.2.2](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.2.1...ultimo-v0.2.2) - 2026-06-04

### Added

- session management (cookies + secure sessions, in-memory store) — closes #3 ([#43](https://github.com/ultimo-rs/ultimo/pull/43))
- testing utilities (TestClient, assertions, middleware/DB helpers, fixtures) — closes #4 ([#37](https://github.com/ultimo-rs/ultimo/pull/37))

### Fixed

- *(router)* static routes beat params regardless of order; add raw_body (#21, #22) ([#45](https://github.com/ultimo-rs/ultimo/pull/45))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).