### PR TITLE
ci(release): don't release on docs-only commits

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,7 +32,8 @@ commit_parsers = [
   { message = "^fix", group = "Fixed" },
   { message = "^perf", group = "Performance" },
   { message = "^refactor", group = "Changed" },
-  { message = "^docs", group = "Documentation" },
+  # docs/chore/ci/test/style do NOT warrant a crate release on their own.
+  { message = "^docs", skip = true },
   { message = "^chore", skip = true },
   { message = "^ci", skip = true },
   { message = "^test", skip = true },


### PR DESCRIPTION
Maps `docs` to `skip` in release-plz so doc-only changes don't open spurious release PRs (they previously proposed a patch bump — the stale #49 0.3.1 PR). crates.io is correctly at 0.3.0; this just stops the recurrence.