### PR TITLE
feat(security): CSRF protection — double-submit cookie (closes #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       # --all-targets here lints lib, integration tests and benches together,
       # all of which compile once websocket+test-helpers are enabled.
       # Database features are linted in the `test-db` job (needs system libs).
-      - name: clippy (websocket + test-helpers + testing + session, all targets)
-        run: cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session" -- -D warnings
+      - name: clippy (websocket + test-helpers + testing + session + csrf, all targets)
+        run: cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session,csrf" -- -D warnings
 
   # ── Unit + integration tests (no DB system deps) ──────────────────────
   test:
@@ -85,6 +85,8 @@ jobs:
           cargo test -p ultimo --features "testing" --test security_headers
           cargo test -p ultimo --features "testing" --test body_limit
           cargo test -p ultimo --features "testing" --test client_ip
+          cargo test -p ultimo --features "csrf" --lib csrf
+          cargo test -p ultimo --features "csrf,testing" --test csrf
           cargo test -p ultimo --features "session" --lib session
           cargo test -p ultimo --features "session,testing" --test session
           cargo test -p ultimo --features "session" --doc

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - 🛡️ **Type Safety Everywhere** - From Rust backend to TypeScript frontend
 - 🔒 **100% Safe Rust** - The framework enforces `#![forbid(unsafe_code)]` — zero `unsafe`
 - 🎫 **Sessions & Cookies** - Secure-by-default cookie sessions (HttpOnly/Secure/SameSite, 256-bit ids, anti session-fixation) over a pluggable store
-- 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
+- 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), CSRF protection, request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
 - 🧪 **Testing Utilities** - In-process `TestClient`, response assertions, middleware/DB/fixture helpers
 - 🔥 **Developer Experience First** - Ergonomic APIs, helpful errors, minimal boilerplate
 - 💪 **Production Ready** - Built-in validation, authentication, rate limiting, CORS
