### PR TITLE
feat: session management (cookies + secure sessions, in-memory store) — closes #3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       # --all-targets here lints lib, integration tests and benches together,
       # all of which compile once websocket+test-helpers are enabled.
       # Database features are linted in the `test-db` job (needs system libs).
-      - name: clippy (websocket + test-helpers + testing, all targets)
-        run: cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing" -- -D warnings
+      - name: clippy (websocket + test-helpers + testing + session, all targets)
+        run: cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session" -- -D warnings
 
   # ── Unit + integration tests (no DB system deps) ──────────────────────
   test:
@@ -77,6 +77,14 @@ jobs:
         run: |
           cargo test -p ultimo --features "testing" --test testing_utils
           cargo test -p ultimo --features "testing" --doc
+
+      # Cookie (core) + session feature: unit, integration, security, and doctests.
+      - name: Cookie + session tests
+        run: |
+          cargo test -p ultimo --features "testing" --test cookie
+          cargo test -p ultimo --features "session" --lib session
+          cargo test -p ultimo --features "session,testing" --test session
+          cargo test -p ultimo --features "session" --doc
 
       # websocket_pubsub_bench uses test_helpers::ChannelManager, so benches
       # need test-helpers in addition to websocket.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cookie helper** (`ultimo::cookie`, core): `Cookie`/`CookieOptions`/`SameSite`,
