### PR TITLE
docs(site): fix stale version strings (0.2.1→0.3) + roadmap

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,6 +102,11 @@ and commit the result to the release PR branch. The `version-sync` CI gate will
 **fail the release PR** until these match, so drift can't be merged. Update the
 docs-site changelog (`changelog.mdx`) to mirror the `CHANGELOG.md` entry.
 
+**On a MINOR release** (e.g. 0.3 → 0.4), also bump the floating install-version
+snippets in the docs-site pages — `getting-started.mdx`, `diesel.mdx`,
+`sqlx.mdx`, `api-reference.mdx`, `cli.mdx` (they pin `ultimo = "0.3"`, so patch
+releases need no change) — and refresh `roadmap.mdx`'s "(Current)" markers.
+
 > Future enhancement: have the sites read the version at build time from a single
 > generated file so even this step is automatic. Until then, `sync-versions.sh`
 > + the CI gate keep it correct.

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -625,7 +625,7 @@ Enable optional functionality through Cargo features:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.1.2", features = ["sqlx", "postgres"] }
+ultimo = { version = "0.3", features = ["sqlx-postgres"] }
 ```
 
 ### Available Features

--- a/docs-site/docs/pages/cli.mdx
+++ b/docs-site/docs/pages/cli.mdx
@@ -20,7 +20,7 @@ Verify installation:
 
 ```bash
 ultimo --version
-# ultimo 0.1.0
+# ultimo 0.3.0
 ```
 
 ## Commands

--- a/docs-site/docs/pages/diesel.mdx
+++ b/docs-site/docs/pages/diesel.mdx
@@ -18,7 +18,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.1.2", features = ["diesel"] }
+ultimo = { version = "0.3", features = ["diesel-postgres"] }
 diesel = { version = "2", features = ["postgres", "r2d2"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/docs-site/docs/pages/getting-started.mdx
+++ b/docs-site/docs/pages/getting-started.mdx
@@ -8,7 +8,7 @@ Add Ultimo to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = "0.2.1"
+ultimo = "0.3"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -18,14 +18,14 @@ Upcoming features and improvements planned for Ultimo.
 
 ### Session & Auth
 
-- 🎫 **Session Management** - Cookie-based sessions
 - 🎫 **Redis Sessions** - Distributed session storage
 - 🔐 **JWT Support** - Built-in JWT middleware
 - 🔐 **OAuth2** - OAuth provider integration
 
+(Cookie-based session management shipped in 0.3.0 — see [Sessions](/sessions).)
+
 ### Testing & Development
 
-- 🧪 **Test Client** - Built-in HTTP test client
 - 🧪 **Mock Server** - Testing utilities
 - 🔄 **Hot Reload** - Development mode with automatic restart
 - 📊 **Request Logging** - Structured request/response logging
@@ -71,8 +71,8 @@ Upcoming features and improvements planned for Ultimo.
 | **Rate Limiting**         | ✅ Available     | 0.1.0   |
 | **Database Integration**  | ✅ Available     | 0.1.0   |
 | **WebSocket Support**     | ✅ Available     | 0.2.1   |
-| Sessions                  | 🔥 High Priority | 0.3.0   |
-| Test Client               | 📋 Planned       | 0.3.0   |
+| **Sessions & Cookies**    | ✅ Available     | 0.3.0   |
+| **Testing Utilities**     | ✅ Available     | 0.3.0   |
 | Static Files              | 📋 Planned       | 0.4.0   |
 | Compression               | 📋 Planned       | 0.4.0   |
 | Hot Reload                | 📋 Planned       | 0.4.0   |
@@ -82,7 +82,7 @@ Upcoming features and improvements planned for Ultimo.
 
 ## Version Timeline
 
-### v0.1.0 (Current)
+### v0.1.0
 
 - Core framework features
 - RPC system with TypeScript generation
@@ -90,7 +90,7 @@ Upcoming features and improvements planned for Ultimo.
 - CLI tools
 - Database integration (SQLx & Diesel)
 
-### v0.2.1 (Current)
+### v0.2.1
 
 - ✅ **WebSocket Support (Complete)** - Production-ready RFC 6455 implementation
 - ✅ **Configuration System** - WebSocketConfig with size limits, timeouts, and buffer sizes
@@ -104,11 +104,13 @@ Upcoming features and improvements planned for Ultimo.
 - ✅ **279 Comprehensive Tests** - Production-ready with extensive test coverage
 - ✅ **Two Working Examples** - Simple chat + React chat
 
-### v0.3.0 (Next)
+### v0.3.0 (Current)
 
-- Session management
-- Test utilities
-- Enhanced error handling
+- ✅ **Session management** — cookie-based sessions, `SessionStore` + in-memory store, secure middleware
+- ✅ **Cookie helper** — parsing + `Set-Cookie` with security guards
+- ✅ **Testing utilities** — in-process `TestClient`, assertions, middleware/DB/fixture helpers
+- ✅ **Router precedence fix**, `Ultimo::oneshot`, `Request::raw_body()`
+- ✅ MSRV 1.86, hardened dependency floors, automated releases + CI guardrails
 
 ### v0.4.0
 

--- a/docs-site/docs/pages/sqlx.mdx
+++ b/docs-site/docs/pages/sqlx.mdx
@@ -18,7 +18,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.1.2", features = ["sqlx"] }
+ultimo = { version = "0.3", features = ["sqlx-postgres"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Fixes the stale versions on docs.ultimo.dev that the install snippets showed (getting-started said `ultimo = "0.2.1"`; diesel/sqlx/api-reference/cli showed 0.1.x). Now floating `"0.3"` (patch-proof). Roadmap updated: sessions/cookies/testing Available in 0.3.0, 0.3.0 marked current. RELEASING.md notes the minor-release docs step. Docs-only; Vercel verifies the build.