### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-04
+
 ### Added
 
 - **Cookie helper** (`ultimo::cookie`, core): `Cookie`/`CookieOptions`/`SameSite`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2565,6 +2565,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "session-auth-example"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing-subscriber",
+ "ultimo",
 ]
 
 [[package]]
@@ -3407,7 +3418,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3415,6 +3426,7 @@ dependencies = [
  "criterion",
  "diesel",
  "futures-util",
+ "getrandom 0.3.4",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
@@ -3438,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-04
+
+### Added
+
+- **Sessions** (`session` feature): cookie-based session management — `SessionStore` + `MemoryStore`, `ctx.session()`, secure middleware (256-bit ids, HttpOnly/Secure/SameSite, anti-fixation/DoS), `SessionConfig`. See the session-auth example.
+- **Cookie helper** (`ultimo::cookie`): parsing + `Set-Cookie` formatting and `ctx.cookie`/`set_cookie`/`remove_cookie`.
+- **Testing utilities** (`testing` feature): in-process `TestClient`, request builder, response assertions, macros, middleware/DB/fixture helpers.
+- `Ultimo::oneshot` for in-process dispatch; `Request::raw_body()`.
+
+### Fixed
+
+- Router precedence: static routes win over parameterized ones regardless of registration order.
+
+### Changed
+
+- **MSRV raised to 1.86.0** (breaking). Dependency floors hardened for RUSTSEC advisories.
+
 ## [0.2.1] - 2026-01-04
 
 ### Fixed

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.2.1 Now Available
+          v0.3.0 Now Available
         </div>
 
         <h1 className="text-4xl sm:text-6xl md:text-7xl font-bold tracking-tight mb-6 max-w-4xl text-balance">

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
**The 0.3.0 release.** Merging this publishes `ultimo` + `ultimo-cli` 0.3.0 to crates.io (release-plz `release` job), tags, and creates the GitHub Release.

## Version → 0.3.0 (minor; MSRV bump is breaking in 0.x)
Synced across `Cargo.toml`, both `package.json`s, the hero badge, and both changelogs (`version-sync` CI gate confirms).

## What's in 0.3.0 (since 0.2.1)
- **Sessions** (`session` feature) + **cookie helper** — with the `session-auth` example
- **Testing utilities** (`testing` feature) + `Ultimo::oneshot`
- **Router precedence** fix; `Request::raw_body()`
- **MSRV → 1.86**, dependency floors hardened (RUSTSEC); `Cargo.lock` committed
- CI: build/test/lint/MSRV/semver/audit/version-sync; release-plz automation
- Coverage measurement fixed → ~80%

## Pre-flight
Both crates `cargo publish --dry-run` clean at 0.3.0. CI re-verifies (semver-checks, audit, all tests). Supersedes release-plz PR #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)