### PR TITLE
docs(site): add deployment guides to roadmap

### DIFF
--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -83,6 +83,7 @@ Upcoming features and improvements planned for Ultimo.
 | Hot Reload                | 📋 Planned       | 0.5.0   |
 | Development Dashboard     | 📋 Planned       | 0.5.0   |
 | Multi-language Clients    | 📋 Planned       | 0.5.0   |
+| Deployment Guides         | 📋 Planned       | 0.5.0   |
 | MCP Server                | 📋 Planned       | 0.6.0   |
 
 ## Version Timeline
@@ -143,6 +144,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - Hot reload development mode
 - Development dashboard with live metrics and debugging tools
 - Multi-language client generation (Python/Go/Dart/Swift)
+- **Deployment guides** — Docker, AWS (ECS/Fargate, Lambda + API Gateway, EC2), DigitalOcean (App Platform/Droplet), Azure Container Apps, Google Cloud Run, Fly.io/Railway, Kubernetes — each with ready-to-use config
 - Production-ready optimizations
 
 ### v0.6.0


### PR DESCRIPTION
Adds **Deployment Guides** to the roadmap (v0.5.0) — Docker, AWS (ECS/Fargate, Lambda+API Gateway, EC2), DigitalOcean (App Platform/Droplet), Azure Container Apps, Google Cloud Run, Fly.io/Railway, Kubernetes. Tracked in #7 (expanded with the platform matrix). Roadmap-only; no implementation.