### PR TITLE
feat(examples): session-auth full-stack demo + frontend-example rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (256-bit ids, HttpOnly/Secure/SameSite defaults, anti session-fixation,
   anti-DoS, server-side expiry), configurable via `SessionConfig`. Redis/SQL
   stores and CSRF are planned follow-ups. See `docs/sessions.md`.
+- `examples/session-auth` — a full-stack login/logout demo of the session
+  feature (Rust backend serving an HTML+JS frontend).
 
 - **Testing utilities** (`testing` feature, #4): in-process `TestClient`, fluent
   request builder, `TestResponse` with assertion helpers, `assert_json_eq!` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,17 @@ Perf claims (158k+ req/s) live or die by these — guard against regressions bef
 - v0.6.0: **MCP server for AI-assisted development** (worth dogfooding once built)
 - v1.0.0: stable API + complete docs
 
+## Frontend examples (MUST follow)
+**When a feature can be used from the frontend, ship a frontend example for it.**
+Ultimo's whole pitch is full-stack DX (typed TS clients, etc.), so any
+frontend-relevant feature (routes/RPC, cookies, sessions, WebSocket, auth, SSE,
+file upload…) must **create or update an example under `examples/`** that
+demonstrates it from a client. Prefer a self-contained example (a Rust backend
+serving an HTML+JS page, runnable with `cargo run -p <example>`, added to the
+workspace `members` so CI builds it) unless a React example is the better fit.
+The session feature's example is `examples/session-auth`. Update the relevant
+example in the same PR as the feature — don't defer it.
+
 ## Conventions
 - **These are published crates — see the "PUBLISHED CRATES" section at the top before
   changing any public code, features, MSRV, or dep floors.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-demo", "examples/database-sqlx", "examples/database-diesel", "examples/database-api-styles", "examples/websocket-chat", "examples/websocket-chat-react", "ultimo-cli", "coverage-tool"]
+members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-demo", "examples/database-sqlx", "examples/database-diesel", "examples/database-api-styles", "examples/websocket-chat", "examples/websocket-chat-react", "examples/session-auth", "ultimo-cli", "coverage-tool"]
 resolver = "2"
 
 [workspace.package]

--- a/examples/session-auth/Cargo.toml
+++ b/examples/session-auth/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "session-auth-example"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+ultimo = { path = "../../ultimo", features = ["session"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/examples/session-auth/src/main.rs
+++ b/examples/session-auth/src/main.rs
@@ -1,0 +1,107 @@
+//! Session auth example — a tiny full-stack demo of Ultimo's session feature.
+//!
+//! The backend serves a single HTML page whose JavaScript logs in/out against
+//! cookie-backed session routes. Run it, then open http://127.0.0.1:3000.
+//!
+//! ```text
+//! cargo run -p session-auth-example
+//! ```
+
+use ultimo::prelude::*;
+use ultimo::session::{session, MemoryStore, SessionConfig};
+
+/// The frontend: a minimal login UI driven entirely by `fetch` against the
+/// session API below. Cookies flow automatically (same-origin).
+const PAGE: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ultimo · Session Auth Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 4rem auto; padding: 0 1rem; }
+    input, button { font: inherit; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #ccc; }
+    button { cursor: pointer; border-color: #4f46e5; background: #4f46e5; color: white; }
+    #status { margin-top: 1rem; padding: 0.75rem; border-radius: 0.5rem; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <h1>Ultimo Session Auth</h1>
+  <p>Log in to set a cookie-backed session, then refresh — you stay logged in.</p>
+  <div>
+    <input id="username" placeholder="username" value="ada" />
+    <button id="login">Log in</button>
+    <button id="logout">Log out</button>
+  </div>
+  <div id="status">…</div>
+
+  <script>
+    const statusEl = document.getElementById('status');
+    async function refresh() {
+      const res = await fetch('/api/me');
+      const { user } = await res.json();
+      statusEl.textContent = user ? `Logged in as ${user}` : 'Not logged in';
+    }
+    document.getElementById('login').onclick = async () => {
+      const username = document.getElementById('username').value || 'guest';
+      await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ username }),
+      });
+      refresh();
+    };
+    document.getElementById('logout').onclick = async () => {
+      await fetch('/api/logout', { method: 'POST' });
+      refresh();
+    };
+    refresh();
+  </script>
+</body>
+</html>"#;
+
+#[derive(Deserialize)]
+struct LoginBody {
+    username: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let mut app = Ultimo::new_without_defaults();
+
+    // Cookie-backed sessions. secure(false) so the cookie works over local HTTP;
+    // in production keep the default secure(true) and serve over HTTPS.
+    app.use_middleware(session(
+        MemoryStore::new(),
+        SessionConfig::default().secure(false),
+    ));
+
+    // Serve the frontend.
+    app.get("/", |ctx: Context| async move { ctx.html(PAGE).await });
+
+    // Log in: store the user in the session and rotate the id (fixation defense).
+    app.post("/api/login", |ctx: Context| async move {
+        let body: LoginBody = ctx.req.json().await?;
+        let s = ctx.session().await;
+        s.set("user", &body.username).await?;
+        s.regenerate();
+        ctx.json(json!({ "ok": true, "user": body.username })).await
+    });
+
+    // Who am I? Reads the session (None if not logged in).
+    app.get("/api/me", |ctx: Context| async move {
+        let user: Option<String> = ctx.session().await.get("user").await?;
+        ctx.json(json!({ "user": user })).await
+    });
+
+    // Log out: destroy the session + expire the cookie.
+    app.post("/api/logout", |ctx: Context| async move {
+        ctx.session().await.destroy();
+        ctx.json(json!({ "ok": true })).await
+    });
+
+    println!("🔐 Session auth demo: http://127.0.0.1:3000");
+    app.listen("127.0.0.1:3000").await
+}


### PR DESCRIPTION
Adds a frontend example for the new session feature, and a standing rule.

## `examples/session-auth`
A self-contained full-stack demo: a Rust backend serves an HTML+JS page whose JS logs in/out against cookie-backed session routes (`/api/login` → `set` + `regenerate`, `/api/me`, `/api/logout` → `destroy`). Run with `cargo run -p session-auth-example` → http://127.0.0.1:3000. Workspace member, so CI builds it. Smoke-tested end-to-end (login sets cookie → `/me` returns the user → logout clears it).

## Rule in `CLAUDE.md`
**When a feature can be used from the frontend, ship/update an `examples/` example for it in the same PR.** Ultimo's pitch is full-stack DX, so frontend-relevant features (routes/RPC, cookies, sessions, WebSocket, auth, SSE, uploads…) must come with a client-side demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)