### PR TITLE
feat(security): real client IP, trusted-proxy aware (#65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           cargo test -p ultimo --features "testing" --test cookie
           cargo test -p ultimo --features "testing" --test security_headers
           cargo test -p ultimo --features "testing" --test body_limit
+          cargo test -p ultimo --features "testing" --test client_ip
           cargo test -p ultimo --features "session" --lib session
           cargo test -p ultimo --features "session,testing" --test session
           cargo test -p ultimo --features "session" --doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.9"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "bitflags 2.12.1",
  "byteorder",

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -36,7 +36,7 @@ getrandom = { version = "0.3", optional = true }
 
 # Database support (optional)
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls"], optional = true }
-diesel = { version = "2.3.8", optional = true }  # >=2.3.8: RUSTSEC fix for COPY command injection + unaligned access
+diesel = { version = "2.3.10", optional = true }  # >=2.3.8: RUSTSEC fix for COPY command injection + unaligned access
 r2d2 = { version = "0.8", optional = true }
 
 [dev-dependencies]

--- a/ultimo/src/app.rs
+++ b/ultimo/src/app.rs
@@ -44,6 +44,7 @@ pub struct Ultimo {
     handlers: Vec<BoxedHandler>,
     middleware: Vec<BoxedMiddleware>,
     max_body_size: Option<usize>,
+    trust_proxy: bool,
 
     #[cfg(feature = "database")]
     database: Option<Database>,
@@ -66,6 +67,7 @@ impl Ultimo {
             handlers: Vec::new(),
             middleware: Vec::new(),
             max_body_size: None,
+            trust_proxy: false,
             #[cfg(feature = "database")]
             database: None,
             #[cfg(feature = "websocket")]
@@ -91,6 +93,7 @@ impl Ultimo {
             handlers: Vec::new(),
             middleware: Vec::new(),
             max_body_size: None,
+            trust_proxy: false,
             #[cfg(feature = "database")]
             database: None,
             #[cfg(feature = "websocket")]
@@ -107,6 +110,16 @@ impl Ultimo {
     /// Defaults to no limit — setting one is recommended for production.
     pub fn max_body_size(&mut self, bytes: usize) -> &mut Self {
         self.max_body_size = Some(bytes);
+        self
+    }
+
+    /// Trust `X-Forwarded-For` / `Forwarded` headers for [`Context::client_ip`].
+    ///
+    /// **Only enable when the app sits behind a trusted proxy/load balancer** —
+    /// these headers are client-spoofable, so trusting them on a directly-exposed
+    /// server lets clients forge their IP. Defaults to `false`.
+    pub fn trust_proxy(&mut self, trust: bool) -> &mut Self {
+        self.trust_proxy = trust;
         self
     }
 
@@ -272,7 +285,7 @@ impl Ultimo {
     }
 
     /// Handle an incoming HTTP request
-    async fn handle_request(&self, req: HyperRequest<Incoming>) -> Response {
+    async fn handle_request(&self, req: HyperRequest<Incoming>, peer_addr: SocketAddr) -> Response {
         // Check for WebSocket upgrade request (needs the live `Incoming` body)
         #[cfg(feature = "websocket")]
         {
@@ -316,11 +329,16 @@ impl Ultimo {
                 }
             },
         };
-        self.dispatch_parts(parts, bytes).await
+        self.dispatch_parts(parts, bytes, Some(peer_addr)).await
     }
 
     /// Run routing + middleware + handler against an already-buffered request.
-    async fn dispatch_parts(&self, parts: hyper::http::request::Parts, body: Bytes) -> Response {
+    async fn dispatch_parts(
+        &self,
+        parts: hyper::http::request::Parts,
+        body: Bytes,
+        client_addr: Option<SocketAddr>,
+    ) -> Response {
         let method_str = parts.method.clone();
         let path = parts.uri.path().to_string();
 
@@ -348,7 +366,8 @@ impl Ultimo {
         // This allows CORS middleware to respond to preflight requests
         if method_str == hyper::Method::OPTIONS {
             // Create context for OPTIONS request
-            let ctx = Context::from_parts(parts, body, Params::new());
+            let mut ctx = Context::from_parts(parts, body, Params::new());
+            ctx.set_client(client_addr, self.trust_proxy);
             let cookie_sink = ctx.set_cookies_handle();
 
             // Build and execute middleware chain
@@ -390,8 +409,8 @@ impl Ultimo {
         let _handler = &self.handlers[handler_id];
 
         // Create context
-        #[cfg_attr(not(feature = "database"), allow(unused_mut))]
         let mut ctx = Context::from_parts(parts, body, params);
+        ctx.set_client(client_addr, self.trust_proxy);
         let cookie_sink = ctx.set_cookies_handle();
 
         // Attach database if configured
@@ -434,7 +453,7 @@ impl Ultimo {
             .await
             .map(|c| c.to_bytes())
             .unwrap_or_default();
-        self.dispatch_parts(parts, bytes).await
+        self.dispatch_parts(parts, bytes, None).await
     }
 
     /// Start the HTTP server
@@ -450,14 +469,14 @@ impl Ultimo {
         let app = Arc::new(self);
 
         loop {
-            let (stream, _) = listener.accept().await?;
+            let (stream, peer_addr) = listener.accept().await?;
             let io = TokioIo::new(stream);
             let app = app.clone();
 
             tokio::task::spawn(async move {
                 let service = service_fn(move |req| {
                     let app = app.clone();
-                    async move { Ok::<_, hyper::Error>(app.handle_request(req).await) }
+                    async move { Ok::<_, hyper::Error>(app.handle_request(req, peer_addr).await) }
                 });
 
                 if let Err(err) = http1::Builder::new()

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -12,6 +12,7 @@ use http_body_util::BodyExt;
 use hyper::{body::Incoming, Request as HyperRequest};
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -191,6 +192,31 @@ mod request_body_tests {
     }
 }
 
+/// Extract the IP from the first `for=` element of an RFC 7239 `Forwarded` header.
+fn parse_forwarded_for(header: &str) -> Option<IpAddr> {
+    let first = header.split(',').next()?;
+    for part in first.split(';') {
+        let part = part.trim();
+        if part.len() >= 4 && part[..4].eq_ignore_ascii_case("for=") {
+            let v = part[4..].trim().trim_matches('"');
+            // IPv6 in brackets, optionally with port: [::1]:1234
+            if let Some(rest) = v.strip_prefix('[') {
+                if let Some(end) = rest.find(']') {
+                    return rest[..end].parse().ok();
+                }
+            }
+            // Bare IP, or IPv4 with :port
+            if let Ok(ip) = v.parse::<IpAddr>() {
+                return Some(ip);
+            }
+            if let Some((host, _)) = v.rsplit_once(':') {
+                return host.parse().ok();
+            }
+        }
+    }
+    None
+}
+
 /// Context holds request data and provides response building methods
 pub struct Context {
     pub req: Request,
@@ -198,6 +224,10 @@ pub struct Context {
     response_status: Arc<RwLock<Option<u16>>>,
     response_headers: Arc<RwLock<HashMap<String, String>>>,
     set_cookies: Arc<RwLock<Vec<String>>>,
+    /// Peer address of the connection (set by the server; None for in-process dispatch).
+    client_addr: Option<SocketAddr>,
+    /// Whether to trust `X-Forwarded-For` / `Forwarded` headers for `client_ip()`.
+    trust_proxy: bool,
     #[cfg(feature = "session")]
     session: Arc<RwLock<Option<crate::session::Session>>>,
 
@@ -218,6 +248,8 @@ impl Context {
             response_status: Arc::new(RwLock::new(None)),
             response_headers: Arc::new(RwLock::new(HashMap::new())),
             set_cookies: Arc::new(RwLock::new(Vec::new())),
+            client_addr: None,
+            trust_proxy: false,
             #[cfg(feature = "session")]
             session: Arc::new(RwLock::new(None)),
             #[cfg(feature = "database")]
@@ -321,6 +353,46 @@ impl Context {
     /// Shared handle to the queued Set-Cookie values (drained by the dispatcher).
     pub(crate) fn set_cookies_handle(&self) -> Arc<RwLock<Vec<String>>> {
         self.set_cookies.clone()
+    }
+
+    /// Set the connection peer address + proxy-trust (used by the server).
+    pub(crate) fn set_client(&mut self, addr: Option<SocketAddr>, trust_proxy: bool) {
+        self.client_addr = addr;
+        self.trust_proxy = trust_proxy;
+    }
+
+    /// The peer address of the underlying connection, if known. This is the
+    /// direct socket peer — for the originating client behind a proxy, use
+    /// [`client_ip`](Self::client_ip).
+    pub fn peer_addr(&self) -> Option<SocketAddr> {
+        self.client_addr
+    }
+
+    /// Best-effort originating client IP.
+    ///
+    /// When proxy trust is enabled (`app.trust_proxy(true)`) this honors the
+    /// left-most `X-Forwarded-For` entry, then `Forwarded: for=…`; otherwise (or
+    /// if no such header) it falls back to the connection peer. **Only enable
+    /// proxy trust when the app is actually behind a trusted proxy** — these
+    /// headers are client-spoofable.
+    pub fn client_ip(&self) -> Option<IpAddr> {
+        if self.trust_proxy {
+            if let Some(xff) = self.req.header("x-forwarded-for") {
+                if let Some(ip) = xff
+                    .split(',')
+                    .next()
+                    .and_then(|s| s.trim().parse::<IpAddr>().ok())
+                {
+                    return Some(ip);
+                }
+            }
+            if let Some(fwd) = self.req.header("forwarded") {
+                if let Some(ip) = parse_forwarded_for(&fwd) {
+                    return Some(ip);
+                }
+            }
+        }
+        self.client_addr.map(|a| a.ip())
     }
 
     /// The current session. Panics if the session middleware isn't installed.
@@ -685,5 +757,27 @@ mod context_response_tests {
         assert_eq!(c.req.queries().get("a").unwrap().len(), 2);
         assert_eq!(c.req.path(), "/x");
         assert_eq!(c.req.method(), &hyper::Method::GET);
+    }
+}
+
+#[cfg(test)]
+mod forwarded_tests {
+    use super::*;
+
+    #[test]
+    fn parses_forwarded_for_variants() {
+        assert_eq!(
+            parse_forwarded_for("for=192.0.2.1"),
+            Some("192.0.2.1".parse().unwrap())
+        );
+        assert_eq!(
+            parse_forwarded_for("For=\"[2001:db8::1]:4711\";proto=https"),
+            Some("2001:db8::1".parse().unwrap())
+        );
+        assert_eq!(
+            parse_forwarded_for("for=192.0.2.1:8080"),
+            Some("192.0.2.1".parse().unwrap())
+        );
+        assert_eq!(parse_forwarded_for("proto=https;by=10.0.0.1"), None);
     }
 }

--- a/ultimo/tests/client_ip.rs
+++ b/ultimo/tests/client_ip.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "testing")]
+
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+fn ip_app(trust: bool) -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.trust_proxy(trust);
+    app.get("/ip", |ctx: Context| async move {
+        let ip = ctx
+            .client_ip()
+            .map(|i| i.to_string())
+            .unwrap_or_else(|| "none".into());
+        ctx.text(ip).await
+    });
+    app
+}
+
+#[tokio::test]
+async fn xff_used_when_proxy_trusted() {
+    let res = TestClient::new(ip_app(true))
+        .get("/ip")
+        .header("x-forwarded-for", "203.0.113.7, 10.0.0.1")
+        .send()
+        .await;
+    assert_eq!(res.text(), "203.0.113.7");
+}
+
+#[tokio::test]
+async fn xff_ignored_when_not_trusted() {
+    // Untrusted + no real peer (in-process) → no client IP, header ignored.
+    let res = TestClient::new(ip_app(false))
+        .get("/ip")
+        .header("x-forwarded-for", "203.0.113.7")
+        .send()
+        .await;
+    assert_eq!(res.text(), "none");
+}
+
+#[tokio::test]
+async fn forwarded_header_used_when_trusted() {
+    let res = TestClient::new(ip_app(true))
+        .get("/ip")
+        .header("forwarded", "for=198.51.100.5;proto=https")
+        .send()
+        .await;
+    assert_eq!(res.text(), "198.51.100.5");
+}


### PR DESCRIPTION
`ctx.client_ip()` + `ctx.peer_addr()`. The server threads the connection peer `SocketAddr` into the Context; `client_ip()` honors `X-Forwarded-For` (leftmost) then `Forwarded: for=` **only when `app.trust_proxy(true)`** (default **false** — those headers are client-spoofable), otherwise the connection peer. Foundation for IP allow/deny (#66), geo-blocking (#68), and per-IP rate limiting. Forwarded-parser unit test + 3 integration tests + CI. Closes #65.