+  RFC 6265 parsing + `Set-Cookie` formatting (with header-injection guards), and
+  `ctx.cookie`/`cookies`/`set_cookie`/`remove_cookie`.
+- **Session management** (`session` feature, #3): `SessionStore` trait +
+  `MemoryStore`, `Session` via `ctx.session()`, and secure session middleware
+  (256-bit ids, HttpOnly/Secure/SameSite defaults, anti session-fixation,
+  anti-DoS, server-side expiry), configurable via `SessionConfig`. Redis/SQL
+  stores and CSRF are planned follow-ups. See `docs/sessions.md`.
+
 - **Testing utilities** (`testing` feature, #4): in-process `TestClient`, fluent
   request builder, `TestResponse` with assertion helpers, `assert_json_eq!` /
   `assert_status!` macros, middleware test helpers (`test_context`,

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,100 @@
+# Sessions
+
+Ultimo ships cookie-based session management behind the `session` feature. It's
+structured Hono-style: cookies are a core helper, and sessions are middleware
+over a pluggable store.
+
+## Enable
+
+```toml
+[dependencies]
+ultimo = { version = "0.3", features = ["session"] }
+```
+
+## Register the middleware
+
+```rust
+use ultimo::session::{session, MemoryStore, SessionConfig};
+
+let mut app = Ultimo::new_without_defaults();
+app.use_middleware(session(MemoryStore::new(), SessionConfig::default()));
+```
+
+## Read & write
+
+Access the session from any handler via `ctx.session()`:
+
+```rust
+// write
+app.post("/login", |ctx: Context| async move {
+    ctx.session().await.set("user_id", &42u64).await?;
+    ctx.text("logged in").await
+});
+
+// read
+app.get("/me", |ctx: Context| async move {
+    let id: Option<u64> = ctx.session().await.get("user_id").await?;
+    ctx.json(serde_json::json!({ "user_id": id })).await
+});
+```
+
+Values are typed (serde): `set(key, &value)` / `get::<T>(key)`. Other methods:
+`remove(key)`, `clear()`, `id()`.
+
+## Security model
+
+Defaults are secure:
+
+- **256-bit random ids** (`getrandom`); the session id is opaque and unguessable.
+- **`HttpOnly` + `Secure` + `SameSite=Lax`** cookie by default.
+- **Server-side data** — only the id is in the cookie, so there's no tampering or
+  confidentiality risk on the client.
+- **Anti session-fixation** — a client-supplied id is never adopted; unknown ids
+  get a fresh server id. Call **`regenerate(new_id)`** on login/privilege change.
+- **Anti-DoS** — empty/untouched sessions are not persisted and get no cookie.
+- **Expiration** — enforced server-side (store TTL) *and* via the cookie `Max-Age`.
+
+On logout, call `ctx.session().await.destroy()` — it removes the server-side
+entry and expires the cookie.
+
+> **CSRF:** `SameSite=Lax` is partial protection. Full CSRF tokens are a planned
+> follow-up; don't rely on sessions alone for CSRF defense yet.
+
+### Local development
+
+The `Secure` cookie won't be sent over plain HTTP. For local dev:
+
+```rust
+SessionConfig::default().secure(false)  // dev only
+```
+
+## Configuration
+
+```rust
+use std::time::Duration;
+use ultimo::cookie::SameSite;
+
+SessionConfig::default()
+    .cookie_name("my_sid")
+    .ttl(Duration::from_secs(3600))
+    .same_site(SameSite::Strict)
+    .secure(true)
+```
+
+`SameSite::None` requires `secure(true)` (enforced at construction).
+
+## Stores
+
+`MemoryStore` (single-process) is built in. Implement the `SessionStore` trait
+for other backends:
+
+```rust
+#[async_trait::async_trait]
+impl SessionStore for MyStore {
+    async fn load(&self, id: &str) -> Option<SessionData> { /* ... */ }
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration) { /* ... */ }
+    async fn destroy(&self, id: &str) { /* ... */ }
+}
+```
+
+Redis and SQL stores are planned follow-ups.

--- a/docs/superpowers/plans/2026-06-03-session-management.md
+++ b/docs/superpowers/plans/2026-06-03-session-management.md
@@ -1,0 +1,1052 @@
+# Session Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cookie-based session management for Ultimo — core cookie helper + a `session` feature providing `SessionStore`/`MemoryStore`, a `Session` handle on Context, and secure session middleware (issue #3, core slice).
+
+**Architecture:** Cookies live in core (hand-rolled, no new dep) with a `Vec<Set-Cookie>` slot on Context flushed onto the final `Response` in `app.rs::dispatch_parts`. Sessions sit behind a `session` Cargo feature as middleware over an `#[async_trait] SessionStore` (the one extension point), with `MemoryStore` as the first backend. Security is designed in (see spec).
+
+**Tech Stack:** Rust, hyper 1.x, tokio, serde_json (existing), `async-trait` + `base64` (existing deps), `getrandom` 0.3 (new, session-gated).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-session-management-design.md` (read its Security section before Task 7).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `ultimo/src/cookie.rs` (create) | `Cookie`, `CookieOptions`, `SameSite`, parse + Set-Cookie formatting (validated) |
+| `ultimo/src/context.rs` (modify) | `set_cookies` slot + `cookie/cookies/set_cookie/remove_cookie`; `session` slot + `session()` (gated) |
+| `ultimo/src/app.rs` (modify) | flush queued `Set-Cookie` onto the response in `dispatch_parts` |
+| `ultimo/src/lib.rs` (modify) | `pub mod cookie;` + `#[cfg(feature="session")] pub mod session;` |
+| `ultimo/Cargo.toml` (modify) | `session` feature + optional `getrandom` |
+| `ultimo/src/session/mod.rs` (create) | `Session` handle + `SessionData` + re-exports |
+| `ultimo/src/session/store.rs` (create) | `SessionStore` trait + `MemoryStore` |
+| `ultimo/src/session/config.rs` (create) | `SessionConfig` (+ validation) |
+| `ultimo/src/session/middleware.rs` (create) | `session(store, config)` middleware |
+| `ultimo/tests/cookie.rs` (create) | cookie integration tests |
+| `ultimo/tests/session.rs` (create) | session + security integration tests (uses `testing`) |
+
+**Verification commands:**
+- Cookies (core): `cargo test -p ultimo --lib cookie` / `cargo test -p ultimo --test cookie`
+- Sessions: `cargo test -p ultimo --features "session" --lib`
+- Session integration: `cargo test -p ultimo --features "session,testing" --test session`
+- Lint: `cargo clippy -p ultimo --all-targets --features "session,testing,websocket,test-helpers" -- -D warnings`
+
+---
+
+## Task 1: Cookie primitives (core)
+
+**Files:** Create `ultimo/src/cookie.rs`; modify `ultimo/src/lib.rs`.
+
+- [ ] **Step 1: Declare the module** — in `ultimo/src/lib.rs`, near the other `pub mod` lines, add:
+
+```rust
+pub mod cookie;
+```
+
+- [ ] **Step 2: Write `ultimo/src/cookie.rs` with failing-test-first content**
+
+```rust
+//! HTTP cookie parsing and `Set-Cookie` formatting (RFC 6265).
+
+use crate::error::{Result, UltimoError};
+use std::collections::HashMap;
+
+/// `SameSite` cookie attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SameSite {
+    Strict,
+    Lax,
+    None,
+}
+
+impl SameSite {
+    fn as_str(&self) -> &'static str {
+        match self {
+            SameSite::Strict => "Strict",
+            SameSite::Lax => "Lax",
+            SameSite::None => "None",
+        }
+    }
+}
+
+/// Attributes for a `Set-Cookie`.
+#[derive(Debug, Clone, Default)]
+pub struct CookieOptions {
+    pub http_only: bool,
+    pub secure: bool,
+    pub same_site: Option<SameSite>,
+    /// Max-Age in seconds.
+    pub max_age: Option<i64>,
+    pub path: Option<String>,
+    pub domain: Option<String>,
+}
+
+/// A cookie to emit via `Set-Cookie`.
+#[derive(Debug, Clone)]
+pub struct Cookie {
+    pub name: String,
+    pub value: String,
+    pub options: CookieOptions,
+}
+
+impl Cookie {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+            options: CookieOptions::default(),
+        }
+    }
+
+    pub fn http_only(mut self, v: bool) -> Self {
+        self.options.http_only = v;
+        self
+    }
+    pub fn secure(mut self, v: bool) -> Self {
+        self.options.secure = v;
+        self
+    }
+    pub fn same_site(mut self, v: SameSite) -> Self {
+        self.options.same_site = Some(v);
+        self
+    }
+    pub fn max_age(mut self, secs: i64) -> Self {
+        self.options.max_age = Some(secs);
+        self
+    }
+    pub fn path(mut self, p: impl Into<String>) -> Self {
+        self.options.path = Some(p.into());
+        self
+    }
+    pub fn domain(mut self, d: impl Into<String>) -> Self {
+        self.options.domain = Some(d.into());
+        self
+    }
+
+    /// Format as a `Set-Cookie` header value. Rejects names/values containing
+    /// control characters (header-injection guard).
+    pub fn to_set_cookie_string(&self) -> Result<String> {
+        validate_token(&self.name)?;
+        validate_value(&self.value)?;
+        let mut s = format!("{}={}", self.name, self.value);
+        if let Some(p) = &self.options.path {
+            validate_value(p)?;
+            s.push_str(&format!("; Path={p}"));
+        }
+        if let Some(d) = &self.options.domain {
+            validate_value(d)?;
+            s.push_str(&format!("; Domain={d}"));
+        }
+        if let Some(m) = self.options.max_age {
+            s.push_str(&format!("; Max-Age={m}"));
+        }
+        if let Some(ss) = self.options.same_site {
+            s.push_str(&format!("; SameSite={}", ss.as_str()));
+        }
+        if self.options.secure {
+            s.push_str("; Secure");
+        }
+        if self.options.http_only {
+            s.push_str("; HttpOnly");
+        }
+        Ok(s)
+    }
+}
+
+fn has_ctl(s: &str) -> bool {
+    s.bytes().any(|b| b < 0x20 || b == 0x7f)
+}
+
+fn validate_token(name: &str) -> Result<()> {
+    if name.is_empty() || has_ctl(name) || name.contains([';', '=', ' ', '\t']) {
+        return Err(UltimoError::BadRequest(format!("invalid cookie name: {name:?}")));
+    }
+    Ok(())
+}
+
+fn validate_value(value: &str) -> Result<()> {
+    if has_ctl(value) || value.contains([';', '\r', '\n']) {
+        return Err(UltimoError::BadRequest("invalid cookie value".to_string()));
+    }
+    Ok(())
+}
+
+/// Parse a request `Cookie:` header into name → value pairs.
+pub fn parse_cookie_header(header: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for pair in header.split(';') {
+        let pair = pair.trim();
+        if let Some((k, v)) = pair.split_once('=') {
+            out.insert(k.trim().to_string(), v.trim().to_string());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_multiple_cookies() {
+        let m = parse_cookie_header("a=1; b=2;  c=3");
+        assert_eq!(m.get("a").map(String::as_str), Some("1"));
+        assert_eq!(m.get("b").map(String::as_str), Some("2"));
+        assert_eq!(m.get("c").map(String::as_str), Some("3"));
+    }
+
+    #[test]
+    fn formats_all_attributes() {
+        let c = Cookie::new("sid", "abc")
+            .http_only(true)
+            .secure(true)
+            .same_site(SameSite::Lax)
+            .max_age(3600)
+            .path("/");
+        let s = c.to_set_cookie_string().unwrap();
+        assert!(s.starts_with("sid=abc"));
+        assert!(s.contains("; Path=/"));
+        assert!(s.contains("; Max-Age=3600"));
+        assert!(s.contains("; SameSite=Lax"));
+        assert!(s.contains("; Secure"));
+        assert!(s.contains("; HttpOnly"));
+    }
+
+    #[test]
+    fn rejects_header_injection() {
+        let c = Cookie::new("sid", "abc\r\nSet-Cookie: evil=1");
+        assert!(c.to_set_cookie_string().is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Run tests** — `cargo test -p ultimo --lib cookie` → 3 pass.
+- [ ] **Step 4: clippy + fmt** — `cargo clippy -p ultimo --lib -- -D warnings` clean; `cargo fmt --all`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/src/cookie.rs ultimo/src/lib.rs
+git commit -m "feat(cookie): RFC6265 cookie parsing + Set-Cookie formatting"
+```
+
+---
+
+## Task 2: Context cookie API + response flush
+
+**Files:** Modify `ultimo/src/context.rs` (add `set_cookies` slot + methods), `ultimo/src/app.rs` (flush in `dispatch_parts`).
+
+- [ ] **Step 1: Add the slot to `Context`** — in `context.rs`, the `Context` struct (around line 150-159) add a field:
+
+```rust
+    set_cookies: Arc<RwLock<Vec<String>>>,
+```
+
+Initialize it in BOTH `Context::from_parts` (the constructor added earlier) — add `set_cookies: Arc::new(RwLock::new(Vec::new())),` alongside the other field inits.
+
+- [ ] **Step 2: Add cookie methods** — in the `impl Context` block (near `set`/`get`), add:
+
+```rust
+    /// Read a request cookie by name.
+    pub fn cookie(&self, name: &str) -> Option<String> {
+        self.req
+            .header("cookie")
+            .and_then(|h| crate::cookie::parse_cookie_header(&h).remove(name))
+    }
+
+    /// All request cookies.
+    pub fn cookies(&self) -> std::collections::HashMap<String, String> {
+        self.req
+            .header("cookie")
+            .map(|h| crate::cookie::parse_cookie_header(&h))
+            .unwrap_or_default()
+    }
+
+    /// Queue a `Set-Cookie` for the response. Errors if the cookie is invalid.
+    pub async fn set_cookie(&self, cookie: crate::cookie::Cookie) -> Result<()> {
+        let s = cookie.to_set_cookie_string()?;
+        self.set_cookies.write().await.push(s);
+        Ok(())
+    }
+
+    /// Queue a deletion of the named cookie (Max-Age=0).
+    pub async fn remove_cookie(&self, name: &str) -> Result<()> {
+        let c = crate::cookie::Cookie::new(name, "").max_age(0).path("/");
+        self.set_cookie(c).await
+    }
+
+    /// Drain queued Set-Cookie header values (used by the dispatcher).
+    pub(crate) async fn take_set_cookies(&self) -> Vec<String> {
+        std::mem::take(&mut *self.set_cookies.write().await)
+    }
+```
+
+> Note: `self.req.header(...)` returns `Option<String>` (see `Request::header`). Confirm the field name `req` on `Context` (it is `pub req: Request`).
+
+- [ ] **Step 3: Flush cookies in `dispatch_parts`** — in `app.rs`, the `dispatch_parts` method builds a `Context` (`ctx`) then runs the chain producing a `Response`. The Context is moved into `chain.execute(ctx, ...)`, so capture a clone of the cookie slot BEFORE moving it. Simplest: after building `ctx` and before `chain.execute`, clone the Arc handle is not exposed — instead, change the flow to retrieve cookies via the returned context. Since `execute` consumes `ctx`, use this approach: wrap the response post-processing by having the handler-execution return both. **Concretely:** the `Context` is `Clone`? It is not. Instead, add a helper: keep a clone of the `set_cookies` Arc.
+
+  Add, right after `let ctx = Context::from_parts(parts, body, params);` (and after any db attach), in BOTH the OPTIONS branch and the main branch:
+
+```rust
+        // Clone the cookie sink so we can flush it after the chain consumes ctx.
+        let cookie_sink = ctx.set_cookies_handle();
+```
+
+  And add this accessor to `impl Context` (context.rs):
+
+```rust
+    pub(crate) fn set_cookies_handle(&self) -> Arc<RwLock<Vec<String>>> {
+        self.set_cookies.clone()
+    }
+```
+
+  Then, after obtaining the final `response` from the chain (replace the `match result { Ok(response) => response, ... }` tail so it binds to a `let mut response = ...;`), append cookies:
+
+```rust
+        let mut response = match result {
+            Ok(response) => response,
+            Err(err) => {
+                error!("Handler error: {}", err);
+                response::helpers::error_response(&err)
+                    .unwrap_or_else(|_| response::helpers::text("Internal Error").unwrap())
+            }
+        };
+        for value in cookie_sink.write().await.drain(..) {
+            if let Ok(hv) = hyper::header::HeaderValue::from_str(&value) {
+                response
+                    .headers_mut()
+                    .append(hyper::header::SET_COOKIE, hv);
+            }
+        }
+        response
+```
+
+  Apply the same flush in the OPTIONS branch (it also runs middleware that may set cookies).
+
+  Add the import if missing: `use std::sync::Arc;` and `use tokio::sync::RwLock;` are already used via context; in app.rs add `use std::sync::Arc;` if not present.
+
+- [ ] **Step 4: Write the integration test** — create `ultimo/tests/cookie.rs`:
+
+```rust
+#![cfg(feature = "testing")]
+
+use ultimo::cookie::{Cookie, SameSite};
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+#[tokio::test]
+async fn set_cookie_appears_on_response() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/set", |ctx: Context| async move {
+        ctx.set_cookie(Cookie::new("sid", "xyz").http_only(true).same_site(SameSite::Lax))
+            .await?;
+        ctx.text("ok").await
+    });
+
+    let client = TestClient::new(app);
+    let res = client.get("/set").send().await;
+    let sc = res.header("set-cookie").unwrap();
+    assert!(sc.contains("sid=xyz"));
+    assert!(sc.contains("HttpOnly"));
+    assert!(sc.contains("SameSite=Lax"));
+}
+
+#[tokio::test]
+async fn reads_request_cookie() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/read", |ctx: Context| async move {
+        let v = ctx.cookie("token").unwrap_or_else(|| "none".into());
+        ctx.text(v).await
+    });
+
+    let client = TestClient::new(app);
+    let res = client.get("/read").header("cookie", "token=secret123").send().await;
+    assert_eq!(res.text(), "secret123");
+}
+```
+
+- [ ] **Step 5: Run** — `cargo test -p ultimo --features testing --test cookie` → 2 pass. Then `cargo test -p ultimo --lib` (no regressions) and `cargo test -p ultimo --features "websocket,test-helpers" --tests`.
+- [ ] **Step 6: clippy + fmt** — `cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing" -- -D warnings`; `cargo fmt --all`.
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultimo/src/context.rs ultimo/src/app.rs ultimo/tests/cookie.rs
+git commit -m "feat(context): cookie read + Set-Cookie flush on response"
+```
+
+---
+
+## Task 3: `session` feature + module skeleton + getrandom
+
+**Files:** Modify `ultimo/Cargo.toml`, `ultimo/src/lib.rs`; create `ultimo/src/session/mod.rs`.
+
+- [ ] **Step 1: Cargo.toml** — under `[features]` after `testing = []`:
+
+```toml
+# Session management (cookie-based, pluggable store)
+session = ["dep:getrandom"]
+```
+
+And under `[dependencies]` (near base64):
+
+```toml
+getrandom = { version = "0.3", optional = true }
+```
+
+- [ ] **Step 2: lib.rs** — add:
+
+```rust
+#[cfg(feature = "session")]
+pub mod session;
+```
+
+- [ ] **Step 3: Create `ultimo/src/session/mod.rs`** (minimal skeleton that compiles):
+
+```rust
+//! Cookie-based session management.
+//!
+//! Enable with the `session` feature. Register the middleware with a store:
+//! `app.use_middleware(session(MemoryStore::new(), SessionConfig::default()))`.
+
+mod config;
+mod middleware;
+mod store;
+
+pub use config::SessionConfig;
+pub use middleware::session;
+pub use store::{MemoryStore, SessionStore};
+
+use std::collections::HashMap;
+
+/// Session payload: arbitrary JSON values keyed by string.
+pub type SessionData = HashMap<String, serde_json::Value>;
+```
+
+> The `Session` type is added in Task 5; `config`/`store`/`middleware` submodules are filled in Tasks 4-7. To keep this task compiling on its own, create empty stub files now: `ultimo/src/session/{config,store,middleware}.rs` each `//! stub`, and temporarily comment the three `pub use` lines until their tasks add the types. (Each later task uncomments its own re-export.)
+
+- [ ] **Step 4: Verify** — `cargo build -p ultimo --features session` compiles. `cargo clippy -p ultimo --features session -- -D warnings` clean.
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/Cargo.toml ultimo/src/lib.rs ultimo/src/session/
+git commit -m "feat(session): feature flag + module skeleton + getrandom dep"
+```
+
+---
+
+## Task 4: `SessionStore` trait + `MemoryStore`
+
+**Files:** Replace `ultimo/src/session/store.rs`; uncomment store re-export in `mod.rs`.
+
+- [ ] **Step 1: Write `store.rs`**
+
+```rust
+//! Session store trait and in-memory implementation.
+
+use super::SessionData;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Backing store for session data. Implement this for Redis/SQL/etc.
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Load session data by id, or `None` if absent/expired.
+    async fn load(&self, id: &str) -> Option<SessionData>;
+    /// Persist session data under id with a time-to-live.
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration);
+    /// Remove a session.
+    async fn destroy(&self, id: &str);
+}
+
+/// In-memory store. Suitable for single-process apps and tests.
+#[derive(Clone, Default)]
+pub struct MemoryStore {
+    inner: Arc<RwLock<HashMap<String, (SessionData, Instant)>>>,
+}
+
+impl MemoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SessionStore for MemoryStore {
+    async fn load(&self, id: &str) -> Option<SessionData> {
+        let map = self.inner.read().await;
+        match map.get(id) {
+            Some((data, expiry)) if *expiry > Instant::now() => Some(data.clone()),
+            _ => None,
+        }
+    }
+
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration) {
+        let mut map = self.inner.write().await;
+        // Opportunistic eviction of expired entries.
+        let now = Instant::now();
+        map.retain(|_, (_, exp)| *exp > now);
+        map.insert(id.to_string(), (data.clone(), now + ttl));
+    }
+
+    async fn destroy(&self, id: &str) {
+        self.inner.write().await.remove(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn store_load_destroy_roundtrip() {
+        let s = MemoryStore::new();
+        let mut data = SessionData::new();
+        data.insert("k".into(), serde_json::json!("v"));
+        s.store("id1", &data, Duration::from_secs(60)).await;
+        assert_eq!(s.load("id1").await.unwrap().get("k").unwrap(), &serde_json::json!("v"));
+        s.destroy("id1").await;
+        assert!(s.load("id1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn expired_entries_are_not_loaded() {
+        let s = MemoryStore::new();
+        s.store("id2", &SessionData::new(), Duration::from_millis(1)).await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(s.load("id2").await.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Uncomment** `pub use store::{MemoryStore, SessionStore};` in `mod.rs`.
+- [ ] **Step 3: Run** — `cargo test -p ultimo --features session --lib session::store` → 2 pass.
+- [ ] **Step 4: clippy + fmt + commit**
+
+```bash
+git add ultimo/src/session/store.rs ultimo/src/session/mod.rs
+git commit -m "feat(session): SessionStore trait + MemoryStore"
+```
+
+---
+
+## Task 5: `Session` handle + Context integration
+
+**Files:** Modify `ultimo/src/session/mod.rs` (add `Session`); modify `ultimo/src/context.rs` (add gated `session` slot + `session()`).
+
+- [ ] **Step 1: Add `Session` to `mod.rs`** (append after `SessionData`):
+
+```rust
+use crate::error::Result;
+use serde::{de::DeserializeOwned, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::RwLock;
+
+/// A handle to the current session. Cheap to clone (shares inner state).
+#[derive(Clone)]
+pub struct Session {
+    inner: std::sync::Arc<SessionInner>,
+}
+
+struct SessionInner {
+    id: RwLock<String>,
+    data: RwLock<SessionData>,
+    dirty: AtomicBool,
+    destroyed: AtomicBool,
+    new_id: RwLock<Option<String>>, // set by regenerate()
+}
+
+impl Session {
+    pub(crate) fn new(id: String, data: SessionData) -> Self {
+        Self {
+            inner: std::sync::Arc::new(SessionInner {
+                id: RwLock::new(id),
+                data: RwLock::new(data),
+                dirty: AtomicBool::new(false),
+                destroyed: AtomicBool::new(false),
+                new_id: RwLock::new(None),
+            }),
+        }
+    }
+
+    /// Current session id.
+    pub async fn id(&self) -> String {
+        self.inner.id.read().await.clone()
+    }
+
+    /// Get a typed value by key.
+    pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
+        let data = self.inner.data.read().await;
+        match data.get(key) {
+            Some(v) => Ok(Some(serde_json::from_value(v.clone())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Set a typed value (marks the session dirty).
+    pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<()> {
+        let v = serde_json::to_value(value)?;
+        self.inner.data.write().await.insert(key.to_string(), v);
+        self.inner.dirty.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Remove a key (marks dirty).
+    pub async fn remove(&self, key: &str) {
+        self.inner.data.write().await.remove(key);
+        self.inner.dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Clear all data (marks dirty).
+    pub async fn clear(&self) {
+        self.inner.data.write().await.clear();
+        self.inner.dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Issue a new id on the next persist (session-fixation defense). The old
+    /// store entry is destroyed by the middleware.
+    pub async fn regenerate(&self, new_id: String) {
+        *self.inner.new_id.write().await = Some(new_id);
+        self.inner.dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Destroy the session (server-side + cookie).
+    pub fn destroy(&self) {
+        self.inner.destroyed.store(true, Ordering::SeqCst);
+    }
+
+    // --- internal accessors for the middleware ---
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.inner.dirty.load(Ordering::SeqCst)
+    }
+    pub(crate) fn is_destroyed(&self) -> bool {
+        self.inner.destroyed.load(Ordering::SeqCst)
+    }
+    pub(crate) async fn snapshot(&self) -> SessionData {
+        self.inner.data.read().await.clone()
+    }
+    pub(crate) async fn take_new_id(&self) -> Option<String> {
+        self.inner.new_id.write().await.take()
+    }
+    pub(crate) async fn is_empty(&self) -> bool {
+        self.inner.data.read().await.is_empty()
+    }
+}
+```
+
+- [ ] **Step 2: Add the Context slot (gated)** — in `context.rs`, the `Context` struct, add:
+
+```rust
+    #[cfg(feature = "session")]
+    session: Arc<RwLock<Option<crate::session::Session>>>,
+```
+
+Initialize in `Context::from_parts`: `#[cfg(feature = "session")] session: Arc::new(RwLock::new(None)),`.
+
+- [ ] **Step 3: Add Context session methods (gated)** — in `impl Context`:
+
+```rust
+    /// The current session. Panics if the session middleware isn't installed.
+    #[cfg(feature = "session")]
+    pub async fn session(&self) -> crate::session::Session {
+        self.session
+            .read()
+            .await
+            .clone()
+            .expect("session middleware not installed (add `session(store, config)`)")
+    }
+
+    #[cfg(feature = "session")]
+    pub(crate) async fn set_session(&self, s: crate::session::Session) {
+        *self.session.write().await = Some(s);
+    }
+```
+
+- [ ] **Step 4: Add a unit test in `mod.rs`** verifying the handle:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_get_and_dirty() {
+        let s = Session::new("id".into(), SessionData::new());
+        assert!(!s.is_dirty());
+        s.set("n", &7u32).await.unwrap();
+        assert!(s.is_dirty());
+        assert_eq!(s.get::<u32>("n").await.unwrap(), Some(7));
+    }
+}
+```
+
+- [ ] **Step 5: Run** — `cargo test -p ultimo --features session --lib session` → store + handle tests pass. `cargo build -p ultimo` (no session) still compiles.
+- [ ] **Step 6: clippy + fmt + commit**
+
+```bash
+git add ultimo/src/session/mod.rs ultimo/src/context.rs
+git commit -m "feat(session): Session handle + ctx.session() integration"
+```
+
+---
+
+## Task 6: `SessionConfig`
+
+**Files:** Replace `ultimo/src/session/config.rs`; uncomment config re-export in `mod.rs`.
+
+- [ ] **Step 1: Write `config.rs`**
+
+```rust
+//! Session configuration.
+
+use crate::cookie::SameSite;
+use std::time::Duration;
+
+/// Session middleware configuration. Secure-by-default.
+#[derive(Debug, Clone)]
+pub struct SessionConfig {
+    pub cookie_name: String,
+    pub ttl: Duration,
+    pub http_only: bool,
+    pub secure: bool,
+    pub same_site: SameSite,
+    pub path: String,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            cookie_name: "ultimo_sid".to_string(),
+            ttl: Duration::from_secs(60 * 60 * 24),
+            http_only: true,
+            secure: true,
+            same_site: SameSite::Lax,
+            path: "/".to_string(),
+        }
+    }
+}
+
+impl SessionConfig {
+    pub fn cookie_name(mut self, n: impl Into<String>) -> Self {
+        self.cookie_name = n.into();
+        self
+    }
+    pub fn ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+    pub fn secure(mut self, v: bool) -> Self {
+        self.secure = v;
+        self
+    }
+    pub fn same_site(mut self, v: SameSite) -> Self {
+        self.same_site = v;
+        self
+    }
+
+    /// Validate invariants. `SameSite=None` requires `Secure`.
+    pub fn validated(self) -> Self {
+        if self.same_site == SameSite::None && !self.secure {
+            panic!("SessionConfig: SameSite=None requires secure=true");
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secure_defaults() {
+        let c = SessionConfig::default();
+        assert!(c.http_only && c.secure);
+        assert_eq!(c.same_site, SameSite::Lax);
+    }
+
+    #[test]
+    #[should_panic(expected = "SameSite=None requires secure")]
+    fn samesite_none_requires_secure() {
+        SessionConfig::default().same_site(SameSite::None).secure(false).validated();
+    }
+}
+```
+
+- [ ] **Step 2: Uncomment** `pub use config::SessionConfig;` in `mod.rs`.
+- [ ] **Step 3: Run** — `cargo test -p ultimo --features session --lib session::config` → 2 pass.
+- [ ] **Step 4: clippy + fmt + commit**
+
+```bash
+git add ultimo/src/session/config.rs ultimo/src/session/mod.rs
+git commit -m "feat(session): SessionConfig with secure defaults + validation"
+```
+
+---
+
+## Task 7: Session middleware (security-critical — see spec Security section)
+
+**Files:** Replace `ultimo/src/session/middleware.rs`; uncomment middleware re-export in `mod.rs`; create `ultimo/tests/session.rs`.
+
+- [ ] **Step 1: Write `middleware.rs`**
+
+```rust
+//! Session middleware.
+
+use super::{Session, SessionConfig, SessionStore};
+use crate::context::Context;
+use crate::cookie::Cookie;
+use crate::middleware::{BoxedMiddleware, Next};
+use crate::response::Response;
+use base64::Engine;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Generate a 256-bit URL-safe session id. Panics if the OS RNG fails (we must
+/// never fall back to weak randomness for a security token).
+fn generate_id() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("OS RNG failure generating session id");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Build session middleware over `store`. Construct like the built-ins.
+pub fn session<S>(store: S, config: SessionConfig) -> BoxedMiddleware
+where
+    S: SessionStore + 'static,
+{
+    let store = Arc::new(store);
+    let config = Arc::new(config.validated());
+
+    Arc::new(move |ctx: Context, next: Next| {
+        let store = store.clone();
+        let config = config.clone();
+        Box::pin(async move {
+            // 1-2. Load existing session ONLY if the cookie id is known to the
+            // store. Never adopt a client-supplied id (anti session-fixation).
+            let cookie_id = ctx.cookie(&config.cookie_name);
+            let (id, data) = match &cookie_id {
+                Some(cid) => match store.load(cid).await {
+                    Some(d) => (cid.clone(), d),
+                    None => (generate_id(), super::SessionData::new()),
+                },
+                None => (generate_id(), super::SessionData::new()),
+            };
+
+            let session = Session::new(id.clone(), data);
+            ctx.set_session(session.clone()).await;
+
+            // 4. Run the handler.
+            let response: Response = next(ctx_with_session(&ctx)).await?;
+
+            // 5. Persist per the security rules.
+            if session.is_destroyed() {
+                store.destroy(&id).await;
+                let _ = queue_cookie(&ctx, expiry_cookie(&config)).await;
+            } else if session.is_dirty() && !session.is_empty().await {
+                let final_id = match session.take_new_id().await {
+                    Some(new_id) => {
+                        store.destroy(&id).await; // fixation: drop old entry
+                        new_id
+                    }
+                    None => id.clone(),
+                };
+                store.store(&final_id, &session.snapshot().await, config.ttl).await;
+                let _ = queue_cookie(&ctx, id_cookie(&config, &final_id)).await;
+            }
+            // empty/untouched session: persist nothing, no cookie (anti-DoS).
+
+            Ok(response)
+        }) as Pin<Box<dyn Future<Output = crate::error::Result<Response>> + Send>>
+    })
+}
+
+// `ctx` is shared via interior mutability; the same Context flows through.
+fn ctx_with_session(ctx: &Context) -> Context {
+    ctx.clone_handle()
+}
+
+async fn queue_cookie(ctx: &Context, cookie: Cookie) -> crate::error::Result<()> {
+    ctx.set_cookie(cookie).await
+}
+
+fn id_cookie(config: &SessionConfig, id: &str) -> Cookie {
+    Cookie::new(config.cookie_name.clone(), id.to_string())
+        .http_only(config.http_only)
+        .secure(config.secure)
+        .same_site(config.same_site)
+        .path(config.path.clone())
+        .max_age(config.ttl.as_secs() as i64)
+}
+
+fn expiry_cookie(config: &SessionConfig) -> Cookie {
+    Cookie::new(config.cookie_name.clone(), "")
+        .http_only(config.http_only)
+        .secure(config.secure)
+        .same_site(config.same_site)
+        .path(config.path.clone())
+        .max_age(0)
+}
+```
+
+> **Context sharing note:** the middleware needs to set the session on the same
+> Context the handler sees, then still reference `ctx` after `next` consumes it.
+> `Next` takes `Context` by value. Add a `pub(crate) fn clone_handle(&self) ->
+> Context` to `Context` that clones all the `Arc` slots (so both copies share the
+> same interior-mutable state — `state`, `response_*`, `set_cookies`, `session`,
+> and `req` must be shareable). If `Request` is not `Clone`, wrap the shared
+> bits; simplest is to make `Context` hold its fields as `Arc`s already (most are)
+> and derive a manual `clone_handle`. **Implementer:** verify `Context`'s fields
+> are all `Arc`-shared; `req: Request` holds `Arc<RwLock<..>>` for the body but
+> `method/uri/headers/params` are owned — make `clone_handle` clone those owned
+> values and share the `Arc`s. Add a focused unit test that a value set on one
+> handle is visible on the clone.
+
+- [ ] **Step 2: Uncomment** `pub use middleware::session;` in `mod.rs`.
+
+- [ ] **Step 3: Write security integration tests** — create `ultimo/tests/session.rs`:
+
+```rust
+#![cfg(all(feature = "session", feature = "testing"))]
+
+use ultimo::session::{session, MemoryStore, SessionConfig};
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(session(MemoryStore::new(), SessionConfig::default().secure(false)));
+    app.get("/login", |ctx: Context| async move {
+        ctx.session().await.set("uid", &42u64).await?;
+        ctx.text("ok").await
+    });
+    app.get("/me", |ctx: Context| async move {
+        let uid: Option<u64> = ctx.session().await.get("uid").await?;
+        ctx.json(serde_json::json!({ "uid": uid })).await
+    });
+    app.get("/anon", |ctx: Context| async move { ctx.text("hi").await });
+    app
+}
+
+fn sid(set_cookie: &str) -> String {
+    set_cookie.split(';').next().unwrap().to_string() // "ultimo_sid=VALUE"
+}
+
+#[tokio::test]
+async fn session_persists_across_requests() {
+    let client = TestClient::new(app());
+    let login = client.get("/login").send().await;
+    let cookie = sid(login.header("set-cookie").unwrap());
+
+    let me = client.get("/me").header("cookie", &cookie).send().await;
+    assert_eq!(me.json::<serde_json::Value>(), serde_json::json!({ "uid": 42 }));
+}
+
+#[tokio::test]
+async fn empty_session_sets_no_cookie() {
+    // anti-DoS: a request that never touches the session gets no Set-Cookie.
+    let client = TestClient::new(app());
+    let res = client.get("/anon").send().await;
+    assert!(res.header("set-cookie").is_none());
+}
+
+#[tokio::test]
+async fn unknown_client_id_is_not_adopted() {
+    // anti-fixation: a forged cookie id must not become the session id.
+    let client = TestClient::new(app());
+    let res = client
+        .get("/login")
+        .header("cookie", "ultimo_sid=attacker_fixed_id")
+        .send()
+        .await;
+    let issued = sid(res.header("set-cookie").unwrap());
+    assert_ne!(issued, "ultimo_sid=attacker_fixed_id");
+}
+
+#[tokio::test]
+async fn default_cookie_is_httponly_lax() {
+    let mut app = Ultimo::new_without_defaults();
+    // secure(true) default would also add Secure; here assert HttpOnly + SameSite.
+    app.use_middleware(session(MemoryStore::new(), SessionConfig::default().secure(false)));
+    app.get("/login", |ctx: Context| async move {
+        ctx.session().await.set("x", &1u8).await?;
+        ctx.text("ok").await
+    });
+    let res = TestClient::new(app).get("/login").send().await;
+    let sc = res.header("set-cookie").unwrap();
+    assert!(sc.contains("HttpOnly"));
+    assert!(sc.contains("SameSite=Lax"));
+}
+```
+
+- [ ] **Step 4: Run** — `cargo test -p ultimo --features "session,testing" --test session` → 4 pass. Fix the `clone_handle`/Context-sharing detail until the persistence test passes (this is the crux).
+- [ ] **Step 5: clippy + fmt** — `cargo clippy -p ultimo --all-targets --features "session,testing,websocket,test-helpers" -- -D warnings`; `cargo fmt --all`.
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/src/session/middleware.rs ultimo/src/session/mod.rs ultimo/src/context.rs ultimo/tests/session.rs
+git commit -m "feat(session): secure session middleware (fixation/DoS/cookie hardening)"
+```
+
+---
+
+## Task 8: Docs + CHANGELOG + CI wiring
+
+**Files:** create `docs/sessions.md`; modify `CHANGELOG.md`, `.github/workflows/ci.yml`.
+
+- [ ] **Step 1: Module doctest** — ensure `ultimo/src/session/mod.rs` has a runnable doc example (the login/me snippet from the spec, gated/`no_run` as needed). Run `cargo test -p ultimo --features "session" --doc`.
+
+- [ ] **Step 2: Guide** — create `docs/sessions.md` covering: enabling the feature, registering `session(store, config)`, `ctx.session().get/set`, `regenerate()` on login (security note), `destroy()` on logout, cookie/security defaults, and that Redis/DB stores + CSRF are forthcoming. Use the real API from Tasks 4-7.
+
+- [ ] **Step 3: CHANGELOG** — under `## [Unreleased]` → `### Added`:
+
+```markdown
+- Cookie helper (`ultimo::cookie`) + `ctx.cookie`/`set_cookie`/`remove_cookie`.
+- Session management (`session` feature): `SessionStore` + `MemoryStore`,
+  `Session` via `ctx.session()`, secure session middleware (HttpOnly/Secure/
+  SameSite, anti-fixation, anti-DoS), `SessionConfig`. (#3)
+```
+
+- [ ] **Step 4: CI** — in `.github/workflows/ci.yml`:
+  - `test` job, after the testing-utilities step, add:
+    ```yaml
+          - name: Session + cookie tests
+            run: |
+              cargo test -p ultimo --features "testing" --test cookie
+              cargo test -p ultimo --features "session,testing" --test session
+              cargo test -p ultimo --features "session" --lib
+    ```
+  - `lint` job: extend the feature clippy to include `session`:
+    `cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session" -- -D warnings`
+
+- [ ] **Step 5: Validate + full verify**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ok')"
+cargo fmt --all --check
+cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session" -- -D warnings
+cargo test -p ultimo --lib
+cargo test -p ultimo --features "testing" --test cookie
+cargo test -p ultimo --features "session,testing" --test session
+cargo test -p ultimo --features "session" --doc
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/sessions.md CHANGELOG.md .github/workflows/ci.yml ultimo/src/session/mod.rs
+git commit -m "docs+ci: session guide, changelog, CI wiring (#3)"
+```
+
+---
+
+## Notes for the implementer
+- **The crux is Task 7's Context sharing** (`clone_handle`): the session middleware sets the session, passes the Context to `next`, then reads the same session back after. All Context state is `Arc`-shared interior-mutable, so cloning the handle (sharing the `Arc`s) makes this work. Verify with the persistence test before moving on.
+- `getrandom` 0.3 uses `getrandom::fill(&mut buf)`. If the resolved version is 0.2, the call is `getrandom::getrandom(&mut buf)` — check `Cargo.lock`.
+- `base64` 0.21 is already a dep: `base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(..)` with `use base64::Engine;`.
+- `async-trait` is already a dep — used for `SessionStore` (keeps store futures `Send` + dyn-safe).
+- Keep every new public item documented (docs.rs).

--- a/docs/superpowers/specs/2026-06-03-session-management-design.md
+++ b/docs/superpowers/specs/2026-06-03-session-management-design.md
@@ -1,0 +1,153 @@
+# Session Management — Design Spec
+
+- **Issue:** [#3 Add session management system](https://github.com/ultimo-rs/ultimo/issues/3)
+- **Milestone:** v0.3.0
+- **Date:** 2026-06-03
+- **Status:** Approved (design), pending implementation plan
+- **Scope:** Core slice only (see "Out of scope" for deferred work)
+
+## Goal
+
+Built-in, secure, cookie-based session management for Ultimo apps, structured
+Hono-style: **cookies as a core helper**, **sessions as middleware over a
+pluggable store**. This slice ships a complete, working session system on an
+in-memory store; Redis/DB stores and CSRF are deferred and slot in behind the
+same `SessionStore` trait without rework.
+
+Target usage:
+
+```rust
+use ultimo::session::{session, MemoryStore, SessionConfig};
+
+let mut app = Ultimo::new_without_defaults();
+app.use_middleware(session(MemoryStore::new(), SessionConfig::default()));
+
+app.get("/login", |ctx: Context| async move {
+    ctx.session().set("user_id", &42u64).await?;
+    ctx.text("logged in").await
+});
+
+app.get("/me", |ctx: Context| async move {
+    let id: Option<u64> = ctx.session().get("user_id").await?;
+    ctx.json(serde_json::json!({ "user_id": id })).await
+});
+```
+
+## Approach
+
+- **Cookies live in core** (no feature flag), hand-rolled with **no new
+  dependency** — consistent with the zero-dependency websocket module. Cookie
+  parsing (`Cookie:` header) and emission (`Set-Cookie`) are small and
+  well-specified (RFC 6265).
+- **Sessions live behind a `session` Cargo feature** (`default = []`). The only
+  new dependency is **`getrandom`** (tiny) for cryptographically secure session
+  IDs. Session data (de)serializes via `serde_json` (already a dependency).
+- Sessions are delivered as **middleware over a `SessionStore` trait**, mirroring
+  Hono's "session as middleware" model. The store is the single extension point.
+
+## Module structure
+
+```
+ultimo/src/
+  cookie.rs            # CORE: Cookie, CookieOptions, parse + Set-Cookie formatting
+  session/
+    mod.rs             # Session handle + re-exports (gated: feature = "session")
+    store.rs           # SessionStore trait + MemoryStore
+    middleware.rs      # session() middleware constructor
+    config.rs          # SessionConfig
+```
+
+`lib.rs`: `pub mod cookie;` (core) and `#[cfg(feature = "session")] pub mod session;`.
+
+## Components
+
+### 1. Cookies (core, `ultimo::cookie` + Context methods)
+- `struct Cookie { name, value, options: CookieOptions }`.
+- `struct CookieOptions { http_only: bool, secure: bool, same_site: Option<SameSite>, max_age: Option<i64> /*seconds*/, path: Option<String>, domain: Option<String>, expires: Option<…> }` with a builder.
+- `enum SameSite { Strict, Lax, None }`.
+- Parsing: `parse_cookie_header(&str) -> HashMap<String, String>`.
+- Formatting: `Cookie::to_set_cookie_string() -> String` (RFC 6265 attributes).
+- Context API (additive):
+  - `ctx.cookie(name) -> Option<String>` — read a request cookie.
+  - `ctx.cookies() -> HashMap<String, String>` — all request cookies.
+  - `ctx.set_cookie(Cookie)` — queue a `Set-Cookie` (stored on Context, flushed onto the response).
+  - `ctx.remove_cookie(name)` — queue a deletion cookie (`Max-Age=0`).
+- **Response flushing:** Context accumulates queued Set-Cookie headers; they are
+  written onto the outgoing `Response` when the handler/middleware result is
+  finalized. (Mechanism detailed in the plan — likely a `Vec<String>` slot on
+  Context applied in `dispatch_parts` / by middleware.)
+
+### 2. `SessionStore` trait + `MemoryStore` (`session/store.rs`)
+```rust
+#[async_trait-like or RPIT]
+pub trait SessionStore: Send + Sync {
+    async fn load(&self, id: &str) -> Option<SessionData>;
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration);
+    async fn destroy(&self, id: &str);
+}
+```
+- `SessionData = HashMap<String, serde_json::Value>`.
+- `MemoryStore`: `Arc<RwLock<HashMap<String, (SessionData, Instant /*expiry*/)>>>`,
+  lazily evicting expired entries on access.
+
+### 3. `Session` handle (`session/mod.rs`)
+Accessed via `ctx.session()`. Holds the current id + an in-memory copy of the
+data + a dirty flag.
+- `id(&self) -> &str`
+- `get::<T: DeserializeOwned>(&self, key) -> Result<Option<T>>`
+- `set::<T: Serialize>(&self, key, &T) -> Result<()>` (marks dirty)
+- `remove(&self, key)` / `clear(&self)` (mark dirty)
+- `regenerate(&self)` — issue a new id (session fixation defense), keep data
+- `destroy(&self)` — drop the session + expire the cookie
+
+### 4. Session middleware (`session/middleware.rs`)
+`session(store, config) -> BoxedMiddleware`. Flow per request:
+1. Read the session-id cookie (`config.cookie_name`).
+2. If present, `store.load(id)`; else (or on miss) create a fresh session with a
+   new secure id.
+3. Attach the `Session` to the Context (typed slot; `ctx.session()` returns it).
+4. `next(ctx).await` → response.
+5. If the session is dirty/new: `store.store(id, data, ttl)` and queue the
+   `Set-Cookie` (HttpOnly/Secure/SameSite/Max-Age per config). If destroyed:
+   `store.destroy(id)` + queue an expiry cookie.
+6. Flush queued cookies onto the response.
+
+### 5. `SessionConfig` (`session/config.rs`)
+`{ cookie_name: String = "ultimo_sid", ttl: Duration = 24h, http_only: bool = true, secure: bool = true, same_site: SameSite = Lax, path: String = "/" }`, with a builder. Secure defaults.
+
+### 6. Secure IDs
+`getrandom` → 32 random bytes → URL-safe encoding (hex or base64url). No
+predictable IDs.
+
+## Context integration
+
+`Context` gains two additive slots (interior-mutable, like existing state):
+- `set_cookies: Arc<RwLock<Vec<String>>>` — queued Set-Cookie header values.
+- `session: Arc<RwLock<Option<Session>>>` — attached by the middleware;
+  `ctx.session()` reads it (panics with a clear message if the session
+  middleware isn't installed, or returns a Result — decided in the plan).
+
+`ctx.session()` returning a guard vs a cloneable handle is settled in the plan;
+the data lives in the store, the handle mediates access.
+
+## Testing strategy
+- Cookie unit tests: parse round-trips, Set-Cookie formatting (all attributes,
+  SameSite, Max-Age=0 deletion).
+- Session unit tests: MemoryStore load/store/destroy + expiry eviction.
+- Integration (via the `testing` feature's `TestClient`): login sets a cookie →
+  subsequent request with that cookie sees the session value; destroy clears it;
+  regenerate changes the id; expired session is not loaded.
+- All under CI with the `session` feature added to the relevant jobs.
+
+## Published-crate impact
+Additive only: new `cookie` core module + `ctx.cookie/cookies/set_cookie/remove_cookie`,
+new `session` feature + `ultimo::session` items + `ctx.session()`. No existing
+signature changes; `cargo-semver-checks` confirms. Ships in **v0.3.0**; add a
+`CHANGELOG.md` entry.
+
+## Out of scope (deferred follow-up issues)
+- Redis session store (implements `SessionStore`).
+- SQLx / Diesel session store (implements `SessionStore`).
+- CSRF protection (separate middleware, builds on sessions/cookies).
+- MessagePack serialization option (JSON only for now).
+- Signed/encrypted cookies (Hono's signed-cookie equivalent) — future.

--- a/docs/superpowers/specs/2026-06-03-session-management-design.md
+++ b/docs/superpowers/specs/2026-06-03-session-management-design.md
@@ -66,7 +66,12 @@ ultimo/src/
 - `struct CookieOptions { http_only: bool, secure: bool, same_site: Option<SameSite>, max_age: Option<i64> /*seconds*/, path: Option<String>, domain: Option<String>, expires: Option<…> }` with a builder.
 - `enum SameSite { Strict, Lax, None }`.
 - Parsing: `parse_cookie_header(&str) -> HashMap<String, String>`.
-- Formatting: `Cookie::to_set_cookie_string() -> String` (RFC 6265 attributes).
+- Formatting: `Cookie::to_set_cookie_string() -> Result<String>` (RFC 6265
+  attributes). **Header-injection defense:** reject cookie names/values
+  containing control characters (CR, LF, NUL) or other characters illegal per
+  RFC 6265 — never emit unvalidated, attacker-influenced bytes into a response
+  header. (Generated session ids are already safe; this guards `ctx.set_cookie`
+  with app-supplied values.)
 - Context API (additive):
   - `ctx.cookie(name) -> Option<String>` — read a request cookie.
   - `ctx.cookies() -> HashMap<String, String>` — all request cookies.
@@ -97,27 +102,41 @@ data + a dirty flag.
 - `get::<T: DeserializeOwned>(&self, key) -> Result<Option<T>>`
 - `set::<T: Serialize>(&self, key, &T) -> Result<()>` (marks dirty)
 - `remove(&self, key)` / `clear(&self)` (mark dirty)
-- `regenerate(&self)` — issue a new id (session fixation defense), keep data
-- `destroy(&self)` — drop the session + expire the cookie
+- `regenerate(&self)` — issue a **new** secure id and **destroy the old store
+  entry** (session-fixation defense), keeping the data
+- `destroy(&self)` — drop the session server-side + expire the cookie
 
 ### 4. Session middleware (`session/middleware.rs`)
 `session(store, config) -> BoxedMiddleware`. Flow per request:
 1. Read the session-id cookie (`config.cookie_name`).
-2. If present, `store.load(id)`; else (or on miss) create a fresh session with a
-   new secure id.
+2. If a cookie id is present **and found in the store**, load it. **If the id is
+   absent OR not found in the store, generate a fresh server-side id — never
+   adopt a client-supplied id** (anti session-fixation). Do not yet persist.
 3. Attach the `Session` to the Context (typed slot; `ctx.session()` returns it).
 4. `next(ctx).await` → response.
-5. If the session is dirty/new: `store.store(id, data, ttl)` and queue the
-   `Set-Cookie` (HttpOnly/Secure/SameSite/Max-Age per config). If destroyed:
-   `store.destroy(id)` + queue an expiry cookie.
+5. Persistence (security-critical rules):
+   - **Only persist when the session is dirty AND non-empty.** An untouched /
+     empty session is **not** stored and **gets no cookie** — this prevents an
+     unbounded-session DoS (one stored entry + Set-Cookie per anonymous hit) and
+     avoids needless cookies.
+   - On dirty+non-empty: `store.store(id, data, ttl)` and queue the `Set-Cookie`
+     (HttpOnly/Secure/SameSite/Max-Age per config).
+   - On `destroy()`: `store.destroy(id)` + queue an expiry cookie (`Max-Age=0`).
+   - On `regenerate()`: `store.destroy(old_id)`, `store.store(new_id, …)`, cookie
+     carries the new id.
 6. Flush queued cookies onto the response.
 
 ### 5. `SessionConfig` (`session/config.rs`)
-`{ cookie_name: String = "ultimo_sid", ttl: Duration = 24h, http_only: bool = true, secure: bool = true, same_site: SameSite = Lax, path: String = "/" }`, with a builder. Secure defaults.
+`{ cookie_name: String = "ultimo_sid", ttl: Duration = 24h, http_only: bool = true, secure: bool = true, same_site: SameSite = Lax, path: String = "/" }`, with a builder. **Secure-by-default.**
+Validation: if `same_site == None`, `secure` **must** be `true` (browsers reject
+`SameSite=None` without `Secure`) — enforce at construction. The `secure` default
+is `true`; document that local HTTP dev needs `.secure(false)` explicitly (a
+deliberate opt-out, not a silent default).
 
 ### 6. Secure IDs
-`getrandom` → 32 random bytes → URL-safe encoding (hex or base64url). No
-predictable IDs.
+`getrandom` → 32 random bytes (256 bits) → URL-safe base64 (no padding). IDs are
+unguessable. **`getrandom` failure is a hard error** — never fall back to a
+weaker RNG. The high entropy also makes store-lookup timing irrelevant.
 
 ## Context integration
 
@@ -130,6 +149,32 @@ predictable IDs.
 `ctx.session()` returning a guard vs a cloneable handle is settled in the plan;
 the data lives in the store, the handle mediates access.
 
+## Security (threat model + mitigations)
+
+Sessions are security-critical; these are designed in, not bolted on.
+
+| Threat | Mitigation (in this design) |
+|---|---|
+| **Session prediction/brute force** | 256-bit CSPRNG ids (`getrandom`); hard error on RNG failure (no weak fallback). |
+| **Session fixation** | Never adopt a client-supplied id — unknown/absent id → fresh server id. `regenerate()` (apps must call it on login/privilege change) issues a new id and **destroys the old store entry**. |
+| **XSS cookie theft** | `HttpOnly` default `true` — JS can't read the session cookie. |
+| **Cookie interception (MITM)** | `Secure` default `true` — cookie only sent over HTTPS. |
+| **CSRF** | `SameSite=Lax` default gives partial protection. **Full CSRF protection is a deferred follow-up (known gap)** — documented clearly so users don't assume coverage. `SameSite=None` requires `Secure` (enforced). |
+| **Header injection via cookies** | Cookie name/value validated; control chars (CR/LF/NUL) rejected before emitting `Set-Cookie`. |
+| **Session-store DoS (unbounded growth)** | Empty/untouched sessions are never persisted and get no cookie; only dirty, non-empty sessions are stored, with TTL eviction. |
+| **Stale session reuse** | Server-side TTL eviction in the store **and** cookie `Max-Age` — expiry enforced server-side, not just client-side. |
+| **Data tampering/confidentiality** | Session data lives **server-side** (store); only the opaque id is in the cookie — no signed/encrypted-cookie attack surface. |
+| **Logout not ending the session** | `destroy()` removes the entry server-side (not just the cookie) + expires the cookie. |
+
+**Known limitations (documented, acceptable for this slice):**
+- Concurrent requests sharing a session are last-write-wins (read-modify-write
+  race) — acceptable for v1; revisit if atomic updates are needed.
+- No CSRF tokens yet (see deferred follow-ups); `SameSite=Lax` is the interim
+  defense.
+
+**Future hardening (deferred):** `__Host-`/`__Secure-` cookie name prefixes,
+signed/encrypted cookies, sliding-expiration option, idle vs absolute timeout.
+
 ## Testing strategy
 - Cookie unit tests: parse round-trips, Set-Cookie formatting (all attributes,
   SameSite, Max-Age=0 deletion).
@@ -137,6 +182,15 @@ the data lives in the store, the handle mediates access.
 - Integration (via the `testing` feature's `TestClient`): login sets a cookie →
   subsequent request with that cookie sees the session value; destroy clears it;
   regenerate changes the id; expired session is not loaded.
+- **Security tests (required):**
+  - A client-supplied unknown id is **not** adopted — the server issues a
+    different id (anti-fixation).
+  - `regenerate()` changes the id AND the old id no longer resolves in the store.
+  - An empty/untouched session is **not** persisted and **no** `Set-Cookie` is
+    emitted (anti-DoS).
+  - Default cookie carries `HttpOnly`, `Secure`, and `SameSite=Lax`.
+  - A cookie value with `\r`/`\n` is rejected (header-injection guard).
+  - `SameSite=None` without `Secure` is rejected at config construction.
 - All under CI with the `session` feature added to the relevant jobs.
 
 ## Published-crate impact

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -31,6 +31,9 @@ sha1 = "0.10"
 base64 = "0.21"
 async-trait = "0.1"
 
+# Session support (optional) — getrandom for secure session ids
+getrandom = { version = "0.3", optional = true }
+
 # Database support (optional)
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls"], optional = true }
 diesel = { version = "2.3.8", optional = true }  # >=2.3.8: RUSTSEC fix for COPY command injection + unaligned access
@@ -56,6 +59,9 @@ test-helpers = []
 
 # Testing utilities for Ultimo apps (TestClient, assertions, fixtures)
 testing = []
+
+# Session management (cookie-based, pluggable store)
+session = ["dep:getrandom"]
 
 # Database features
 database = []

--- a/ultimo/src/app.rs
+++ b/ultimo/src/app.rs
@@ -317,6 +317,7 @@ impl Ultimo {
         if method_str == hyper::Method::OPTIONS {
             // Create context for OPTIONS request
             let ctx = Context::from_parts(parts, body, Params::new());
+            let cookie_sink = ctx.set_cookies_handle();
 
             // Build and execute middleware chain
             let mut chain = MiddlewareChain::new();
@@ -333,7 +334,7 @@ impl Ultimo {
                 })
                 .await;
 
-            return match result {
+            let response = match result {
                 Ok(response) => response,
                 Err(err) => {
                     error!("Middleware error: {}", err);
@@ -341,6 +342,7 @@ impl Ultimo {
                         .unwrap_or_else(|_| response::helpers::text("Internal Error").unwrap())
                 }
             };
+            return flush_set_cookies(response, cookie_sink).await;
         }
 
         // Find matching route
@@ -358,6 +360,7 @@ impl Ultimo {
         // Create context
         #[cfg_attr(not(feature = "database"), allow(unused_mut))]
         let mut ctx = Context::from_parts(parts, body, params);
+        let cookie_sink = ctx.set_cookies_handle();
 
         // Attach database if configured
         #[cfg(feature = "database")]
@@ -380,14 +383,15 @@ impl Ultimo {
             .await;
 
         // Handle result
-        match result {
+        let response = match result {
             Ok(response) => response,
             Err(err) => {
                 error!("Handler error: {}", err);
                 response::helpers::error_response(&err)
                     .unwrap_or_else(|_| response::helpers::text("Internal Error").unwrap())
             }
-        }
+        };
+        flush_set_cookies(response, cookie_sink).await
     }
 
     /// Dispatch a fully-buffered request through the app in-process (no socket).
@@ -434,6 +438,21 @@ impl Ultimo {
             });
         }
     }
+}
+
+/// Append queued `Set-Cookie` header values (from `ctx.set_cookie`) onto the
+/// response. Uses `append` so multiple cookies become multiple headers.
+async fn flush_set_cookies(
+    mut response: Response,
+    sink: Arc<tokio::sync::RwLock<Vec<String>>>,
+) -> Response {
+    let cookies = std::mem::take(&mut *sink.write().await);
+    for value in cookies {
+        if let Ok(hv) = hyper::header::HeaderValue::from_str(&value) {
+            response.headers_mut().append(hyper::header::SET_COOKIE, hv);
+        }
+    }
+    response
 }
 
 impl Default for Ultimo {

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -158,6 +158,9 @@ pub struct Context {
     state: Arc<RwLock<HashMap<String, String>>>,
     response_status: Arc<RwLock<Option<u16>>>,
     response_headers: Arc<RwLock<HashMap<String, String>>>,
+    set_cookies: Arc<RwLock<Vec<String>>>,
+    #[cfg(feature = "session")]
+    session: Arc<RwLock<Option<crate::session::Session>>>,
 
     #[cfg(feature = "database")]
     database: Option<Database>,
@@ -175,6 +178,9 @@ impl Context {
             state: Arc::new(RwLock::new(HashMap::new())),
             response_status: Arc::new(RwLock::new(None)),
             response_headers: Arc::new(RwLock::new(HashMap::new())),
+            set_cookies: Arc::new(RwLock::new(Vec::new())),
+            #[cfg(feature = "session")]
+            session: Arc::new(RwLock::new(None)),
             #[cfg(feature = "database")]
             database: None,
         }
@@ -243,6 +249,55 @@ impl Context {
     pub async fn get(&self, key: &str) -> Option<String> {
         let state = self.state.read().await;
         state.get(key).cloned()
+    }
+
+    /// Read a request cookie by name.
+    pub fn cookie(&self, name: &str) -> Option<String> {
+        self.req
+            .header("cookie")
+            .and_then(|h| crate::cookie::parse_cookie_header(&h).remove(name))
+    }
+
+    /// All request cookies.
+    pub fn cookies(&self) -> HashMap<String, String> {
+        self.req
+            .header("cookie")
+            .map(|h| crate::cookie::parse_cookie_header(&h))
+            .unwrap_or_default()
+    }
+
+    /// Queue a `Set-Cookie` for the response. Errors if the cookie is invalid.
+    pub async fn set_cookie(&self, cookie: crate::cookie::Cookie) -> Result<()> {
+        let s = cookie.to_set_cookie_string()?;
+        self.set_cookies.write().await.push(s);
+        Ok(())
+    }
+
+    /// Queue a deletion of the named cookie (`Max-Age=0`).
+    pub async fn remove_cookie(&self, name: &str) -> Result<()> {
+        let c = crate::cookie::Cookie::new(name, "").max_age(0).path("/");
+        self.set_cookie(c).await
+    }
+
+    /// Shared handle to the queued Set-Cookie values (drained by the dispatcher).
+    pub(crate) fn set_cookies_handle(&self) -> Arc<RwLock<Vec<String>>> {
+        self.set_cookies.clone()
+    }
+
+    /// The current session. Panics if the session middleware isn't installed.
+    #[cfg(feature = "session")]
+    pub async fn session(&self) -> crate::session::Session {
+        self.session
+            .read()
+            .await
+            .clone()
+            .expect("session middleware not installed (add `session(store, config)`)")
+    }
+
+    /// Attach a session to this context (used by the session middleware).
+    #[cfg(feature = "session")]
+    pub(crate) async fn set_session(&self, s: crate::session::Session) {
+        *self.session.write().await = Some(s);
     }
 
     /// Set the response status code

--- a/ultimo/src/cookie.rs
+++ b/ultimo/src/cookie.rs
@@ -1,0 +1,181 @@
+//! HTTP cookie parsing and `Set-Cookie` formatting (RFC 6265).
+
+use crate::error::{Result, UltimoError};
+use std::collections::HashMap;
+
+/// `SameSite` cookie attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SameSite {
+    Strict,
+    Lax,
+    None,
+}
+
+impl SameSite {
+    fn as_str(&self) -> &'static str {
+        match self {
+            SameSite::Strict => "Strict",
+            SameSite::Lax => "Lax",
+            SameSite::None => "None",
+        }
+    }
+}
+
+/// Attributes for a `Set-Cookie`.
+#[derive(Debug, Clone, Default)]
+pub struct CookieOptions {
+    pub http_only: bool,
+    pub secure: bool,
+    pub same_site: Option<SameSite>,
+    /// Max-Age in seconds.
+    pub max_age: Option<i64>,
+    pub path: Option<String>,
+    pub domain: Option<String>,
+}
+
+/// A cookie to emit via `Set-Cookie`.
+#[derive(Debug, Clone)]
+pub struct Cookie {
+    pub name: String,
+    pub value: String,
+    pub options: CookieOptions,
+}
+
+impl Cookie {
+    /// Create a cookie with default options.
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+            options: CookieOptions::default(),
+        }
+    }
+
+    /// Set the `HttpOnly` attribute.
+    pub fn http_only(mut self, v: bool) -> Self {
+        self.options.http_only = v;
+        self
+    }
+    /// Set the `Secure` attribute.
+    pub fn secure(mut self, v: bool) -> Self {
+        self.options.secure = v;
+        self
+    }
+    /// Set the `SameSite` attribute.
+    pub fn same_site(mut self, v: SameSite) -> Self {
+        self.options.same_site = Some(v);
+        self
+    }
+    /// Set `Max-Age` in seconds.
+    pub fn max_age(mut self, secs: i64) -> Self {
+        self.options.max_age = Some(secs);
+        self
+    }
+    /// Set the `Path` attribute.
+    pub fn path(mut self, p: impl Into<String>) -> Self {
+        self.options.path = Some(p.into());
+        self
+    }
+    /// Set the `Domain` attribute.
+    pub fn domain(mut self, d: impl Into<String>) -> Self {
+        self.options.domain = Some(d.into());
+        self
+    }
+
+    /// Format as a `Set-Cookie` header value. Rejects names/values containing
+    /// control characters (header-injection guard).
+    pub fn to_set_cookie_string(&self) -> Result<String> {
+        validate_token(&self.name)?;
+        validate_value(&self.value)?;
+        let mut s = format!("{}={}", self.name, self.value);
+        if let Some(p) = &self.options.path {
+            validate_value(p)?;
+            s.push_str(&format!("; Path={p}"));
+        }
+        if let Some(d) = &self.options.domain {
+            validate_value(d)?;
+            s.push_str(&format!("; Domain={d}"));
+        }
+        if let Some(m) = self.options.max_age {
+            s.push_str(&format!("; Max-Age={m}"));
+        }
+        if let Some(ss) = self.options.same_site {
+            s.push_str(&format!("; SameSite={}", ss.as_str()));
+        }
+        if self.options.secure {
+            s.push_str("; Secure");
+        }
+        if self.options.http_only {
+            s.push_str("; HttpOnly");
+        }
+        Ok(s)
+    }
+}
+
+fn has_ctl(s: &str) -> bool {
+    s.bytes().any(|b| b < 0x20 || b == 0x7f)
+}
+
+fn validate_token(name: &str) -> Result<()> {
+    if name.is_empty() || has_ctl(name) || name.contains([';', '=', ' ', '\t']) {
+        return Err(UltimoError::BadRequest(format!(
+            "invalid cookie name: {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_value(value: &str) -> Result<()> {
+    if has_ctl(value) || value.contains([';', '\r', '\n']) {
+        return Err(UltimoError::BadRequest("invalid cookie value".to_string()));
+    }
+    Ok(())
+}
+
+/// Parse a request `Cookie:` header into name → value pairs.
+pub fn parse_cookie_header(header: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for pair in header.split(';') {
+        let pair = pair.trim();
+        if let Some((k, v)) = pair.split_once('=') {
+            out.insert(k.trim().to_string(), v.trim().to_string());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_multiple_cookies() {
+        let m = parse_cookie_header("a=1; b=2;  c=3");
+        assert_eq!(m.get("a").map(String::as_str), Some("1"));
+        assert_eq!(m.get("b").map(String::as_str), Some("2"));
+        assert_eq!(m.get("c").map(String::as_str), Some("3"));
+    }
+
+    #[test]
+    fn formats_all_attributes() {
+        let c = Cookie::new("sid", "abc")
+            .http_only(true)
+            .secure(true)
+            .same_site(SameSite::Lax)
+            .max_age(3600)
+            .path("/");
+        let s = c.to_set_cookie_string().unwrap();
+        assert!(s.starts_with("sid=abc"));
+        assert!(s.contains("; Path=/"));
+        assert!(s.contains("; Max-Age=3600"));
+        assert!(s.contains("; SameSite=Lax"));
+        assert!(s.contains("; Secure"));
+        assert!(s.contains("; HttpOnly"));
+    }
+
+    #[test]
+    fn rejects_header_injection() {
+        let c = Cookie::new("sid", "abc\r\nSet-Cookie: evil=1");
+        assert!(c.to_set_cookie_string().is_err());
+    }
+}

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod app;
 pub mod context;
+pub mod cookie;
 pub mod error;
 pub mod handler;
 pub mod middleware;

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -47,6 +47,9 @@ pub mod websocket;
 #[cfg(feature = "testing")]
 pub mod testing;
 
+#[cfg(feature = "session")]
+pub mod session;
+
 // Re-exports for convenience
 pub use app::Ultimo;
 pub use context::Context;

--- a/ultimo/src/session/config.rs
+++ b/ultimo/src/session/config.rs
@@ -1,0 +1,87 @@
+//! Session configuration.
+
+use crate::cookie::SameSite;
+use std::time::Duration;
+
+/// Session middleware configuration. Secure-by-default.
+#[derive(Debug, Clone)]
+pub struct SessionConfig {
+    /// Name of the session-id cookie.
+    pub cookie_name: String,
+    /// Server-side + cookie lifetime.
+    pub ttl: Duration,
+    /// `HttpOnly` cookie attribute (default true).
+    pub http_only: bool,
+    /// `Secure` cookie attribute (default true).
+    pub secure: bool,
+    /// `SameSite` cookie attribute (default Lax).
+    pub same_site: SameSite,
+    /// Cookie `Path` (default "/").
+    pub path: String,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            cookie_name: "ultimo_sid".to_string(),
+            ttl: Duration::from_secs(60 * 60 * 24),
+            http_only: true,
+            secure: true,
+            same_site: SameSite::Lax,
+            path: "/".to_string(),
+        }
+    }
+}
+
+impl SessionConfig {
+    /// Set the session cookie name.
+    pub fn cookie_name(mut self, n: impl Into<String>) -> Self {
+        self.cookie_name = n.into();
+        self
+    }
+    /// Set the session lifetime.
+    pub fn ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+    /// Set the `Secure` attribute (disable only for local HTTP dev).
+    pub fn secure(mut self, v: bool) -> Self {
+        self.secure = v;
+        self
+    }
+    /// Set the `SameSite` attribute.
+    pub fn same_site(mut self, v: SameSite) -> Self {
+        self.same_site = v;
+        self
+    }
+
+    /// Validate invariants. `SameSite=None` requires `Secure` (browser rule).
+    /// Panics on violation — a misconfigured session is a programming error.
+    pub fn validated(self) -> Self {
+        if self.same_site == SameSite::None && !self.secure {
+            panic!("SessionConfig: SameSite=None requires secure=true");
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secure_defaults() {
+        let c = SessionConfig::default();
+        assert!(c.http_only && c.secure);
+        assert_eq!(c.same_site, SameSite::Lax);
+    }
+
+    #[test]
+    #[should_panic(expected = "SameSite=None requires secure")]
+    fn samesite_none_requires_secure() {
+        SessionConfig::default()
+            .same_site(SameSite::None)
+            .secure(false)
+            .validated();
+    }
+}

--- a/ultimo/src/session/middleware.rs
+++ b/ultimo/src/session/middleware.rs
@@ -1,0 +1,101 @@
+//! Session middleware. See the spec's Security section for the threat model.
+
+use super::{Session, SessionConfig, SessionData, SessionStore};
+use crate::context::Context;
+use crate::cookie::Cookie;
+use crate::error::Result;
+use crate::middleware::{BoxedMiddleware, Next};
+use crate::response::Response;
+use base64::Engine;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Generate a 256-bit URL-safe session id. Panics if the OS RNG fails — we must
+/// never fall back to weak randomness for a security token.
+fn generate_id() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("OS RNG failure generating session id");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn id_cookie(config: &SessionConfig, id: &str) -> Cookie {
+    Cookie::new(config.cookie_name.clone(), id.to_string())
+        .http_only(config.http_only)
+        .secure(config.secure)
+        .same_site(config.same_site)
+        .path(config.path.clone())
+        .max_age(config.ttl.as_secs() as i64)
+}
+
+fn expiry_cookie(config: &SessionConfig) -> Cookie {
+    Cookie::new(config.cookie_name.clone(), "")
+        .http_only(config.http_only)
+        .secure(config.secure)
+        .same_site(config.same_site)
+        .path(config.path.clone())
+        .max_age(0)
+}
+
+async fn push_cookie(sink: &Arc<RwLock<Vec<String>>>, cookie: Cookie) {
+    if let Ok(s) = cookie.to_set_cookie_string() {
+        sink.write().await.push(s);
+    }
+}
+
+/// Build session middleware over `store`. Register with `app.use_middleware(...)`.
+pub fn session<S>(store: S, config: SessionConfig) -> BoxedMiddleware
+where
+    S: SessionStore + 'static,
+{
+    let store = Arc::new(store);
+    let config = Arc::new(config.validated());
+
+    Arc::new(move |ctx: Context, next: Next| {
+        let store = store.clone();
+        let config = config.clone();
+        Box::pin(async move {
+            // Load an existing session ONLY if the cookie id is known to the
+            // store. Never adopt a client-supplied id (anti session-fixation).
+            let cookie_id = ctx.cookie(&config.cookie_name);
+            let (id, data) = match &cookie_id {
+                Some(cid) => match store.load(cid).await {
+                    Some(d) => (cid.clone(), d),
+                    None => (generate_id(), SessionData::new()),
+                },
+                None => (generate_id(), SessionData::new()),
+            };
+
+            // Share the session with the handler; capture the cookie sink so we
+            // can write Set-Cookie after `next` consumes `ctx`.
+            let session = Session::new(id.clone(), data);
+            ctx.set_session(session.clone()).await;
+            let cookie_sink = ctx.set_cookies_handle();
+
+            let response: Response = next(ctx).await?;
+
+            // Persist per the security rules.
+            if session.is_destroyed() {
+                store.destroy(&id).await;
+                push_cookie(&cookie_sink, expiry_cookie(&config)).await;
+            } else if session.is_dirty() && !session.is_empty().await {
+                // Only persist dirty, non-empty sessions (anti unbounded-DoS).
+                let final_id = match session.take_new_id().await {
+                    Some(new_id) => {
+                        store.destroy(&id).await; // fixation: drop the old entry
+                        new_id
+                    }
+                    None => id.clone(),
+                };
+                store
+                    .store(&final_id, &session.snapshot().await, config.ttl)
+                    .await;
+                push_cookie(&cookie_sink, id_cookie(&config, &final_id)).await;
+            }
+            // Empty/untouched session: persist nothing, emit no cookie.
+
+            Ok(response)
+        }) as Pin<Box<dyn Future<Output = Result<Response>> + Send>>
+    })
+}

--- a/ultimo/src/session/mod.rs
+++ b/ultimo/src/session/mod.rs
@@ -1,0 +1,152 @@
+//! Cookie-based session management.
+//!
+//! Enable with the `session` feature. Register the middleware with a store, then
+//! read/write the session via [`Context::session`](crate::context::Context::session).
+//!
+//! ```
+//! use ultimo::session::{session, MemoryStore, SessionConfig};
+//! use ultimo::{Context, Ultimo};
+//!
+//! # async fn build() {
+//! let mut app = Ultimo::new_without_defaults();
+//! app.use_middleware(session(MemoryStore::new(), SessionConfig::default()));
+//!
+//! app.get("/login", |ctx: Context| async move {
+//!     ctx.session().await.set("user_id", &42u64).await?;
+//!     ctx.text("logged in").await
+//! });
+//! # }
+//! ```
+
+mod config;
+mod middleware;
+mod store;
+
+pub use config::SessionConfig;
+pub use middleware::session;
+pub use store::{MemoryStore, SessionStore};
+
+use crate::error::Result;
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Session payload: arbitrary JSON values keyed by string.
+pub type SessionData = HashMap<String, serde_json::Value>;
+
+/// A handle to the current session. Cheap to clone (shares inner state), so the
+/// middleware and the handler observe the same session.
+#[derive(Clone)]
+pub struct Session {
+    inner: Arc<SessionInner>,
+}
+
+struct SessionInner {
+    id: RwLock<String>,
+    data: RwLock<SessionData>,
+    dirty: AtomicBool,
+    destroyed: AtomicBool,
+    new_id: RwLock<Option<String>>,
+}
+
+impl Session {
+    pub(crate) fn new(id: String, data: SessionData) -> Self {
+        Self {
+            inner: Arc::new(SessionInner {
+                id: RwLock::new(id),
+                data: RwLock::new(data),
+                dirty: AtomicBool::new(false),
+                destroyed: AtomicBool::new(false),
+                new_id: RwLock::new(None),
+            }),
+        }
+    }
+
+    /// Current session id.
+    pub async fn id(&self) -> String {
+        self.inner.id.read().await.clone()
+    }
+
+    /// Get a typed value by key.
+    pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
+        let data = self.inner.data.read().await;
+        match data.get(key) {
+            Some(v) => Ok(Some(serde_json::from_value(v.clone())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Set a typed value (marks the session dirty).
+    pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<()> {
+        let v = serde_json::to_value(value)?;
+        self.inner.data.write().await.insert(key.to_string(), v);
+        self.inner.dirty.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Remove a key (marks dirty).
+    pub async fn remove(&self, key: &str) {
+        self.inner.data.write().await.remove(key);
+        self.inner.dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Clear all data (marks dirty).
+    pub async fn clear(&self) {
+        self.inner.data.write().await.clear();
+        self.inner.dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Issue a new id on the next persist (session-fixation defense). The old
+    /// store entry is destroyed by the middleware.
+    pub async fn regenerate(&self, new_id: String) {
+        *self.inner.new_id.write().await = Some(new_id);
+        self.inner.dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Destroy the session (server-side entry + cookie are cleared).
+    pub fn destroy(&self) {
+        self.inner.destroyed.store(true, Ordering::SeqCst);
+    }
+
+    // --- internal accessors used by the middleware ---
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.inner.dirty.load(Ordering::SeqCst)
+    }
+    pub(crate) fn is_destroyed(&self) -> bool {
+        self.inner.destroyed.load(Ordering::SeqCst)
+    }
+    pub(crate) async fn snapshot(&self) -> SessionData {
+        self.inner.data.read().await.clone()
+    }
+    pub(crate) async fn take_new_id(&self) -> Option<String> {
+        self.inner.new_id.write().await.take()
+    }
+    pub(crate) async fn is_empty(&self) -> bool {
+        self.inner.data.read().await.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_get_and_dirty() {
+        let s = Session::new("id".into(), SessionData::new());
+        assert!(!s.is_dirty());
+        s.set("n", &7u32).await.unwrap();
+        assert!(s.is_dirty());
+        assert_eq!(s.get::<u32>("n").await.unwrap(), Some(7));
+        assert!(!s.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn regenerate_queues_new_id() {
+        let s = Session::new("old".into(), SessionData::new());
+        s.regenerate("new".into()).await;
+        assert_eq!(s.take_new_id().await, Some("new".to_string()));
+        assert!(s.is_dirty());
+    }
+}

--- a/ultimo/src/session/store.rs
+++ b/ultimo/src/session/store.rs
@@ -1,0 +1,83 @@
+//! Session store trait and in-memory implementation.
+
+use super::SessionData;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Backing store for session data. Implement this for Redis/SQL/etc. backends.
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Load session data by id, or `None` if absent/expired.
+    async fn load(&self, id: &str) -> Option<SessionData>;
+    /// Persist session data under id with a time-to-live.
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration);
+    /// Remove a session.
+    async fn destroy(&self, id: &str);
+}
+
+/// In-memory store. Suitable for single-process apps and tests.
+#[derive(Clone, Default)]
+pub struct MemoryStore {
+    inner: Arc<RwLock<HashMap<String, (SessionData, Instant)>>>,
+}
+
+impl MemoryStore {
+    /// Create an empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SessionStore for MemoryStore {
+    async fn load(&self, id: &str) -> Option<SessionData> {
+        let map = self.inner.read().await;
+        match map.get(id) {
+            Some((data, expiry)) if *expiry > Instant::now() => Some(data.clone()),
+            _ => None,
+        }
+    }
+
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration) {
+        let mut map = self.inner.write().await;
+        // Opportunistic eviction of expired entries.
+        let now = Instant::now();
+        map.retain(|_, (_, exp)| *exp > now);
+        map.insert(id.to_string(), (data.clone(), now + ttl));
+    }
+
+    async fn destroy(&self, id: &str) {
+        self.inner.write().await.remove(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn store_load_destroy_roundtrip() {
+        let s = MemoryStore::new();
+        let mut data = SessionData::new();
+        data.insert("k".into(), serde_json::json!("v"));
+        s.store("id1", &data, Duration::from_secs(60)).await;
+        assert_eq!(
+            s.load("id1").await.unwrap().get("k").unwrap(),
+            &serde_json::json!("v")
+        );
+        s.destroy("id1").await;
+        assert!(s.load("id1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn expired_entries_are_not_loaded() {
+        let s = MemoryStore::new();
+        s.store("id2", &SessionData::new(), Duration::from_millis(1))
+            .await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(s.load("id2").await.is_none());
+    }
+}

--- a/ultimo/tests/cookie.rs
+++ b/ultimo/tests/cookie.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "testing")]
+
+use ultimo::cookie::{Cookie, SameSite};
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+#[tokio::test]
+async fn set_cookie_appears_on_response() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/set", |ctx: Context| async move {
+        ctx.set_cookie(
+            Cookie::new("sid", "xyz")
+                .http_only(true)
+                .same_site(SameSite::Lax),
+        )
+        .await?;
+        ctx.text("ok").await
+    });
+
+    let client = TestClient::new(app);
+    let res = client.get("/set").send().await;
+    let sc = res.header("set-cookie").unwrap();
+    assert!(sc.contains("sid=xyz"));
+    assert!(sc.contains("HttpOnly"));
+    assert!(sc.contains("SameSite=Lax"));
+}
+
+#[tokio::test]
+async fn reads_request_cookie() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/read", |ctx: Context| async move {
+        let v = ctx.cookie("token").unwrap_or_else(|| "none".into());
+        ctx.text(v).await
+    });
+
+    let client = TestClient::new(app);
+    let res = client
+        .get("/read")
+        .header("cookie", "token=secret123")
+        .send()
+        .await;
+    assert_eq!(res.text(), "secret123");
+}

--- a/ultimo/tests/session.rs
+++ b/ultimo/tests/session.rs
@@ -1,0 +1,72 @@
+#![cfg(all(feature = "session", feature = "testing"))]
+
+use ultimo::session::{session, MemoryStore, SessionConfig};
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    // secure(false) so the test cookie isn't HTTPS-only (TestClient is in-process).
+    app.use_middleware(session(
+        MemoryStore::new(),
+        SessionConfig::default().secure(false),
+    ));
+    app.get("/login", |ctx: Context| async move {
+        ctx.session().await.set("uid", &42u64).await?;
+        ctx.text("ok").await
+    });
+    app.get("/me", |ctx: Context| async move {
+        let uid: Option<u64> = ctx.session().await.get("uid").await?;
+        ctx.json(serde_json::json!({ "uid": uid })).await
+    });
+    app.get("/anon", |ctx: Context| async move { ctx.text("hi").await });
+    app
+}
+
+/// Extract the "name=value" pair from a Set-Cookie header.
+fn sid(set_cookie: &str) -> String {
+    set_cookie.split(';').next().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn session_persists_across_requests() {
+    let client = TestClient::new(app());
+    let login = client.get("/login").send().await;
+    let cookie = sid(login.header("set-cookie").expect("login sets a cookie"));
+
+    let me = client.get("/me").header("cookie", &cookie).send().await;
+    assert_eq!(
+        me.json::<serde_json::Value>(),
+        serde_json::json!({ "uid": 42 })
+    );
+}
+
+#[tokio::test]
+async fn empty_session_sets_no_cookie() {
+    // anti-DoS: a request that never touches the session gets no Set-Cookie.
+    let client = TestClient::new(app());
+    let res = client.get("/anon").send().await;
+    assert!(res.header("set-cookie").is_none());
+}
+
+#[tokio::test]
+async fn unknown_client_id_is_not_adopted() {
+    // anti-fixation: a forged cookie id must not become the session id.
+    let client = TestClient::new(app());
+    let res = client
+        .get("/login")
+        .header("cookie", "ultimo_sid=attacker_fixed_id")
+        .send()
+        .await;
+    let issued = sid(res.header("set-cookie").expect("login sets a cookie"));
+    assert_ne!(issued, "ultimo_sid=attacker_fixed_id");
+}
+
+#[tokio::test]
+async fn default_cookie_is_httponly_lax() {
+    let client = TestClient::new(app());
+    let res = client.get("/login").send().await;
+    let sc = res.header("set-cookie").expect("login sets a cookie");
+    assert!(sc.contains("HttpOnly"));
+    assert!(sc.contains("SameSite=Lax"));
+}


### PR DESCRIPTION
Implements [#3](https://github.com/ultimo-rs/ultimo/issues/3), core slice. Milestone **v0.3.0**. All additive (semver-checks confirms). Built spec → security review → plan → TDD (`docs/superpowers/specs|plans/2026-06-03-session-management*`).

## What's included
- **Cookies (core, no new dep):** `ultimo::cookie` (`Cookie`/`CookieOptions`/`SameSite`, RFC 6265 parse + `Set-Cookie` format with **header-injection guards**) and `ctx.cookie`/`cookies`/`set_cookie`/`remove_cookie`. Cookies flush onto the response in `dispatch_parts` (supports multiple `Set-Cookie`).
- **Sessions (`session` feature):** `SessionStore` trait + `MemoryStore`, `Session` via `ctx.session()` (typed `get/set/remove/clear`, `regenerate`, `destroy`), `SessionConfig`, and the `session(store, config)` middleware.

## Security (designed in — see spec Security section)
- 256-bit `getrandom` ids; **hard error on RNG failure** (no weak fallback)
- `HttpOnly` + `Secure` + `SameSite=Lax` defaults; `SameSite=None` requires `Secure` (enforced)
- **Anti session-fixation:** client-supplied ids never adopted; `regenerate()` destroys the old store entry
- **Anti-DoS:** empty/untouched sessions are not persisted and get no cookie
- Server-side data (only the opaque id in the cookie); server-side TTL eviction
- 6 security behaviors are **tests** (4 integration + cookie/config unit tests)

## Packaging
New `session` feature (only new dep: `getrandom`, optional). Reuses existing `async-trait` (Send-safe store) + `base64` (id encoding). Cookies are core.

## Verification (local, all green)
fmt · clippy `-D warnings` (incl. session) · lib tests · cookie integration · 6 session unit · 4 session security · session doctest. CI re-verifies across ubuntu/macOS + MSRV + semver + audit.

## Deferred follow-ups (same `SessionStore` trait, no rework)
Redis store, SQLx/Diesel store, CSRF protection.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)