### PR TITLE
docs(site): Sessions page + fix stale Testing page (0.3.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,14 @@ workspace `members` so CI builds it) unless a React example is the better fit.
 The session feature's example is `examples/session-auth`. Update the relevant
 example in the same PR as the feature — don't defer it.
 
+**User-facing docs go to the docs SITE, not just `docs/`.** The published site
+(docs.ultimo.dev) is **Vocs** under `docs-site/`: feature pages live in
+`docs-site/docs/pages/*.mdx` and the sidebar is in `docs-site/vocs.config.ts`.
+A new user-facing feature must add/update its `docs-site` page **and** the
+sidebar entry in the same PR. The repo's top-level `docs/` is internal notes;
+writing only there does NOT surface a feature to users. (Vercel auto-deploys the
+site on merge to `main`.)
+
 ## Conventions
 - **These are published crates — see the "PUBLISHED CRATES" section at the top before
   changing any public code, features, MSRV, or dep floors.**

--- a/docs-site/docs/pages/sessions.mdx
+++ b/docs-site/docs/pages/sessions.mdx
@@ -1,0 +1,133 @@
+# Sessions
+
+Ultimo ships cookie-based session management behind the `session` feature.
+Cookies are a core helper; sessions are middleware over a pluggable store.
+
+## Enable
+
+```toml
+[dependencies]
+ultimo = { version = "0.3", features = ["session"] }
+```
+
+## Register the middleware
+
+```rust
+use ultimo::session::{session, MemoryStore, SessionConfig};
+
+let mut app = Ultimo::new_without_defaults();
+app.use_middleware(session(MemoryStore::new(), SessionConfig::default()));
+```
+
+## Read & write
+
+Access the session from any handler with `ctx.session()`. Values are typed
+(serde):
+
+```rust
+// write
+app.post("/login", |ctx: Context| async move {
+    let s = ctx.session().await;
+    s.set("user_id", &42u64).await?;
+    s.regenerate(); // rotate the id on login (session-fixation defense)
+    ctx.text("logged in").await
+});
+
+// read
+app.get("/me", |ctx: Context| async move {
+    let id: Option<u64> = ctx.session().await.get("user_id").await?;
+    ctx.json(serde_json::json!({ "user_id": id })).await
+});
+
+// log out
+app.post("/logout", |ctx: Context| async move {
+    ctx.session().await.destroy();
+    ctx.text("bye").await
+});
+```
+
+Other methods: `remove(key)`, `clear()`, `id()`.
+
+## Security
+
+Defaults are secure-by-default:
+
+- **256-bit random ids** (`getrandom`) — opaque and unguessable.
+- **`HttpOnly` + `Secure` + `SameSite=Lax`** cookie by default.
+- **Server-side data** — only the id is in the cookie (no tampering surface).
+- **Anti session-fixation** — client-supplied ids are never adopted; call
+  `regenerate()` on login/privilege change (the middleware issues a fresh id and
+  drops the old one).
+- **Anti-DoS** — empty/untouched sessions are never persisted and get no cookie.
+- **Expiry** — enforced server-side (store TTL) *and* via the cookie `Max-Age`.
+
+:::warning CSRF
+`SameSite=Lax` is partial CSRF protection. Full CSRF tokens are a planned
+follow-up — don't rely on sessions alone for CSRF defense yet.
+:::
+
+### Local development
+
+The `Secure` cookie isn't sent over plain HTTP. For local dev:
+
+```rust
+SessionConfig::default().secure(false) // dev only
+```
+
+## Configuration
+
+```rust
+use std::time::Duration;
+use ultimo::cookie::SameSite;
+
+SessionConfig::default()
+    .cookie_name("my_sid")
+    .ttl(Duration::from_secs(3600))
+    .same_site(SameSite::Strict)
+    .secure(true)
+```
+
+`SameSite::None` requires `secure(true)` (enforced at construction).
+
+## Cookies
+
+The session feature builds on the core cookie helper, which you can use directly:
+
+```rust
+use ultimo::cookie::{Cookie, SameSite};
+
+// set
+ctx.set_cookie(
+    Cookie::new("theme", "dark")
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .max_age(86_400),
+).await?;
+
+// read
+let theme = ctx.cookie("theme"); // Option<String>
+
+// delete
+ctx.remove_cookie("theme").await?;
+```
+
+## Custom stores
+
+`MemoryStore` (single-process) is built in. Implement `SessionStore` for other
+backends:
+
+```rust
+#[async_trait::async_trait]
+impl SessionStore for MyStore {
+    async fn load(&self, id: &str) -> Option<SessionData> { /* ... */ }
+    async fn store(&self, id: &str, data: &SessionData, ttl: Duration) { /* ... */ }
+    async fn destroy(&self, id: &str) { /* ... */ }
+}
+```
+
+Redis and SQL stores are planned follow-ups.
+
+## Full example
+
+See [`examples/session-auth`](https://github.com/ultimo-rs/ultimo/tree/main/examples/session-auth)
+— a runnable backend serving an HTML+JS login/logout page.

--- a/docs-site/docs/pages/testing.mdx
+++ b/docs-site/docs/pages/testing.mdx
@@ -1,270 +1,168 @@
 # Testing
 
-Learn how to test your Ultimo applications effectively.
+Ultimo ships first-class testing utilities behind the `testing` feature. The
+`TestClient` drives your app **in-process** — no socket, no ports, fully
+deterministic and fast.
 
-## Test Client
+## Enable
 
-:::info Coming Soon
-Built-in test client is coming soon.
-:::
+Add `ultimo` with the `testing` feature as a **dev-dependency**:
 
-The planned test client will make integration testing easy:
+```toml
+[dev-dependencies]
+ultimo = { version = "0.3", features = ["testing"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+## TestClient
 
 ```rust
-use ultimo::prelude::*;
-use ultimo::test::TestClient;
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
 
-#[tokio::test]
-async fn test_get_users() {
-    let mut app = Ultimo::new();
-
-    app.get("/users", |ctx| async move {
-        ctx.json(vec![
-            User { id: 1, name: "Alice".to_string() }
-        ]).await
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/hello", |ctx: Context| async move { ctx.text("hi").await });
+    app.post("/echo", |ctx: Context| async move {
+        let body: serde_json::Value = ctx.req.json().await.unwrap_or_default();
+        ctx.json(body).await
     });
-
-    let client = TestClient::new(app);
-
-    let response = client.get("/users").send().await?;
-
-    assert_eq!(response.status(), 200);
-    assert_eq!(response.json::<Vec<User>>().await?.len(), 1);
-}
-```
-
-## Testing Patterns
-
-### Unit Testing Handlers
-
-Test your handler logic separately:
-
-```rust
-#[derive(Serialize)]
-struct User {
-    id: u32,
-    name: String,
-}
-
-async fn get_users() -> Vec<User> {
-    vec![
-        User { id: 1, name: "Alice".to_string() },
-        User { id: 2, name: "Bob".to_string() },
-    ]
+    app
 }
 
 #[tokio::test]
-async fn test_get_users() {
-    let users = get_users().await;
-    assert_eq!(users.len(), 2);
-    assert_eq!(users[0].name, "Alice");
+async fn hello_works() {
+    let client = TestClient::new(app());
+
+    let res = client.get("/hello").send().await;
+
+    res.assert_ok();            // 200
+    assert_eq!(res.text(), "hi");
 }
 ```
 
-### Integration Testing
+## Building requests
 
-Test the full HTTP stack:
+The builder from `client.get/post/put/delete/patch/head/options(path)` (or
+`client.request(method, path)`) is fluent:
 
 ```rust
-use reqwest;
-
-#[tokio::test]
-async fn test_api_integration() {
-    // Start your server in the background
-    tokio::spawn(async {
-        let mut app = Ultimo::new();
-        app.get("/health", |ctx| async move {
-            ctx.json(json!({"status": "ok"})).await
-        });
-        app.listen("127.0.0.1:3001").await
-    });
-
-    // Give server time to start
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    // Test with real HTTP client
-    let response = reqwest::get("http://127.0.0.1:3001/health")
-        .await?;
-
-    assert_eq!(response.status(), 200);
-}
+let res = client
+    .post("/users")
+    .bearer("my-token")                          // Authorization: Bearer my-token
+    .header("x-trace", "abc")
+    .query(&[("page", "2"), ("q", "ada")])       // ?page=2&q=ada
+    .json(&serde_json::json!({ "name": "Ada" })) // sets content-type: application/json
+    .send()
+    .await;
 ```
 
-### Testing with Database
+Other body setters: `.body(bytes)` and `.text("…")`.
+
+## Inspecting responses
+
+All accessors are synchronous (the body is already buffered):
+
+- `res.status() -> StatusCode`
+- `res.header(name) -> Option<&str>`, `res.headers()`
+- `res.text() -> String`, `res.bytes() -> &Bytes`
+- `res.json::<T>() -> T`
+
+Chainable assertions (panic with a clear message; return `&Self`):
 
 ```rust
-#[tokio::test]
-async fn test_user_crud() {
-    // Setup test database
-    let pool = SqlxPool::connect("postgres://localhost/test_db").await?;
-
-    let mut app = Ultimo::new();
-    app.with_sqlx(pool);
-
-    // Add routes
-    app.post("/users", create_user_handler);
-    app.get("/users/:id", get_user_handler);
-
-    let client = TestClient::new(app);
-
-    // Test create
-    let response = client
-        .post("/users")
-        .json(&json!({"name": "Alice", "email": "alice@example.com"}))
-        .send()
-        .await?;
-
-    assert_eq!(response.status(), 201);
-
-    let user: User = response.json().await?;
-
-    // Test get
-    let response = client
-        .get(&format!("/users/{}", user.id))
-        .send()
-        .await?;
-
-    assert_eq!(response.status(), 200);
-}
+res.assert_status(201)
+   .assert_header("content-type", "application/json")
+   .assert_json(&serde_json::json!({ "id": 1 }));
 ```
 
-### Mocking Dependencies
+Also `assert_ok()` (200) and `assert_status_is_success()` (2xx).
+
+## Macros
 
 ```rust
-// Mock RPC client for testing
-struct MockRpcClient;
+ultimo::assert_status!(res, 200);
+ultimo::assert_json_eq!(res.json::<serde_json::Value>(), serde_json::json!({ "ok": true }));
+```
 
-impl MockRpcClient {
-    async fn get_user(&self, id: u32) -> User {
-        User {
-            id,
-            name: "Test User".to_string(),
-            email: "test@example.com".to_string(),
-        }
-    }
+## Testing middleware in isolation
+
+Build a `Context` with `test_context()` and run a single middleware with
+`run_middleware` (construct the middleware like the built-ins —
+`Arc::new(|ctx, next| Box::pin(async move { … }))`):
+
+```rust
+use std::sync::Arc;
+use ultimo::middleware::{BoxedMiddleware, Next};
+use ultimo::testing::{run_middleware, test_context};
+use ultimo::Context;
+
+fn auth() -> BoxedMiddleware {
+    Arc::new(|ctx: Context, next: Next| {
+        Box::pin(async move {
+            if ctx.req.header("authorization").is_none() {
+                return ultimo::response::ResponseBuilder::new()
+                    .status(401)
+                    .text("unauthorized")
+                    .build();
+            }
+            next(ctx).await
+        })
+    })
 }
 
 #[tokio::test]
-async fn test_with_mock() {
-    let mock_client = MockRpcClient;
-    let user = mock_client.get_user(1).await;
-    assert_eq!(user.name, "Test User");
+async fn blocks_unauthenticated() {
+    let ctx = test_context().path("/private").build();
+    let res = run_middleware(auth(), ctx, |ctx| async move { ctx.text("ok").await })
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
 }
 ```
 
-## Best Practices
+## Database tests with rollback
 
-### ✅ Use #[tokio::test] for Async Tests
+Enable `testing` plus a `sqlx-*` backend. `with_test_transaction` runs your
+closure inside a transaction that is **always rolled back** — tests never mutate
+state. Return a boxed future (mirrors sqlx's `Pool::transaction`):
 
 ```rust
-#[tokio::test]
-async fn test_async_handler() {
-    let result = async_operation().await;
-    assert!(result.is_ok());
-}
+use ultimo::testing::with_test_transaction;
+
+let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY)").execute(&pool).await.unwrap();
+
+with_test_transaction(&pool, |tx| {
+    Box::pin(async move {
+        sqlx::query("INSERT INTO t (id) VALUES (1)")
+            .execute(&mut **tx)
+            .await
+            .unwrap();
+        Ok(())
+    })
+})
+.await
+.unwrap();
+// the insert was rolled back
 ```
 
-### ✅ Clean Up Test Data
+## Fixtures
 
 ```rust
-#[tokio::test]
-async fn test_with_cleanup() {
-    // Setup
-    let db = setup_test_db().await;
+use ultimo::testing::load_fixture;
 
-    // Test
-    let result = test_operation(&db).await;
+#[derive(serde::Deserialize)]
+struct User { id: u32, name: String }
 
-    // Cleanup
-    cleanup_test_db(&db).await;
-
-    assert!(result.is_ok());
-}
+let user: User = load_fixture("tests/fixtures/user.json");
 ```
 
-### ✅ Test Error Cases
+Implement the `Fixture` trait (`setup`/`teardown`) for seed/cleanup lifecycles.
 
-```rust
-#[tokio::test]
-async fn test_invalid_input() {
-    let result = create_user(CreateUserInput {
-        name: "".to_string(), // Invalid
-        email: "not-an-email".to_string(),
-    }).await;
+## Without the test client
 
-    assert!(result.is_err());
-}
-```
-
-### ✅ Use Test Fixtures
-
-```rust
-struct TestFixture {
-    app: Ultimo,
-    db: SqlxPool,
-}
-
-impl TestFixture {
-    async fn new() -> Self {
-        let db = SqlxPool::connect("postgres://localhost/test_db").await.unwrap();
-        let mut app = Ultimo::new();
-        app.with_sqlx(db.clone());
-        Self { app, db }
-    }
-}
-
-#[tokio::test]
-async fn test_with_fixture() {
-    let fixture = TestFixture::new().await;
-    // Use fixture.app and fixture.db
-}
-```
-
-## CI/CD Integration
-
-```yaml
-# .github/workflows/test.yml
-name: Tests
-
-on: [push, pull_request]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
-      - name: Run tests
-        run: cargo test
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost/test_db
-```
-
-## Coverage
-
-Generate test coverage reports:
-
-```bash
-# Install tarpaulin
-cargo install cargo-tarpaulin
-
-# Run tests with coverage
-cargo tarpaulin --out Html --output-dir coverage
-```
+`Ultimo::oneshot(req)` dispatches a buffered `http::Request` through the app
+in-process and returns the `Response` — the seam `TestClient` is built on, handy
+for lower-level tests or embedding.

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -56,6 +56,10 @@ export default defineConfig({
       text: "Features",
       items: [
         {
+          text: "Sessions",
+          link: "/sessions",
+        },
+        {
           text: "WebSocket",
           link: "/websocket",
         },


### PR DESCRIPTION
The docs site (docs.ultimo.dev) was missing the 0.3.0 features for users.

- **New `sessions.mdx`** — sessions + cookies guide, added to the Features sidebar (`vocs.config.ts`).
- **Rewrote `testing.mdx`** — it said *"test client coming soon"* with the wrong `ultimo::test` path; now documents the shipped `ultimo::testing` API (TestClient, request builder, assertions, macros, middleware/DB/fixture helpers).
- **CLAUDE.md rule**: user-facing feature docs must go to `docs-site/` (+ sidebar), not just the internal repo `docs/`.

Docs-only; no crate release. Vercel preview build on this PR verifies the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)