### PR TITLE
feat(security): request body-size limit (#58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         run: |
           cargo test -p ultimo --features "testing" --test cookie
           cargo test -p ultimo --features "testing" --test security_headers
+          cargo test -p ultimo --features "testing" --test body_limit
           cargo test -p ultimo --features "session" --lib session
           cargo test -p ultimo --features "session,testing" --test session
           cargo test -p ultimo --features "session" --doc

--- a/ultimo/src/app.rs
+++ b/ultimo/src/app.rs
@@ -43,6 +43,7 @@ pub struct Ultimo {
     router: Router,
     handlers: Vec<BoxedHandler>,
     middleware: Vec<BoxedMiddleware>,
+    max_body_size: Option<usize>,
 
     #[cfg(feature = "database")]
     database: Option<Database>,
@@ -64,6 +65,7 @@ impl Ultimo {
             router: Router::new(),
             handlers: Vec::new(),
             middleware: Vec::new(),
+            max_body_size: None,
             #[cfg(feature = "database")]
             database: None,
             #[cfg(feature = "websocket")]
@@ -88,6 +90,7 @@ impl Ultimo {
             router: Router::new(),
             handlers: Vec::new(),
             middleware: Vec::new(),
+            max_body_size: None,
             #[cfg(feature = "database")]
             database: None,
             #[cfg(feature = "websocket")]
@@ -95,6 +98,16 @@ impl Ultimo {
             #[cfg(feature = "websocket")]
             channel_manager: Arc::new(ChannelManager::new()),
         }
+    }
+
+    /// Set the maximum request body size in bytes.
+    ///
+    /// Requests whose body exceeds this are rejected with **413 Payload Too
+    /// Large** (and, on the live server, the oversized body is not buffered).
+    /// Defaults to no limit — setting one is recommended for production.
+    pub fn max_body_size(&mut self, bytes: usize) -> &mut Self {
+        self.max_body_size = Some(bytes);
+        self
     }
 
     /// Attach a SQLx database pool to the application
@@ -279,18 +292,29 @@ impl Ultimo {
             }
         }
 
-        // Buffer the body, then dispatch through the body-agnostic core.
+        // Buffer the body (capped if a max is configured, so an oversized body
+        // is never fully buffered), then dispatch through the body-agnostic core.
         let (parts, body) = req.into_parts();
-        let bytes = match body.collect().await {
-            Ok(c) => c.to_bytes(),
-            Err(e) => {
-                error!("Failed to read body: {}", e);
-                return response::helpers::error_response(&UltimoError::Internal(format!(
-                    "Failed to read body: {}",
-                    e
-                )))
-                .unwrap_or_else(|_| response::helpers::text("Internal Error").unwrap());
-            }
+        let bytes = match self.max_body_size {
+            Some(max) => match http_body_util::Limited::new(body, max).collect().await {
+                Ok(c) => c.to_bytes(),
+                Err(e) => {
+                    if e.downcast_ref::<http_body_util::LengthLimitError>()
+                        .is_some()
+                    {
+                        return body_too_large();
+                    }
+                    error!("Failed to read body: {}", e);
+                    return internal_error();
+                }
+            },
+            None => match body.collect().await {
+                Ok(c) => c.to_bytes(),
+                Err(e) => {
+                    error!("Failed to read body: {}", e);
+                    return internal_error();
+                }
+            },
         };
         self.dispatch_parts(parts, bytes).await
     }
@@ -299,6 +323,14 @@ impl Ultimo {
     async fn dispatch_parts(&self, parts: hyper::http::request::Parts, body: Bytes) -> Response {
         let method_str = parts.method.clone();
         let path = parts.uri.path().to_string();
+
+        // Enforce the body-size limit (covers in-process dispatch + a backstop
+        // for the live path).
+        if let Some(max) = self.max_body_size {
+            if body.len() > max {
+                return body_too_large();
+            }
+        }
 
         // Parse method
         let method = match Method::from_hyper(&method_str) {
@@ -438,6 +470,21 @@ impl Ultimo {
             });
         }
     }
+}
+
+/// 413 Payload Too Large response (body exceeded `max_body_size`).
+fn body_too_large() -> Response {
+    response::ResponseBuilder::new()
+        .status(413)
+        .text("Payload Too Large")
+        .build()
+        .unwrap_or_else(|_| response::helpers::text("Payload Too Large").unwrap())
+}
+
+/// 500 response for a genuine body-read failure (preserves the JSON error shape).
+fn internal_error() -> Response {
+    response::helpers::error_response(&UltimoError::Internal("Failed to read body".to_string()))
+        .unwrap_or_else(|_| response::helpers::text("Internal Error").unwrap())
 }
 
 /// Append queued `Set-Cookie` header values (from `ctx.set_cookie`) onto the

--- a/ultimo/tests/body_limit.rs
+++ b/ultimo/tests/body_limit.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "testing")]
+
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.max_body_size(16); // 16 bytes
+    app.post("/", |ctx: Context| async move { ctx.text("ok").await });
+    app
+}
+
+#[tokio::test]
+async fn rejects_oversized_body() {
+    let big = "x".repeat(100);
+    let res = TestClient::new(app()).post("/").text(&big).send().await;
+    assert_eq!(res.status(), 413);
+}
+
+#[tokio::test]
+async fn allows_body_within_limit() {
+    let res = TestClient::new(app()).post("/").text("small").send().await;
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.text(), "ok");
+}
+
+#[tokio::test]
+async fn no_limit_by_default() {
+    let mut app = Ultimo::new_without_defaults();
+    app.post("/", |ctx: Context| async move { ctx.text("ok").await });
+    let big = "x".repeat(10_000);
+    let res = TestClient::new(app).post("/").text(&big).send().await;
+    assert_eq!(res.status(), 200);
+}


### PR DESCRIPTION
`app.max_body_size(bytes)` rejects oversized requests with **413**. On the live path the body is wrapped in `http_body_util::Limited` so an oversized body is never fully buffered (real DoS protection); `dispatch_parts` enforces it too (covers in-process dispatch). Genuine read failures still return 500. Default: no limit (recommended to set in prod). 3 tests + CI. Closes #58.