### PR TITLE
ci(security): cargo-deny supply-chain checks (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,18 @@ jobs:
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099
 
+  # ── Supply-chain checks (cargo-deny) ──────────────────────────────────
+  # Advisories (RUSTSEC), banned/duplicate deps, and source pinning. License
+  # gating is configured in deny.toml but not yet enforced here (follow-up).
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans sources
+
   # ── Version sync across Cargo.toml + both sites + changelogs ───────────
   # Cargo.toml is the single source of truth; this fails if any site or
   # changelog has drifted. Fix with `scripts/sync-versions.sh`. Especially

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# cargo-deny configuration — supply-chain checks.
+# CI gates on `check advisories bans sources` (see .github/workflows/ci.yml).
+# License gating is configured below but not yet enforced (the ring/rustls
+# license clarification is a follow-up) — see issue #60.
+
+[advisories]
+version = 2
+# Known advisories that all require the sqlx 0.7 -> 0.8 upgrade (tracked
+# separately) plus rsa (no upstream fix; sqlx-mysql-only). Mirrors cargo-audit.
+ignore = [
+  "RUSTSEC-2024-0363",
+  "RUSTSEC-2024-0421",
+  "RUSTSEC-2023-0071",
+  "RUSTSEC-2026-0104",
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+[licenses]
+version = 2
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "MPL-2.0",
+  "CC0-1.0",
+  "BSL-1.0",
+]
+confidence-threshold = 0.8

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,10 @@ ignore = [
   "RUSTSEC-2026-0104",
   "RUSTSEC-2026-0098",
   "RUSTSEC-2026-0099",
+  # Unmaintained (not vulnerabilities) transitive deps — low risk, no control.
+  "RUSTSEC-2024-0436", # paste
+  "RUSTSEC-2024-0370", # proc-macro-error
+  "RUSTSEC-2025-0134", # rustls-pemfile
 ]
 
 [bans]


### PR DESCRIPTION
Adds `deny.toml` + a cargo-deny CI job gating on **advisories / bans / sources** — supply-chain proof beyond cargo-audit (banned/duplicate deps + crates.io-only sources). License allow-list is staged in deny.toml but not yet enforced (the ring/rustls SPDX clarification is a follow-up). Closes #60.