@@ -52,7 +52,7 @@
 
 See the [full roadmap](https://docs.ultimo.dev/roadmap) for upcoming features:
 
-- 🛡️ Auth middleware (JWT / API keys) & CSRF protection
+- 🛡️ Auth middleware (JWT / API keys)
 - 📡 Streaming & SSE
 - 🌍 Multi-language Client Generation
 - And more...

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -470,6 +470,16 @@ app.use_middleware(
 );
 ```
 
+#### `csrf()` / `Csrf` (requires `csrf` feature)
+
+Double-submit-cookie CSRF protection (constant-time compare; unsafe methods must
+echo the cookie token in a header). See [Security](/security).
+
+```rust
+app.use_middleware(ultimo::csrf::csrf());
+// or: ultimo::csrf::Csrf::new().header_name("x-csrf-token").build()
+```
+
 ### Custom Middleware
 
 Create custom middleware by implementing the middleware function signature:
@@ -723,6 +733,7 @@ All features are off by default (`default = []`).
 
 - `websocket` - RFC 6455 WebSocket support (zero extra dependencies)
 - `session` - Cookie-based session management ([Sessions](/sessions))
+- `csrf` - Double-submit-cookie CSRF protection ([Security](/security))
 - `testing` - Testing utilities: `TestClient`, assertions, helpers ([Testing](/testing))
 - `test-helpers` - WebSocket test helpers (for integration tests)
 - `sqlx-postgres` / `sqlx-mysql` / `sqlx-sqlite` - SQLx integration per backend

--- a/docs-site/docs/pages/security.mdx
+++ b/docs-site/docs/pages/security.mdx
@@ -73,6 +73,38 @@ forge their IP.
 Cookie-based sessions are secure by default (HttpOnly, Secure, SameSite, 256-bit
 ids, anti session-fixation, server-side storage). See [Sessions](/sessions).
 
+## CSRF protection
+
+The `csrf` feature provides **double-submit cookie** CSRF protection. The
+middleware issues a random token in a (non-HttpOnly) cookie; on unsafe methods
+(POST/PUT/PATCH/DELETE) the request must echo that token in a header, and the two
+are compared in **constant time** (mismatch → 403). Safe methods are exempt.
+
+```rust
+// Cargo.toml: ultimo = { version = "0.3", features = ["csrf"] }
+app.use_middleware(ultimo::csrf::csrf());
+
+// or customized:
+app.use_middleware(
+    ultimo::csrf::Csrf::new()
+        .header_name("x-csrf-token")
+        .same_site(ultimo::cookie::SameSite::Strict)
+        .build(),
+);
+```
+
+The frontend reads the `csrf_token` cookie and sends it back as the
+`x-csrf-token` header:
+
+```js
+const token = document.cookie.split('; ')
+  .find((c) => c.startsWith('csrf_token='))?.split('=')[1];
+await fetch('/api/action', { method: 'POST', headers: { 'x-csrf-token': token } });
+```
+
+See the [`session-auth` example](https://github.com/ultimo-rs/ultimo/tree/main/examples/session-auth)
+for a working login flow with CSRF.
+
 ## Supply chain
 
 - **`cargo audit`** (RUSTSEC advisories) runs in CI on every PR.
@@ -94,6 +126,6 @@ Please report privately — see [SECURITY.md](https://github.com/ultimo-rs/ultim
 
 ## Roadmap
 
-Planned for v0.4.0: CSRF protection, auth middleware (JWT / API keys),
+Planned for v0.4.0: auth middleware (JWT / API keys),
 authorization guards, IP allow/deny, request guards, and geo-blocking hooks.
 See the [roadmap](/roadmap).

--- a/examples/session-auth/Cargo.toml
+++ b/examples/session-auth/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-ultimo = { path = "../../ultimo", features = ["session"] }
+ultimo = { path = "../../ultimo", features = ["session", "csrf"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/session-auth/src/main.rs
+++ b/examples/session-auth/src/main.rs
@@ -42,17 +42,21 @@ const PAGE: &str = r#"<!doctype html>
       const { user } = await res.json();
       statusEl.textContent = user ? `Logged in as ${user}` : 'Not logged in';
     }
+    // Read the CSRF token the server set in a (non-HttpOnly) cookie.
+    function csrfToken() {
+      return document.cookie.split('; ').find((c) => c.startsWith('csrf_token='))?.split('=')[1] || '';
+    }
     document.getElementById('login').onclick = async () => {
       const username = document.getElementById('username').value || 'guest';
       await fetch('/api/login', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', 'x-csrf-token': csrfToken() },
         body: JSON.stringify({ username }),
       });
       refresh();
     };
     document.getElementById('logout').onclick = async () => {
-      await fetch('/api/logout', { method: 'POST' });
+      await fetch('/api/logout', { method: 'POST', headers: { 'x-csrf-token': csrfToken() } });
       refresh();
     };
     refresh();
@@ -70,6 +74,9 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let mut app = Ultimo::new_without_defaults();
+
+    // CSRF protection (double-submit cookie). secure(false) for local HTTP dev.
+    app.use_middleware(ultimo::csrf::Csrf::new().secure(false).build());
 
     // Cookie-backed sessions. secure(false) so the cookie works over local HTTP;
     // in production keep the default secure(true) and serve over HTTPS.

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -63,6 +63,9 @@ testing = []
 # Session management (cookie-based, pluggable store)
 session = ["dep:getrandom"]
 
+# CSRF protection (double-submit cookie)
+csrf = ["dep:getrandom"]
+
 # Database features
 database = []
 sqlx-postgres = ["database", "sqlx", "sqlx/postgres"]

--- a/ultimo/src/csrf.rs
+++ b/ultimo/src/csrf.rs
@@ -1,0 +1,167 @@
+//! CSRF protection via the **double-submit cookie** pattern.
+//!
+//! The middleware issues a random token in a (non-HttpOnly) cookie so the
+//! frontend can read it and echo it back in a request header on unsafe methods
+//! (POST/PUT/PATCH/DELETE). The token in the cookie and the header must match
+//! (compared in constant time) or the request is rejected with **403**. Safe
+//! methods (GET/HEAD/OPTIONS) are exempt and just (re)issue the token.
+//!
+//! Security rests on the same-origin policy: a cross-site attacker can neither
+//! read the victim's cookie nor set the matching header.
+//!
+//! ```
+//! # use ultimo::Ultimo;
+//! let mut app = Ultimo::new_without_defaults();
+//! app.use_middleware(ultimo::csrf::csrf());
+//! ```
+
+use crate::cookie::{Cookie, SameSite};
+use crate::error::Result;
+use crate::middleware::{BoxedMiddleware, Next};
+use crate::response::{Response, ResponseBuilder};
+use crate::Context;
+use base64::Engine;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// CSRF middleware configuration. Secure-by-default.
+#[derive(Debug, Clone)]
+pub struct Csrf {
+    cookie_name: String,
+    header_name: String,
+    secure: bool,
+    same_site: SameSite,
+}
+
+impl Default for Csrf {
+    fn default() -> Self {
+        Self {
+            cookie_name: "csrf_token".to_string(),
+            header_name: "x-csrf-token".to_string(),
+            secure: true,
+            same_site: SameSite::Lax,
+        }
+    }
+}
+
+impl Csrf {
+    /// Secure defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Name of the CSRF token cookie (default `csrf_token`).
+    pub fn cookie_name(mut self, name: impl Into<String>) -> Self {
+        self.cookie_name = name.into();
+        self
+    }
+    /// Request header carrying the echoed token (default `x-csrf-token`).
+    pub fn header_name(mut self, name: impl Into<String>) -> Self {
+        self.header_name = name.into();
+        self
+    }
+    /// Set the cookie `Secure` attribute (disable only for local HTTP dev).
+    pub fn secure(mut self, v: bool) -> Self {
+        self.secure = v;
+        self
+    }
+    /// Set the cookie `SameSite` attribute.
+    pub fn same_site(mut self, v: SameSite) -> Self {
+        self.same_site = v;
+        self
+    }
+
+    /// Build the CSRF middleware.
+    pub fn build(self) -> BoxedMiddleware {
+        let cfg = Arc::new(self);
+        Arc::new(move |ctx: Context, next: Next| {
+            let cfg = cfg.clone();
+            Box::pin(async move {
+                let existing = ctx.cookie(&cfg.cookie_name);
+
+                // Validate unsafe methods: cookie token must equal the header.
+                if is_unsafe(ctx.req.method()) {
+                    let valid = match (&existing, ctx.req.header(&cfg.header_name)) {
+                        (Some(c), Some(h)) => ct_eq(c.as_bytes(), h.as_bytes()),
+                        _ => false,
+                    };
+                    if !valid {
+                        return Ok(forbidden());
+                    }
+                }
+
+                // Bootstrap a token cookie if the client doesn't have one yet.
+                if existing.is_none() {
+                    let token = generate_token();
+                    let cookie = Cookie::new(cfg.cookie_name.clone(), token)
+                        .secure(cfg.secure)
+                        .same_site(cfg.same_site)
+                        .path("/");
+                    // Note: intentionally NOT HttpOnly — the frontend must read it.
+                    let _ = ctx.set_cookie(cookie).await;
+                }
+
+                next(ctx).await
+            }) as Pin<Box<dyn Future<Output = Result<Response>> + Send>>
+        })
+    }
+}
+
+/// CSRF middleware with secure defaults.
+pub fn csrf() -> BoxedMiddleware {
+    Csrf::new().build()
+}
+
+fn is_unsafe(method: &hyper::Method) -> bool {
+    !matches!(
+        *method,
+        hyper::Method::GET | hyper::Method::HEAD | hyper::Method::OPTIONS | hyper::Method::TRACE
+    )
+}
+
+/// Constant-time byte comparison (avoids leaking match position via timing).
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// 256-bit URL-safe token. Panics if the OS RNG fails (never weak fallback).
+fn generate_token() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("OS RNG failure generating CSRF token");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn forbidden() -> Response {
+    ResponseBuilder::new()
+        .status(403)
+        .text("CSRF token missing or invalid")
+        .build()
+        .unwrap_or_else(|_| crate::response::helpers::text("Forbidden").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ct_eq_basic() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn unsafe_methods() {
+        assert!(is_unsafe(&hyper::Method::POST));
+        assert!(is_unsafe(&hyper::Method::DELETE));
+        assert!(!is_unsafe(&hyper::Method::GET));
+        assert!(!is_unsafe(&hyper::Method::OPTIONS));
+    }
+}

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -53,6 +53,9 @@ pub mod testing;
 #[cfg(feature = "session")]
 pub mod session;
 
+#[cfg(feature = "csrf")]
+pub mod csrf;
+
 // Re-exports for convenience
 pub use app::Ultimo;
 pub use context::Context;

--- a/ultimo/tests/csrf.rs
+++ b/ultimo/tests/csrf.rs
@@ -1,0 +1,52 @@
+#![cfg(all(feature = "csrf", feature = "testing"))]
+
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(ultimo::csrf::Csrf::new().secure(false).build());
+    app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+    app.post(
+        "/submit",
+        |ctx: Context| async move { ctx.text("done").await },
+    );
+    app
+}
+
+#[tokio::test]
+async fn get_issues_token_cookie() {
+    let res = TestClient::new(app()).get("/").send().await;
+    let sc = res.header("set-cookie").expect("GET issues a csrf cookie");
+    assert!(sc.contains("csrf_token="));
+    assert!(!sc.contains("HttpOnly")); // frontend must read it
+}
+
+#[tokio::test]
+async fn post_without_token_is_forbidden() {
+    let res = TestClient::new(app()).post("/submit").send().await;
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn post_with_matching_token_passes() {
+    let res = TestClient::new(app())
+        .post("/submit")
+        .header("cookie", "csrf_token=tok123")
+        .header("x-csrf-token", "tok123")
+        .send()
+        .await;
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.text(), "done");
+}
+
+#[tokio::test]
+async fn post_with_mismatched_token_is_forbidden() {
+    let res = TestClient::new(app())
+        .post("/submit")
+        .header("cookie", "csrf_token=tok123")
+        .header("x-csrf-token", "different")
+        .send()
+        .await;
+    assert_eq!(res.status(), 403);
+}


### PR DESCRIPTION
The final Tier-1 item. **Double-submit cookie** CSRF protection behind a `csrf` feature.

- `ultimo::csrf::csrf()` / `Csrf` builder. Issues a random token in a non-HttpOnly cookie; unsafe methods (POST/PUT/PATCH/DELETE) must echo it in `x-csrf-token`, compared **constant-time** → 403 on mismatch. Safe methods exempt.
- **session-auth example** updated to use it (JS reads the cookie, sends the header) — per the frontend-example rule. Smoke-tested end-to-end (GET issues token → POST without it 403 → POST with it succeeds).
- **Docs in the same PR**: `/security` CSRF section, `/api-reference`, README; CSRF moved out of 'Coming Soon'.
- 6 tests (2 unit + 4 integration) + doctest; CI wired.

Closes #57. **Completes Tier-1 security** (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)