### PR TITLE
fix: router precedence (static > param) + request raw_body (#21, #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-process (no socket); the seam the testing utilities build on.
 - CI: a `cargo-audit` (RUSTSEC) job and an MSRV job; `Cargo.lock` is now
   committed.
+- `Request::raw_body()` — raw request body bytes; the body is buffered and
+  cached so `json`/`text`/`bytes`/`raw_body` can be called repeatedly. (#21)
+
+### Fixed
+
+- Router precedence: static routes now take priority over parameterized ones
+  regardless of registration order (most-specific match wins), so e.g.
+  `/users/me` is no longer shadowed by a `/users/:id` registered before it. (#22)
 
 ### Changed
 

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -143,12 +143,51 @@ impl Request {
             .map_err(|e| UltimoError::BadRequest(format!("Invalid UTF-8: {}", e)))
     }
 
-    /// Get request body as bytes
+    /// Get request body as bytes.
+    ///
+    /// The body is buffered and cached, so this (and [`json`](Self::json) /
+    /// [`text`](Self::text)) may be called any number of times.
     pub async fn bytes(&self) -> Result<Bytes> {
         let body = self.body.read().await;
         body.as_ref()
             .cloned()
             .ok_or_else(|| UltimoError::BadRequest("Body already consumed".to_string()))
+    }
+
+    /// Raw request body bytes (alias for [`bytes`](Self::bytes)). Repeatable.
+    pub async fn raw_body(&self) -> Result<Bytes> {
+        self.bytes().await
+    }
+}
+
+#[cfg(test)]
+mod request_body_tests {
+    use super::*;
+
+    fn req_with_body(body: &'static [u8]) -> Request {
+        let r = HyperRequest::builder()
+            .method("POST")
+            .uri("/")
+            .body(())
+            .unwrap();
+        let (parts, ()) = r.into_parts();
+        Request::from_parts(parts, Bytes::from_static(body), Params::new())
+    }
+
+    #[tokio::test]
+    async fn body_is_readable_multiple_times() {
+        let req = req_with_body(br#"{"n":1}"#);
+        // json twice
+        let a: serde_json::Value = req.json().await.unwrap();
+        let b: serde_json::Value = req.json().await.unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a, serde_json::json!({ "n": 1 }));
+        // then text + raw_body still work
+        assert_eq!(req.text().await.unwrap(), r#"{"n":1}"#);
+        assert_eq!(
+            req.raw_body().await.unwrap(),
+            Bytes::from_static(br#"{"n":1}"#)
+        );
     }
 }
 

--- a/ultimo/src/router.rs
+++ b/ultimo/src/router.rs
@@ -110,6 +110,15 @@ impl Route {
     pub fn path(&self) -> &str {
         &self.raw_path
     }
+
+    /// Route specificity: the number of static segments. Higher is more
+    /// specific, so a fully-static route outranks one with parameters.
+    fn specificity(&self) -> usize {
+        self.segments
+            .iter()
+            .filter(|s| matches!(s, Segment::Static(_)))
+            .count()
+    }
 }
 
 /// Router entry combining method, route, and handler index
@@ -142,16 +151,28 @@ impl Router {
         });
     }
 
-    /// Find a matching route for the given method and path
+    /// Find the best-matching route for the given method and path.
+    ///
+    /// Among all matching routes, the most specific wins (most static segments),
+    /// so static routes take precedence over parameterized ones regardless of
+    /// registration order. Ties are broken by registration order (first wins).
     pub fn find_route(&self, method: Method, path: &str) -> Option<(usize, Params)> {
+        let mut best: Option<(usize, Params, usize)> = None;
         for entry in &self.routes {
             if entry.method == method {
                 if let Some(params) = entry.route.matches(path) {
-                    return Some((entry.handler_id, params));
+                    let spec = entry.route.specificity();
+                    let better = match &best {
+                        Some((_, _, best_spec)) => spec > *best_spec,
+                        None => true,
+                    };
+                    if better {
+                        best = Some((entry.handler_id, params, spec));
+                    }
                 }
             }
         }
-        None
+        best.map(|(id, params, _)| (id, params))
     }
 
     /// Get all registered routes (useful for debugging)
@@ -245,5 +266,35 @@ mod tests {
         let params = params.unwrap();
         assert_eq!(params.get("id"), Some(&"123".to_string()));
         assert_eq!(params.len(), 1);
+    }
+
+    #[test]
+    fn static_route_beats_param_regardless_of_order() {
+        // Param registered FIRST, static SECOND — static must still win.
+        let mut r = Router::new();
+        r.add_route(Method::GET, "/users/:id", 1);
+        r.add_route(Method::GET, "/users/me", 2);
+        let (id, _) = r.find_route(Method::GET, "/users/me").unwrap();
+        assert_eq!(id, 2, "static /users/me should win over /users/:id");
+        // and the param route still matches other values
+        let (id, params) = r.find_route(Method::GET, "/users/42").unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(params.get("id"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn trailing_slash_is_ignored() {
+        let mut r = Router::new();
+        r.add_route(Method::GET, "/users", 1);
+        assert!(r.find_route(Method::GET, "/users/").is_some());
+        assert!(r.find_route(Method::GET, "/users").is_some());
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let mut r = Router::new();
+        r.add_route(Method::GET, "/users/me", 1);
+        assert!(r.find_route(Method::GET, "/posts").is_none());
+        assert!(r.find_route(Method::POST, "/users/me").is_none());
     }
 }


### PR DESCRIPTION
Two v0.3.0 bug items.

## #22 — router precedence (real bug)
`find_route` returned the **first registered** match, so `/users/:id` registered before `/users/me` wrongly shadowed the static route. Now it picks the **most-specific** match (most static segments → static beats param), independent of registration order; ties break by registration order. Added a `specificity()` helper. Trailing-slash handling was already correct — confirmed with tests.

## #21 — request body (already mostly fine)
The body is buffered and cached, so multiple `json()`/`text()`/`bytes()` reads already worked (the "Body already consumed" path was dead). Added the requested **`raw_body()`** accessor + a multiple-reads test.

## Scope note
The **wildcard-routes** checkbox from #22 is a *feature* (not a bug), split to **#44** (v0.4.0). This PR is the bug-fix slice.

## Tests
- Router: static-beats-param-regardless-of-order, trailing-slash, no-match (+ existing 7)
- Body: multiple reads + raw_body
- Full local gate green (fmt, clippy all-features, lib, session regression).

Closes #21, Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)