### PR TITLE
feat(auth): JWT authentication middleware (HS256)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt-auth-example"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing-subscriber",
+ "ultimo",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,8 +944,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1514,6 +1516,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1720,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,6 +1880,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2633,6 +2670,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -3430,6 +3479,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
+ "jsonwebtoken",
  "multer",
  "proptest",
  "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-demo", "examples/database-sqlx", "examples/database-diesel", "examples/database-api-styles", "examples/websocket-chat", "examples/websocket-chat-react", "examples/session-auth", "ultimo-cli", "coverage-tool"]
+members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-demo", "examples/database-sqlx", "examples/database-diesel", "examples/database-api-styles", "examples/websocket-chat", "examples/websocket-chat-react", "examples/session-auth", "examples/jwt-auth", "ultimo-cli", "coverage-tool"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - 🛡️ **Type Safety Everywhere** - From Rust backend to TypeScript frontend
 - 🔒 **100% Safe Rust** - The framework enforces `#![forbid(unsafe_code)]` — zero `unsafe`
 - 🎫 **Sessions & Cookies** - Secure-by-default cookie sessions (HttpOnly/Secure/SameSite, 256-bit ids, anti session-fixation) over a pluggable store
+- 🔑 **JWT Authentication** - HS256 JWT middleware (opt-in `jwt` feature): pins the algorithm (`alg: none` rejected), validates `exp`, attaches claims to the request — sign + verify
 - 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), CSRF protection, request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
 - 🧪 **Testing Utilities** - In-process `TestClient`, response assertions, middleware/DB/fixture helpers
 - 🔥 **Developer Experience First** - Ergonomic APIs, helpful errors, minimal boilerplate
@@ -52,7 +53,7 @@
 
 See the [full roadmap](https://docs.ultimo.dev/roadmap) for upcoming features:
 
-- 🛡️ Auth middleware (JWT / API keys)
+- 🛡️ More auth: API-key middleware & authorization guards (JWT shipped)
 - 📡 Streaming & SSE
 - 🌍 Multi-language Client Generation
 - And more...

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -225,6 +225,23 @@ let id: Option<u64> = ctx.session().await.get("user_id").await?;
 
 See [Sessions](/sessions).
 
+#### JWT claims (requires `jwt` feature)
+
+##### `jwt_claims(&self) -> Option<serde_json::Value>`
+
+The validated JWT claims for this request (`None` if no valid token was presented).
+
+##### `jwt<T: DeserializeOwned>(&self) -> Result<T>`
+
+Deserialize the validated claims into a typed struct (errors if absent or shape mismatch).
+
+```rust
+let claims = ctx.jwt_claims().await;          // Option<serde_json::Value>
+let mine: MyClaims = ctx.jwt::<MyClaims>().await?;
+```
+
+See [Authentication (JWT)](/authentication).
+
 ### `Request`
 
 Access request data through `ctx.req`.
@@ -478,6 +495,21 @@ echo the cookie token in a header). See [Security](/security).
 ```rust
 app.use_middleware(ultimo::csrf::csrf());
 // or: ultimo::csrf::Csrf::new().header_name("x-csrf-token").build()
+```
+
+#### `Jwt` (requires `jwt` feature)
+
+HS256 JWT auth — verifies signed bearer/cookie tokens, attaches claims to the
+`Context`, and issues tokens. The algorithm is pinned (`alg: none` rejected) and
+`exp` is validated by default. Builder: `hs256(secret)`, `issuer(s)`,
+`audience(s)`, `leeway(secs)`, `from_bearer()`, `from_cookie(name)`, `optional()`,
+`sign(&claims)`, `build()`. See [Authentication (JWT)](/authentication).
+
+```rust
+use ultimo::auth::jwt::Jwt;
+let jwt = Jwt::hs256(b"super-secret-key");
+app.use_middleware(jwt.clone().build());
+let token = jwt.sign(&claims)?;
 ```
 
 ### Custom Middleware
@@ -734,6 +766,7 @@ All features are off by default (`default = []`).
 - `websocket` - RFC 6455 WebSocket support (zero extra dependencies)
 - `session` - Cookie-based session management ([Sessions](/sessions))
 - `csrf` - Double-submit-cookie CSRF protection ([Security](/security))
+- `jwt` - HS256 JWT authentication middleware ([Authentication](/authentication))
 - `testing` - Testing utilities: `TestClient`, assertions, helpers ([Testing](/testing))
 - `test-helpers` - WebSocket test helpers (for integration tests)
 - `sqlx-postgres` / `sqlx-mysql` / `sqlx-sqlite` - SQLx integration per backend

--- a/docs-site/docs/pages/authentication.mdx
+++ b/docs-site/docs/pages/authentication.mdx
@@ -1,0 +1,122 @@
+# Authentication (JWT)
+
+Ultimo ships a JWT (JSON Web Token) auth middleware that verifies signed bearer
+tokens, attaches the validated claims to the request `Context`, and can issue
+tokens. It's secure-by-default: the signing algorithm is **pinned to HS256**, so
+`alg: none` and algorithm-confusion attacks are rejected, and token expiry
+(`exp`) is validated automatically.
+
+Verification is delegated to the audited
+[`jsonwebtoken`](https://crates.io/crates/jsonwebtoken) crate rather than
+hand-rolled.
+
+## Enable the feature
+
+JWT support is opt-in:
+
+```toml
+[dependencies]
+ultimo = { version = "0.3", features = ["jwt"] }
+```
+
+## Quick start
+
+```rust
+use ultimo::auth::jwt::Jwt;
+use ultimo::prelude::*;
+
+#[derive(serde::Serialize)]
+struct Claims { sub: String, exp: usize }
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Load the secret from the environment in production — never hardcode it.
+    let jwt = Jwt::hs256(b"super-secret-key");
+
+    let mut app = Ultimo::new_without_defaults();
+
+    // Verify tokens on every request and attach claims to the Context.
+    app.use_middleware(jwt.clone().build());
+
+    app.get("/me", |ctx: Context| async move {
+        let claims = ctx.jwt_claims().await; // Option<serde_json::Value>
+        ctx.json(serde_json::json!({ "claims": claims })).await
+    });
+
+    app.listen("127.0.0.1:3000").await
+}
+```
+
+## Issuing tokens
+
+The same `Jwt` value that verifies can also sign (the HS256 secret is shared).
+Claims must include an `exp` (expiry) field:
+
+```rust
+let token = jwt.sign(&Claims { sub: "ada".into(), exp: 1_900_000_000 })?;
+```
+
+## Reading claims in a handler
+
+After the middleware accepts a token, the claims are available on the `Context`:
+
+```rust
+// Raw claims object (None if unauthenticated / optional mode).
+let claims: Option<serde_json::Value> = ctx.jwt_claims().await;
+
+// Or deserialize into your own type (errors if absent or shape mismatch).
+#[derive(serde::Deserialize)]
+struct MyClaims { sub: String }
+let mine: MyClaims = ctx.jwt::<MyClaims>().await?;
+```
+
+## Configuration
+
+`Jwt` is a builder. All options are chainable:
+
+| Method | Effect |
+|---|---|
+| `Jwt::hs256(secret)` | Configure HS256 with a symmetric secret (signs + verifies). |
+| `.issuer(s)` | Require the `iss` claim to equal `s`. |
+| `.audience(s)` | Require the `aud` claim to equal `s`. |
+| `.leeway(secs)` | Clock-skew tolerance applied to `exp`/`nbf`. |
+| `.from_bearer()` | Read the token from `Authorization: Bearer <token>` (default). |
+| `.from_cookie(name)` | Read the token from a named cookie instead. |
+| `.optional()` | Don't 401 on missing/invalid tokens — pass through unauthenticated. |
+| `.sign(&claims)` | Issue a signed token. |
+| `.build()` | Build the verification middleware. |
+
+### Required vs optional
+
+By default the middleware returns **`401 Unauthorized`** (with a
+`WWW-Authenticate: Bearer` header) when a token is missing or invalid. Call
+`.optional()` for routes that serve both authenticated and anonymous users — the
+request passes through with no claims attached, and your handler decides what to
+do when `ctx.jwt_claims()` is `None`.
+
+## Security notes
+
+- **HS256 only (today).** RS256/EdDSA (asymmetric keys) are planned. The
+  algorithm is pinned, so `alg: none` and HS/RS confusion tokens are rejected.
+- **`exp` is validated by default** — always set a short expiry. Following
+  least-privilege guidance, use **15–60 minutes** for sensitive systems and mint
+  a fresh token on login.
+- **Load the secret from the environment**, never hardcode it, and rotate it if
+  leaked.
+- **Stateless tokens can't be revoked server-side.** A bearer JWT remains valid
+  until it expires, so "log out everywhere" / instant revocation isn't possible
+  with JWT alone. For those needs use short TTLs plus either the
+  [session](/sessions) middleware (server-side, revocable) or a token blocklist.
+- **Cookie source:** if you use `.from_cookie(...)`, serve over HTTPS and set the
+  cookie `Secure` + `HttpOnly` so it can't be read by JavaScript or sent over
+  plaintext.
+- **Audience gotcha:** `jsonwebtoken` validates `aud` by default. If your tokens
+  carry an `aud` claim but you don't call `.audience(...)` on the verifier, they
+  will be **rejected**. Either set `.audience(...)` to match, or don't include
+  `aud` in your tokens.
+
+## Full example
+
+A runnable login → protected-route demo lives at
+[`examples/jwt-auth`](https://github.com/ultimo-rs/ultimo/tree/main/examples/jwt-auth):
+`cargo run -p jwt-auth-example`, then open `http://127.0.0.1:3000`.

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -76,7 +76,8 @@ Upcoming features and improvements planned for Ultimo.
 | **100% Safe Rust** (`forbid(unsafe)`) | ✅ Available | 0.3.0 |
 | Security Headers (HSTS/CSP/…) | 🔒 Planned    | 0.4.0   |
 | CSRF Protection           | 🔒 Planned       | 0.4.0   |
-| Auth (JWT / API keys)     | 🔒 Planned       | 0.4.0   |
+| Auth: JWT middleware      | ✅ Available     | 0.4.0   |
+| Auth: API keys / authz guards | 🔒 Planned   | 0.4.0   |
 | Benchmark Suite + CI Guard | ⚡ Planned      | 0.4.0   |
 | Static Files              | 📋 Planned       | 0.5.0   |
 | Compression               | 📋 Planned       | 0.5.0   |
@@ -126,7 +127,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 - 🔒 Security headers middleware (HSTS, CSP, X-Frame-Options, …)
 - 🔒 CSRF protection (integrates with sessions)
-- 🔒 Auth: JWT + API-key middleware, authorization guards
+- ✅ Auth: JWT middleware (HS256) — shipped; API-key middleware + authorization guards planned
 - 🔒 Request body-size limits, request timeouts, enhanced rate limiting
 - 🔒 `#![forbid(unsafe_code)]` (100% safe Rust), `SECURITY.md` disclosure policy,
   `cargo-deny` + fuzzing in CI, OpenSSF Best Practices

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
           link: "/sessions",
         },
         {
+          text: "Authentication (JWT)",
+          link: "/authentication",
+        },
+        {
           text: "WebSocket",
           link: "/websocket",
         },

--- a/docs/superpowers/plans/2026-06-07-jwt-auth.md
+++ b/docs/superpowers/plans/2026-06-07-jwt-auth.md
@@ -1,0 +1,963 @@
+# JWT Auth Middleware Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a feature-gated JWT auth middleware (HS256) that verifies signed bearer/cookie tokens, attaches validated claims to `Context`, rejects unauthenticated requests with 401, and can also issue tokens.
+
+**Architecture:** New `ultimo::auth::jwt` module behind an opt-in `jwt` Cargo feature. A single `Jwt` config type both signs (`.sign(&claims)`) and builds the verification middleware (`.build()`), reusing the HS256 secret. Validated claims are stored on `Context` in a feature-gated `Arc<RwLock<Option<serde_json::Value>>>` slot — the same pattern the `session` feature already uses — and exposed via async `ctx.jwt_claims()` / typed `ctx.jwt::<T>()`. Verification delegates to the audited `jsonwebtoken` crate, which pins the algorithm and rejects `alg: none` and HS/RS confusion.
+
+**Tech Stack:** Rust, Hyper 1.0, Tokio, `jsonwebtoken` 9.x (HS256), `serde_json`, existing Ultimo middleware/Context/Response primitives.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `ultimo/Cargo.toml` | Add `jwt` feature + optional `jsonwebtoken` dep |
+| `ultimo/src/lib.rs` | Gate `pub mod auth;` on feature `jwt` |
+| `ultimo/src/auth/mod.rs` (new) | Auth namespace; `pub mod jwt;` |
+| `ultimo/src/auth/jwt.rs` (new) | `Jwt` config, `sign`, token extraction, `build` middleware, `unauthorized()`, unit tests |
+| `ultimo/src/context.rs` | `jwt_claims` slot + `set_jwt_claims`/`jwt_claims`/`jwt::<T>()` accessors (feature `jwt`) |
+| `ultimo/tests/jwt.rs` (new) | Integration tests via `Ultimo::oneshot` |
+| `examples/jwt-auth/` (new) | Runnable login/protected-route demo; added to workspace members |
+| `Cargo.toml` (root) | Add `examples/jwt-auth` to `members` |
+| docs surfaces | `api-reference.mdx`, `authentication.mdx` + sidebar, `README.md`, `roadmap.mdx` |
+
+Verification commands used throughout (the `jwt` feature must be enabled to compile this code):
+
+```bash
+cargo test -p ultimo --lib --features "jwt"                                   # unit tests
+cargo test -p ultimo --features "jwt" --test jwt                              # integration tests
+cargo clippy -p ultimo --features "websocket,test-helpers,testing,session,csrf,jwt" --all-targets -- -D warnings
+cargo fmt --all
+```
+
+---
+
+## Task 1: Cargo feature, dependency, and module skeleton
+
+**Files:**
+- Modify: `ultimo/Cargo.toml`
+- Create: `ultimo/src/auth/mod.rs`
+- Create: `ultimo/src/auth/jwt.rs`
+- Modify: `ultimo/src/lib.rs`
+
+- [ ] **Step 1: Add the optional dependency**
+
+In `ultimo/Cargo.toml`, under `[dependencies]`, after the `getrandom` line, add:
+
+```toml
+# JWT auth (optional) — audited impl; pins algorithm, rejects `alg: none`
+jsonwebtoken = { version = "9", optional = true }
+```
+
+- [ ] **Step 2: Add the feature**
+
+In `ultimo/Cargo.toml`, under `[features]`, after the `csrf` line, add:
+
+```toml
+# JWT authentication middleware (HS256)
+jwt = ["dep:jsonwebtoken"]
+```
+
+- [ ] **Step 3: Create the auth namespace module**
+
+Create `ultimo/src/auth/mod.rs`:
+
+```rust
+//! Authentication middleware.
+//!
+//! Currently provides JWT (JSON Web Token) verification + signing behind the
+//! `jwt` feature. API-key auth and authorization guards are planned follow-ups.
+
+pub mod jwt;
+```
+
+- [ ] **Step 4: Create the jwt module stub**
+
+Create `ultimo/src/auth/jwt.rs` with a minimal doc comment so the crate compiles:
+
+```rust
+//! JWT auth middleware (HS256) — verifies signed bearer/cookie tokens, attaches
+//! validated claims to the request `Context`, and can issue tokens via `sign`.
+//!
+//! Verification is delegated to the audited `jsonwebtoken` crate, which pins the
+//! expected algorithm and rejects `alg: none` and HS/RS confusion attacks.
+//!
+//! ```no_run
+//! # use ultimo::Ultimo;
+//! # use ultimo::auth::jwt::Jwt;
+//! let mut app = Ultimo::new_without_defaults();
+//! let jwt = Jwt::hs256(b"super-secret-key".to_vec());
+//! app.use_middleware(jwt.clone().build());
+//! ```
+```
+
+- [ ] **Step 5: Gate the module in lib.rs**
+
+In `ultimo/src/lib.rs`, after the `#[cfg(feature = "csrf")] pub mod csrf;` block, add:
+
+```rust
+#[cfg(feature = "jwt")]
+pub mod auth;
+```
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `cargo build -p ultimo --features "jwt"`
+Expected: builds clean (the stub module has no code yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultimo/Cargo.toml ultimo/src/lib.rs ultimo/src/auth/
+git commit -m "feat(auth): scaffold jwt feature + auth module"
+```
+
+---
+
+## Task 2: Context claims slot + accessors
+
+**Files:**
+- Modify: `ultimo/src/context.rs`
+
+The `Context` already stores the session in `#[cfg(feature = "session")] session: Arc<RwLock<Option<...>>>` and initializes it in `from_parts`. Add a parallel `jwt_claims` slot and accessors. Claims are returned by clone (the slot is behind an async `RwLock`, so we can't hand out borrows — this mirrors how `session()` returns an owned `Session`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the bottom of `ultimo/src/context.rs`, inside a new `#[cfg(all(test, feature = "jwt"))]` module:
+
+```rust
+#[cfg(all(test, feature = "jwt"))]
+mod jwt_claims_tests {
+    use super::*;
+    use serde::Deserialize;
+
+    fn ctx() -> Context {
+        let req = hyper::Request::builder()
+            .method("GET")
+            .uri("/")
+            .body(())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+        Context::from_parts(parts, Bytes::new(), Params::new())
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Claims {
+        sub: String,
+    }
+
+    #[tokio::test]
+    async fn claims_absent_by_default() {
+        let c = ctx();
+        assert!(c.jwt_claims().await.is_none());
+        assert!(c.jwt::<Claims>().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn set_then_read_typed_claims() {
+        let c = ctx();
+        c.set_jwt_claims(serde_json::json!({ "sub": "ada" })).await;
+        assert_eq!(
+            c.jwt_claims().await,
+            Some(serde_json::json!({ "sub": "ada" }))
+        );
+        assert_eq!(c.jwt::<Claims>().await.unwrap(), Claims { sub: "ada".into() });
+    }
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p ultimo --lib --features "jwt" jwt_claims_tests`
+Expected: FAIL to compile — `jwt_claims`, `set_jwt_claims`, `jwt` methods and the field don't exist yet.
+
+- [ ] **Step 3: Add the field**
+
+In `ultimo/src/context.rs`, in the `pub struct Context { ... }` definition, after the `#[cfg(feature = "session")] session: ...` field, add:
+
+```rust
+    #[cfg(feature = "jwt")]
+    jwt_claims: Arc<RwLock<Option<serde_json::Value>>>,
+```
+
+- [ ] **Step 4: Initialize it in `from_parts`**
+
+In the `Context::from_parts` constructor, in the struct literal, after the `#[cfg(feature = "session")] session: Arc::new(RwLock::new(None)),` line, add:
+
+```rust
+            #[cfg(feature = "jwt")]
+            jwt_claims: Arc::new(RwLock::new(None)),
+```
+
+- [ ] **Step 5: Add the accessors**
+
+In `ultimo/src/context.rs`, in `impl Context`, after the `set_session` method, add:
+
+```rust
+    /// The validated JWT claims for this request, if the `jwt` middleware ran
+    /// and accepted a token. Returns a clone of the raw claims object.
+    #[cfg(feature = "jwt")]
+    pub async fn jwt_claims(&self) -> Option<serde_json::Value> {
+        self.jwt_claims.read().await.clone()
+    }
+
+    /// Deserialize the validated JWT claims into a typed struct. Errors if no
+    /// claims are present (unauthenticated) or the shape doesn't match.
+    #[cfg(feature = "jwt")]
+    pub async fn jwt<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        let claims = self
+            .jwt_claims
+            .read()
+            .await
+            .clone()
+            .ok_or_else(|| crate::error::UltimoError::Unauthorized("no JWT claims".to_string()))?;
+        serde_json::from_value(claims).map_err(crate::error::UltimoError::from)
+    }
+
+    /// Store validated claims on the context (used by the jwt middleware).
+    #[cfg(feature = "jwt")]
+    pub(crate) async fn set_jwt_claims(&self, claims: serde_json::Value) {
+        *self.jwt_claims.write().await = Some(claims);
+    }
+```
+
+- [ ] **Step 6: Run the test to confirm it passes**
+
+Run: `cargo test -p ultimo --lib --features "jwt" jwt_claims_tests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultimo/src/context.rs
+git commit -m "feat(auth): add jwt claims slot + accessors to Context"
+```
+
+---
+
+## Task 3: `Jwt` config type + `sign`
+
+**Files:**
+- Modify: `ultimo/src/auth/jwt.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ultimo/src/auth/jwt.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    fn far_future() -> usize {
+        // Fixed timestamp well beyond any reasonable test clock (year 2100).
+        4_102_444_800
+    }
+
+    #[test]
+    fn sign_then_decode_roundtrip() {
+        let jwt = Jwt::hs256(b"test-secret".to_vec());
+        let token = jwt
+            .sign(&Claims { sub: "ada".into(), exp: far_future() })
+            .unwrap();
+        // The signed token has three dot-separated segments.
+        assert_eq!(token.split('.').count(), 3);
+
+        let claims: Claims = jwt.decode(&token).unwrap();
+        assert_eq!(claims, Claims { sub: "ada".into(), exp: far_future() });
+    }
+
+    #[test]
+    fn decode_rejects_bad_signature() {
+        let signer = Jwt::hs256(b"secret-a".to_vec());
+        let verifier = Jwt::hs256(b"secret-b".to_vec());
+        let token = signer
+            .sign(&Claims { sub: "ada".into(), exp: far_future() })
+            .unwrap();
+        assert!(verifier.decode::<Claims>(&token).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_expired() {
+        let jwt = Jwt::hs256(b"secret".to_vec());
+        // exp in the past (epoch second 1) with zero leeway → expired.
+        let token = jwt.sign(&Claims { sub: "ada".into(), exp: 1 }).unwrap();
+        assert!(jwt.decode::<Claims>(&token).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p ultimo --lib --features "jwt" auth::jwt`
+Expected: FAIL to compile — `Jwt`, `hs256`, `sign`, `decode` don't exist.
+
+- [ ] **Step 3: Implement the config type, `sign`, and `decode`**
+
+Insert at the top of the code section of `ultimo/src/auth/jwt.rs` (after the module doc comment):
+
+```rust
+use crate::error::{Result, UltimoError};
+use jsonwebtoken::{
+    decode as jwt_decode, encode as jwt_encode, Algorithm, DecodingKey, EncodingKey, Header,
+    Validation,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Where the middleware looks for the token on an incoming request.
+#[derive(Debug, Clone)]
+enum TokenSource {
+    /// `Authorization: Bearer <token>` (default).
+    Bearer,
+    /// A named cookie carrying the raw token.
+    Cookie(String),
+}
+
+/// JWT auth configuration. Verifies (`build`) and issues (`sign`) tokens using a
+/// shared HS256 secret. Secure-by-default: `exp` is validated, the algorithm is
+/// pinned to HS256, and `alg: none` / algorithm-confusion tokens are rejected.
+#[derive(Clone)]
+pub struct Jwt {
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+    validation: Validation,
+    source: TokenSource,
+    /// When false (default), a missing/invalid token yields 401. When true, the
+    /// request passes through unauthenticated (no claims attached).
+    optional: bool,
+}
+
+impl Jwt {
+    /// Configure HS256 with a symmetric secret. The same secret signs and verifies.
+    pub fn hs256(secret: impl AsRef<[u8]>) -> Self {
+        let secret = secret.as_ref();
+        Self {
+            encoding: EncodingKey::from_secret(secret),
+            decoding: DecodingKey::from_secret(secret),
+            validation: Validation::new(Algorithm::HS256),
+            source: TokenSource::Bearer,
+            optional: false,
+        }
+    }
+
+    /// Require the `iss` claim to equal `issuer`.
+    pub fn issuer(mut self, issuer: impl Into<String>) -> Self {
+        self.validation.set_issuer(&[issuer.into()]);
+        self
+    }
+
+    /// Require the `aud` claim to equal `audience`.
+    pub fn audience(mut self, audience: impl Into<String>) -> Self {
+        self.validation.set_audience(&[audience.into()]);
+        self
+    }
+
+    /// Clock-skew tolerance (seconds) applied to `exp`/`nbf` checks.
+    pub fn leeway(mut self, seconds: u64) -> Self {
+        self.validation.leeway = seconds;
+        self
+    }
+
+    /// Read the token from `Authorization: Bearer <token>` (the default).
+    pub fn from_bearer(mut self) -> Self {
+        self.source = TokenSource::Bearer;
+        self
+    }
+
+    /// Read the token from a named cookie instead of the Authorization header.
+    pub fn from_cookie(mut self, name: impl Into<String>) -> Self {
+        self.source = TokenSource::Cookie(name.into());
+        self
+    }
+
+    /// Make authentication optional: unauthenticated requests pass through with
+    /// no claims attached, instead of receiving a 401. Handlers decide what to do
+    /// when `ctx.jwt_claims()` is `None`.
+    pub fn optional(mut self) -> Self {
+        self.optional = true;
+        self
+    }
+
+    /// Issue a signed HS256 token for the given claims (which must include `exp`).
+    pub fn sign<T: Serialize>(&self, claims: &T) -> Result<String> {
+        jwt_encode(&Header::new(Algorithm::HS256), claims, &self.encoding)
+            .map_err(|e| UltimoError::Internal(format!("JWT signing failed: {e}")))
+    }
+
+    /// Verify a token and deserialize its claims. Errors on bad signature,
+    /// expired/`nbf` violations, wrong `iss`/`aud`, or `alg: none`.
+    pub fn decode<T: DeserializeOwned>(&self, token: &str) -> Result<T> {
+        jwt_decode::<T>(token, &self.decoding, &self.validation)
+            .map(|data| data.claims)
+            .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cargo test -p ultimo --lib --features "jwt" auth::jwt`
+Expected: PASS (3 tests: roundtrip, bad signature, expired).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/src/auth/jwt.rs
+git commit -m "feat(auth): Jwt config type with HS256 sign + decode"
+```
+
+---
+
+## Task 4: Token extraction helper
+
+**Files:**
+- Modify: `ultimo/src/auth/jwt.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add these two test fns inside the existing `mod tests` in `ultimo/src/auth/jwt.rs`:
+
+```rust
+    #[test]
+    fn bearer_parsing_extracts_token() {
+        assert_eq!(parse_bearer("Bearer abc.def.ghi"), Some("abc.def.ghi".to_string()));
+        // Scheme is case-insensitive.
+        assert_eq!(parse_bearer("bearer xyz"), Some("xyz".to_string()));
+        // Non-bearer schemes and missing tokens are rejected.
+        assert_eq!(parse_bearer("Basic abc"), None);
+        assert_eq!(parse_bearer("Bearer"), None);
+        assert_eq!(parse_bearer("Bearer "), None);
+    }
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p ultimo --lib --features "jwt" auth::jwt::tests::bearer_parsing_extracts_token`
+Expected: FAIL to compile — `parse_bearer` is undefined.
+
+- [ ] **Step 3: Implement `parse_bearer` and the context-aware extractor**
+
+Add to the code section of `ultimo/src/auth/jwt.rs` (after the `impl Jwt` block):
+
+```rust
+use crate::Context;
+
+/// Pull the token out of an `Authorization: Bearer <token>` header value.
+/// The scheme match is case-insensitive; an empty token returns `None`.
+fn parse_bearer(header_value: &str) -> Option<String> {
+    let (scheme, token) = header_value.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let token = token.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+/// Read the token from the configured source on this request.
+fn extract_token(jwt: &Jwt, ctx: &Context) -> Option<String> {
+    match &jwt.source {
+        TokenSource::Bearer => ctx.req.header("authorization").and_then(|h| parse_bearer(&h)),
+        TokenSource::Cookie(name) => ctx.cookie(name),
+    }
+}
+```
+
+> Note: `Request::header` lower-cases the lookup, so `"authorization"` matches `Authorization`. `extract_token` reads `jwt.source` (a private field on the same module), so it lives in this module.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cargo test -p ultimo --lib --features "jwt" auth::jwt::tests::bearer_parsing_extracts_token`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/src/auth/jwt.rs
+git commit -m "feat(auth): token extraction (bearer header / cookie)"
+```
+
+---
+
+## Task 5: The middleware + 401 response
+
+**Files:**
+- Modify: `ultimo/src/auth/jwt.rs`
+- Create: `ultimo/tests/jwt.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `ultimo/tests/jwt.rs`:
+
+```rust
+//! Integration tests for the JWT auth middleware (feature `jwt`).
+#![cfg(feature = "jwt")]
+
+use serde::{Deserialize, Serialize};
+use ultimo::auth::jwt::Jwt;
+use ultimo::Ultimo;
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+}
+
+fn far_future() -> usize {
+    4_102_444_800 // ~year 2100
+}
+
+fn app(jwt: Jwt) -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(jwt.build());
+    app.get("/me", |ctx: ultimo::Context| async move {
+        let sub: String = ctx
+            .jwt_claims()
+            .await
+            .and_then(|c| c.get("sub").and_then(|v| v.as_str().map(String::from)))
+            .unwrap_or_else(|| "anonymous".to_string());
+        ctx.json(serde_json::json!({ "sub": sub })).await
+    });
+    app
+}
+
+#[tokio::test]
+async fn valid_token_is_accepted_and_claims_attached() {
+    let jwt = Jwt::hs256(b"secret".to_vec());
+    let token = jwt.sign(&Claims { sub: "ada".into(), exp: far_future() }).unwrap();
+
+    let req = hyper::Request::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(String::new())
+        .unwrap();
+    let res = app(jwt).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn missing_token_is_rejected_with_401() {
+    let jwt = Jwt::hs256(b"secret".to_vec());
+    let req = hyper::Request::builder().uri("/me").body(String::new()).unwrap();
+    let res = app(jwt).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 401);
+    assert_eq!(
+        res.headers().get("www-authenticate").map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+}
+
+#[tokio::test]
+async fn bad_signature_is_rejected_with_401() {
+    let signer = Jwt::hs256(b"secret-a".to_vec());
+    let verifier = Jwt::hs256(b"secret-b".to_vec());
+    let token = signer.sign(&Claims { sub: "ada".into(), exp: far_future() }).unwrap();
+
+    let req = hyper::Request::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(String::new())
+        .unwrap();
+    let res = app(verifier).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn alg_none_token_is_rejected() {
+    // Hand-crafted unsigned token with "alg":"none". jsonwebtoken must reject it
+    // because the validation pins HS256.
+    // header {"alg":"none","typ":"JWT"} . payload {"sub":"ada","exp":4102444800} . (empty sig)
+    let token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.\
+eyJzdWIiOiJhZGEiLCJleHAiOjQxMDI0NDQ4MDB9.";
+    let jwt = Jwt::hs256(b"secret".to_vec());
+    let req = hyper::Request::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(String::new())
+        .unwrap();
+    let res = app(jwt).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn optional_mode_passes_through_without_token() {
+    let jwt = Jwt::hs256(b"secret".to_vec()).optional();
+    let req = hyper::Request::builder().uri("/me").body(String::new()).unwrap();
+    let res = app(jwt).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 200); // handler returns "anonymous"
+}
+
+#[tokio::test]
+async fn cookie_source_reads_token_from_cookie() {
+    let jwt = Jwt::hs256(b"secret".to_vec()).from_cookie("token");
+    let signed = jwt.sign(&Claims { sub: "ada".into(), exp: far_future() }).unwrap();
+
+    let req = hyper::Request::builder()
+        .uri("/me")
+        .header("cookie", format!("token={signed}"))
+        .body(String::new())
+        .unwrap();
+    let res = app(jwt).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 200);
+}
+```
+
+> The `oneshot` body type: match the signature used by the existing `ultimo/tests` (e.g. `cookie.rs`/`session.rs`). If `oneshot` expects `String`, the `.body(String::new())` above is correct; if it expects bytes, adjust to `.body(Vec::new())` / `Bytes::new()` to match those tests. Check one existing integration test before running.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p ultimo --features "jwt" --test jwt`
+Expected: FAIL to compile — `Jwt::build` doesn't exist yet.
+
+- [ ] **Step 3: Implement `build` and `unauthorized`**
+
+Add to the code section of `ultimo/src/auth/jwt.rs` (after `extract_token`):
+
+```rust
+use crate::middleware::{BoxedMiddleware, Next};
+use crate::response::{Response, ResponseBuilder};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+impl Jwt {
+    /// Build the verification middleware. On a valid token it attaches the
+    /// claims to the `Context` and continues; otherwise it returns 401 (unless
+    /// `optional()` was set, in which case it passes through unauthenticated).
+    pub fn build(self) -> BoxedMiddleware {
+        let cfg = Arc::new(self);
+        Arc::new(move |ctx: Context, next: Next| {
+            let cfg = cfg.clone();
+            Box::pin(async move {
+                match extract_token(&cfg, &ctx) {
+                    Some(token) => match cfg.decode::<serde_json::Value>(&token) {
+                        Ok(claims) => {
+                            ctx.set_jwt_claims(claims).await;
+                            next(ctx).await
+                        }
+                        Err(_) if cfg.optional => next(ctx).await,
+                        Err(_) => Ok(unauthorized()),
+                    },
+                    None if cfg.optional => next(ctx).await,
+                    None => Ok(unauthorized()),
+                }
+            }) as Pin<Box<dyn Future<Output = Result<Response>> + Send>>
+        })
+    }
+}
+
+fn unauthorized() -> Response {
+    ResponseBuilder::new()
+        .status(401)
+        .header("WWW-Authenticate", "Bearer")
+        .text("Unauthorized")
+        .build()
+        .unwrap_or_else(|_| crate::response::helpers::text("Unauthorized").unwrap())
+}
+```
+
+> `decode::<serde_json::Value>` still validates `exp`/`nbf`/`iss`/`aud` — `jsonwebtoken` applies `Validation` regardless of the claims type. Decoding into `Value` lets the middleware stay non-generic (it lives in a `Vec<BoxedMiddleware>`).
+
+- [ ] **Step 4: Run the integration tests to confirm they pass**
+
+Run: `cargo test -p ultimo --features "jwt" --test jwt`
+Expected: PASS (6 tests). If a test fails on the `oneshot` body type, fix per the note in Step 1.
+
+- [ ] **Step 5: Run the full unit + integration suite for the feature**
+
+Run: `cargo test -p ultimo --lib --features "jwt" auth::jwt && cargo test -p ultimo --features "jwt" --test jwt`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/src/auth/jwt.rs ultimo/tests/jwt.rs
+git commit -m "feat(auth): jwt verification middleware + 401 response"
+```
+
+---
+
+## Task 6: Example app `examples/jwt-auth`
+
+**Files:**
+- Create: `examples/jwt-auth/Cargo.toml`
+- Create: `examples/jwt-auth/src/main.rs`
+- Modify: `Cargo.toml` (root `members`)
+
+- [ ] **Step 1: Add the example to the workspace**
+
+In the root `Cargo.toml`, add `"examples/jwt-auth"` to the `members` array (e.g. right after `"examples/session-auth"`).
+
+- [ ] **Step 2: Create the example manifest**
+
+Create `examples/jwt-auth/Cargo.toml`:
+
+```toml
+[package]
+name = "jwt-auth-example"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+ultimo = { path = "../../ultimo", features = ["jwt"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }
+```
+
+- [ ] **Step 3: Create the example app**
+
+Create `examples/jwt-auth/src/main.rs`:
+
+```rust
+//! JWT auth example — a tiny full-stack demo of Ultimo's `jwt` feature.
+//!
+//! `/login` issues a short-lived HS256 token; the page stores it and sends it as
+//! `Authorization: Bearer <token>` on calls to the protected `/api/me`.
+//!
+//! ```text
+//! cargo run -p jwt-auth-example
+//! ```
+use ultimo::auth::jwt::Jwt;
+use ultimo::prelude::*;
+
+const PAGE: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ultimo · JWT Auth Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 4rem auto; padding: 0 1rem; }
+    input, button { font: inherit; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #ccc; }
+    button { cursor: pointer; border-color: #4f46e5; background: #4f46e5; color: white; }
+    #status { margin-top: 1rem; padding: 0.75rem; border-radius: 0.5rem; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <h1>Ultimo JWT Auth</h1>
+  <p>Log in to receive a bearer token, then call the protected endpoint.</p>
+  <div>
+    <input id="username" placeholder="username" value="ada" />
+    <button id="login">Log in</button>
+    <button id="me">Call /api/me</button>
+    <button id="logout">Forget token</button>
+  </div>
+  <div id="status">…</div>
+
+  <script>
+    const statusEl = document.getElementById('status');
+    let token = null;
+    document.getElementById('login').onclick = async () => {
+      const username = document.getElementById('username').value || 'guest';
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ username }),
+      });
+      ({ token } = await res.json());
+      statusEl.textContent = 'Got token: ' + token.slice(0, 24) + '…';
+    };
+    document.getElementById('me').onclick = async () => {
+      const res = await fetch('/api/me', {
+        headers: token ? { authorization: 'Bearer ' + token } : {},
+      });
+      const body = await res.json();
+      statusEl.textContent = res.ok ? ('Hello, ' + body.sub) : ('Rejected (' + res.status + ')');
+    };
+    document.getElementById('logout').onclick = () => {
+      token = null;
+      statusEl.textContent = 'Token forgotten — /api/me will now 401.';
+    };
+  </script>
+</body>
+</html>"#;
+
+#[derive(Deserialize)]
+struct LoginBody {
+    username: String,
+}
+
+#[derive(Serialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // In a real app, load the secret from the environment — never hardcode it.
+    let jwt = Jwt::hs256(b"demo-secret-change-me".to_vec());
+
+    let mut app = Ultimo::new_without_defaults();
+
+    // Protect everything under the middleware. /login is reachable because it is
+    // registered with an `.optional()` clone? No — instead we keep /login public
+    // by NOT mounting the verifier globally; we verify only on /api/me via a
+    // route-scoped check using ctx.jwt_claims after a scoped middleware.
+    // Simplest for a demo: mount the verifier in optional mode globally, and let
+    // the protected handler enforce presence.
+    app.use_middleware(jwt.clone().optional().build());
+
+    app.get("/", |ctx: Context| async move { ctx.html(PAGE).await });
+
+    // Issue a token valid for 15 minutes (secure-by-default: short-lived).
+    let signer = jwt.clone();
+    app.post("/api/login", move |ctx: Context| {
+        let signer = signer.clone();
+        async move {
+            let body: LoginBody = ctx.req.json().await?;
+            // exp = now + 900s. Compute via SystemTime (std).
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| UltimoError::Internal(e.to_string()))?
+                .as_secs() as usize;
+            let token = signer.sign(&Claims { sub: body.username.clone(), exp: now + 900 })?;
+            ctx.json(json!({ "token": token })).await
+        }
+    });
+
+    // Protected: requires a valid token (optional middleware attached claims).
+    app.get("/api/me", |ctx: Context| async move {
+        match ctx.jwt_claims().await {
+            Some(c) => ctx.json(json!({ "sub": c.get("sub") })).await,
+            None => Err(UltimoError::Unauthorized("login required".into())),
+        }
+    });
+
+    println!("🔑 JWT auth demo: http://127.0.0.1:3000");
+    app.listen("127.0.0.1:3000").await
+}
+```
+
+> Design note: the demo mounts the verifier in **optional** mode globally so `/login` stays reachable, and `/api/me` enforces presence itself. This keeps the example single-middleware and easy to read. A production app would more likely scope a non-optional verifier to a protected router subtree (a follow-up once route groups land). If `app.post`/`app.get` don't accept a `move` closure capturing `signer`, fall back to constructing the signer inside the handler from a shared secret constant.
+
+- [ ] **Step 4: Build and smoke-test the example**
+
+Run: `cargo build -p jwt-auth-example`
+Expected: builds clean.
+Optional manual check: `cargo run -p jwt-auth-example`, open http://127.0.0.1:3000, click Log in → Call /api/me (shows "Hello, ada"), Forget token → Call /api/me (shows "Rejected (401)").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml examples/jwt-auth/
+git commit -m "feat(auth): add jwt-auth full-stack example"
+```
+
+---
+
+## Task 7: Documentation surfaces
+
+**Files:**
+- Modify: `docs-site/docs/pages/api-reference.mdx`
+- Create: `docs-site/docs/pages/authentication.mdx`
+- Modify: `docs-site/vocs.config.ts`
+- Modify: `README.md`
+- Modify: `docs-site/docs/pages/roadmap.mdx`
+
+- [ ] **Step 1: Write the authentication docs page**
+
+Create `docs-site/docs/pages/authentication.mdx`. Cover, in prose + code: enabling the `jwt` feature; `Jwt::hs256(secret)` and builder options (`issuer`/`audience`/`leeway`/`from_bearer`/`from_cookie`/`optional`); mounting the middleware; issuing tokens with `sign`; reading claims with `ctx.jwt_claims()` and typed `ctx.jwt::<T>()`; the 401 + `WWW-Authenticate: Bearer` behavior. Include a **Security notes** section stating: HS256 only today (RS256 planned); the algorithm is pinned and `alg: none` is rejected; `exp` is validated by default so always set a short expiry (15–60 min for sensitive systems); load the secret from the environment, never hardcode; a stateless bearer JWT cannot be revoked server-side on logout — for logout/revocation use short TTLs plus the `session` feature (or a future token blocklist); when using `from_cookie`, serve over HTTPS and set the cookie `Secure` + `HttpOnly`. Link to the `examples/jwt-auth` example.
+
+- [ ] **Step 2: Add the sidebar entry**
+
+In `docs-site/vocs.config.ts`, add an item under the Security section (next to Sessions/CSRF) pointing to `/authentication` titled "Authentication (JWT)". Match the existing sidebar item shape.
+
+- [ ] **Step 3: Update the API reference**
+
+In `docs-site/docs/pages/api-reference.mdx`, add an **Authentication (JWT)** section documenting the `jwt` feature flag, the `Jwt` type and its methods (`hs256`, `issuer`, `audience`, `leeway`, `from_bearer`, `from_cookie`, `optional`, `sign`, `build`), and the new `Context` methods `jwt_claims()` / `jwt::<T>()`. Add `jwt` to the Feature Flags list.
+
+- [ ] **Step 4: Update the README**
+
+In `README.md`, move JWT auth from any "Coming Soon"/roadmap mention into "Available Now" (or the feature list), note the opt-in `jwt` feature, and reference the `examples/jwt-auth` example. Keep the install snippet/badges accurate.
+
+- [ ] **Step 5: Update the roadmap**
+
+In `docs-site/docs/pages/roadmap.mdx`, mark JWT auth as shipped: add a row to the Feature Status table (e.g. `Auth (JWT)` → ✅ Available → 0.4.0) and reflect it in the v0.4.0 security bullets (note RS256/API-key/authz guards still planned).
+
+- [ ] **Step 6: Verify the docs site builds (if tooling is available locally)**
+
+Run (best-effort): `cd docs-site && npm run build` — or rely on the Vercel preview check on the PR. Expected: build succeeds / preview deploys.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs-site/ README.md
+git commit -m "docs(auth): JWT authentication page, api-reference, README, roadmap"
+```
+
+---
+
+## Task 8: Full verification gate + ship
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --all`
+
+- [ ] **Step 2: Clippy across the feature surface**
+
+Run: `cargo clippy -p ultimo --features "websocket,test-helpers,testing,session,csrf,jwt" --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 3: Unit + doctests**
+
+Run: `cargo test -p ultimo --lib --features "jwt"` then `cargo test -p ultimo --doc --features "jwt"`
+Expected: all PASS (the lib.rs/jwt.rs doc examples compile).
+
+- [ ] **Step 4: Integration tests**
+
+Run: `cargo test -p ultimo --features "jwt" --test jwt`
+Expected: all PASS.
+
+- [ ] **Step 5: Supply-chain check (the new dep pulls `ring`)**
+
+Run: `cargo deny check advisories bans sources` (or rely on the CI `cargo-deny` job).
+Expected: clean. If `ring`/`jsonwebtoken` trips an advisory, bump the floor (e.g. require a patched `ring`) and re-run; do not add to the ignore list unless genuinely unaffected.
+
+- [ ] **Step 6: Ship via the `ship-feature` flow**
+
+Push the branch, open the PR (conventional title, e.g. `feat(auth): JWT authentication middleware (HS256)`), watch CI green (`semver-checks` should report an additive change), then `gh pr merge --squash --admin --delete-branch` and sync `main`. release-plz will compute the version bump from the `feat:` commits and regenerate the changelog — do not hand-edit `CHANGELOG.md`.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- `jsonwebtoken` dep behind opt-in `jwt` feature → Task 1. ✓
+- `Jwt::hs256` + builder (`issuer`/`audience`/`leeway`/`from_bearer`/`from_cookie`/`optional`) → Task 3. ✓
+- `sign` (issue tokens) → Task 3. ✓
+- Middleware verify + attach claims + 401 + `WWW-Authenticate` → Task 5. ✓
+- `optional` pass-through → Task 5 (test + impl). ✓
+- Cookie token source → Task 4 (extract) + Task 5 (test). ✓
+- Claims on `Context` (`jwt_claims`, typed `jwt::<T>()`) → Task 2. ✓ (async/owned-clone, refining the spec's borrowed sketch to match the existing async `RwLock` session pattern.)
+- Test matrix: roundtrip, expired, bad-sig, `alg:none`, missing→401, optional pass-through, cookie source, typed extraction → Tasks 2/3/5. ✓ (wrong-iss/aud is exercised indirectly via `Validation`; covered by `decode` unit behavior — add a dedicated unit test if desired.)
+- Example `examples/jwt-auth` + workspace member → Task 6. ✓
+- Docs: api-reference, authentication.mdx + sidebar, README, roadmap → Task 7. ✓
+- SemVer additive + release-plz → Task 8. ✓
+- Guardrail (token expiration): example uses 15-min `exp`; `exp` validated by default; logout/revocation caveat documented → Task 6 + Task 7 Step 1. ✓
+
+**Placeholder scan:** No TBD/TODO. Docs steps describe exact content to write (Task 7 prose is content-spec, not code, which is appropriate for `.mdx`).
+
+**Type consistency:** `Jwt::hs256`, `sign`, `decode`, `build`, `optional`, `from_cookie`, `from_bearer`, `issuer`, `audience`, `leeway` are used identically across tasks. `Context::jwt_claims`/`jwt`/`set_jwt_claims` names match between Task 2 and Tasks 5/6. `TokenSource`/`extract_token`/`parse_bearer`/`unauthorized` are module-private and consistent.
+
+**Known follow-up flagged for execution:** the `oneshot` request body type (Task 5, Step 1 note) must be matched to existing `ultimo/tests` before the first run — check `ultimo/tests/session.rs` or `cookie.rs`.

--- a/docs/superpowers/specs/2026-06-07-jwt-auth-design.md
+++ b/docs/superpowers/specs/2026-06-07-jwt-auth-design.md
@@ -1,0 +1,145 @@
+# JWT Auth Middleware — Design
+
+**Date:** 2026-06-07
+**Milestone:** v0.4.0 (Security & Performance — Wave 2: auth & abuse)
+**Epic:** #53 (Security: secure-by-default)
+**Status:** Approved, pre-implementation
+
+## Goal
+
+Ship Ultimo's flagship authentication primitive: a JWT middleware that verifies
+signed bearer tokens, attaches the validated claims to the request `Context`, and
+rejects unauthenticated requests with `401`. Include a token-signing helper so apps
+can issue tokens (and so the example/login flow is self-contained). This is the
+first Wave 2 deliverable and sets the pattern for API-key auth and authorization
+guards that follow.
+
+## Non-goals (explicitly deferred — YAGNI)
+
+- **RS256 / EdDSA / asymmetric keys.** v1 is **HS256 only**. The config type is
+  shaped so asymmetric algorithms can be added later without a breaking change.
+- **API-key auth middleware** — next Wave 2 feature, separate PR.
+- **Authorization guards (roles/permissions)** — next Wave 2 feature, separate PR.
+- **Refresh tokens, token revocation/blocklist, JWKS endpoints** — out of scope.
+
+## Key decision: depend on `jsonwebtoken`, do not hand-roll
+
+We depend on the audited [`jsonwebtoken`](https://crates.io/crates/jsonwebtoken)
+crate rather than implementing JWT verification ourselves.
+
+**Why.** JWT has a well-known class of implementation footguns — `alg: none`
+acceptance and HS/RS algorithm-confusion attacks — that a naive verifier gets
+wrong. `jsonwebtoken` forces the caller to pin the expected algorithm(s) and
+rejects `none`. For a framework whose headline pillar is security, relying on a
+battle-tested implementation is the credible, defensible choice. The leaner
+alternative (hand-rolled HS256 over `hmac`/`sha2`) would make *us* responsible for
+those mitigations — exactly what a security-branded framework should not own.
+
+**Cost & containment.** `jsonwebtoken` pulls `ring` (C/asm crypto). This is
+acceptable: `#![forbid(unsafe_code)]` governs only *our* crate, not dependencies,
+and the whole thing sits behind an **opt-in `jwt` Cargo feature**. With
+`default = []`, users who don't enable `jwt` pull none of it.
+
+## Public API
+
+New module `ultimo::auth::jwt`, gated by `#[cfg(feature = "jwt")]`. A single config
+type handles both signing and verification so the key is configured once.
+
+```rust
+use ultimo::auth::jwt::Jwt;
+
+// Configure once (HS256 symmetric secret).
+let jwt = Jwt::hs256(secret)        // secret: impl Into<Vec<u8>> / &[u8]
+    .issuer("ultimo")               // optional: require `iss` to match
+    .audience("web")                // optional: require `aud` to match
+    .leeway(60)                     // optional: clock-skew tolerance (seconds)
+    .from_bearer();                 // token source; default. Or .from_cookie("token")
+
+// Verify on incoming requests + attach claims.
+app.use_middleware(jwt.clone().build());
+
+// Issue a token (e.g. in a /login handler).
+let token: String = jwt.sign(&my_claims)?;
+```
+
+### Type sketch
+
+- `pub struct Jwt` — holds the encoding/decoding key, the pinned algorithm
+  (HS256 for v1), `Validation` settings (iss/aud/leeway/exp), token source
+  (`Bearer` header vs named cookie), header name, and `required` vs `optional`.
+- Builder methods (all `self -> Self`): `hs256(secret)`, `issuer(s)`,
+  `audience(s)`, `leeway(secs)`, `from_bearer()`, `from_cookie(name)`,
+  `header_name(name)`, `optional()`.
+- `pub fn sign<T: Serialize>(&self, claims: &T) -> Result<String>` — encode a
+  signed token. The caller owns the claims struct (must include `exp`, etc.).
+- `pub fn build(self) -> BoxedMiddleware` — the verification middleware.
+
+`Jwt` is `Clone` (so it can be both used as middleware and kept around for `sign`).
+
+### Middleware behavior
+
+1. Extract the token from the configured source (default: `Authorization: Bearer
+   <token>`; alternatively a named cookie).
+2. Verify signature + standard claims (`exp`, `nbf`, and `iss`/`aud` if configured)
+   with the pinned algorithm. `alg: none` and algorithm confusion are rejected by
+   `jsonwebtoken`.
+3. **On success:** store the validated claims (as `serde_json::Value`) on the
+   `Context`, then call `next`.
+4. **On failure (missing/invalid/expired):**
+   - `required` mode (default): return **401** with `WWW-Authenticate: Bearer`.
+   - `optional` mode: attach nothing and call `next` (for mixed public/private
+     routes; handlers decide what to do when claims are absent).
+
+### Context integration
+
+Claims are exposed on `Context` the same way sessions are — a feature-gated slot,
+not a generic-over-claims middleware (the middleware lives in a
+`Vec<BoxedMiddleware>`, so it can't be generic). New `#[cfg(feature = "jwt")]`
+methods on `Context`:
+
+- `pub fn jwt_claims(&self) -> Option<&serde_json::Value>` — raw validated claims.
+- `pub fn jwt<T: DeserializeOwned>(&self) -> Result<T>` — deserialize claims into a
+  typed struct; errors if absent or shape mismatch.
+
+## Error handling
+
+- Auth failures in `required` mode produce a `401 Unauthorized` response with a
+  `WWW-Authenticate: Bearer` header and a short body. This is a normal response,
+  not an `Err` (mirrors the CSRF middleware's `Ok(forbidden())` pattern).
+- `sign()` and `jwt::<T>()` return `ultimo::Result` and surface `jsonwebtoken` /
+  deserialization errors via `UltimoError`.
+
+## Testing
+
+Unit + integration (`Ultimo::oneshot`), gated on the `jwt` feature:
+
+1. sign → verify roundtrip attaches expected claims.
+2. expired token (`exp` in past, no leeway) → rejected (401).
+3. tampered/bad-signature token → rejected.
+4. `alg: none` token → rejected.
+5. wrong `iss`/`aud` when configured → rejected.
+6. missing token, `required` mode → 401 with `WWW-Authenticate`.
+7. missing token, `optional` mode → passes through, `jwt_claims()` is `None`.
+8. cookie source: token in configured cookie is read and verified.
+9. typed `ctx.jwt::<T>()` deserializes; absent claims → error.
+
+## Documentation & example surfaces (same PR)
+
+Per the `ship-feature` doc-surface rules:
+
+- **`examples/jwt-auth`** (new, added to workspace `members`): a Rust backend
+  serving an HTML+JS page. `/login` signs a JWT and returns it; the page stores it
+  and sends `Authorization: Bearer` on subsequent calls; `/me` is protected by the
+  middleware. Runnable via `cargo run -p jwt-auth-example`. Models `examples/session-auth`.
+- **`docs-site/docs/pages/authentication.mdx`** (new) + **sidebar** entry in
+  `docs-site/vocs.config.ts` (under Security).
+- **`docs-site/docs/pages/api-reference.mdx`**: new Auth/JWT section + the `jwt`
+  feature flag.
+- **`README.md`**: move JWT from Coming Soon → Available Now; note the `jwt` feature.
+- **`docs-site/docs/pages/roadmap.mdx`**: mark JWT auth shipped.
+
+## Cargo / SemVer
+
+- Add `jwt = ["dep:jsonwebtoken"]` to `ultimo/Cargo.toml`; `jsonwebtoken` optional.
+- Additive change (new opt-in feature + new `pub` items). release-plz computes the
+  version bump from the `feat:` commit; `semver-checks` confirms no breakage.

--- a/examples/jwt-auth/Cargo.toml
+++ b/examples/jwt-auth/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "jwt-auth-example"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+ultimo = { path = "../../ultimo", features = ["jwt"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/examples/jwt-auth/src/main.rs
+++ b/examples/jwt-auth/src/main.rs
@@ -1,0 +1,119 @@
+//! JWT auth example — a tiny full-stack demo of Ultimo's `jwt` feature.
+//!
+//! `/api/login` issues a short-lived HS256 token; the page stores it and sends it
+//! as `Authorization: Bearer <token>` on calls to the protected `/api/me`.
+//!
+//! ```text
+//! cargo run -p jwt-auth-example
+//! ```
+use std::time::{SystemTime, UNIX_EPOCH};
+use ultimo::auth::jwt::Jwt;
+use ultimo::prelude::*;
+
+const PAGE: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ultimo · JWT Auth Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 4rem auto; padding: 0 1rem; }
+    input, button { font: inherit; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #ccc; }
+    button { cursor: pointer; border-color: #4f46e5; background: #4f46e5; color: white; }
+    #status { margin-top: 1rem; padding: 0.75rem; border-radius: 0.5rem; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <h1>Ultimo JWT Auth</h1>
+  <p>Log in to receive a bearer token, then call the protected endpoint.</p>
+  <div>
+    <input id="username" placeholder="username" value="ada" />
+    <button id="login">Log in</button>
+    <button id="me">Call /api/me</button>
+    <button id="logout">Forget token</button>
+  </div>
+  <div id="status">…</div>
+
+  <script>
+    const statusEl = document.getElementById('status');
+    let token = null;
+    document.getElementById('login').onclick = async () => {
+      const username = document.getElementById('username').value || 'guest';
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ username }),
+      });
+      ({ token } = await res.json());
+      statusEl.textContent = 'Got token: ' + token.slice(0, 24) + '…';
+    };
+    document.getElementById('me').onclick = async () => {
+      const res = await fetch('/api/me', {
+        headers: token ? { authorization: 'Bearer ' + token } : {},
+      });
+      const body = await res.json();
+      statusEl.textContent = res.ok ? ('Hello, ' + body.sub) : ('Rejected (' + res.status + ')');
+    };
+    document.getElementById('logout').onclick = () => {
+      token = null;
+      statusEl.textContent = 'Token forgotten — /api/me will now 401.';
+    };
+  </script>
+</body>
+</html>"#;
+
+#[derive(Deserialize)]
+struct LoginBody {
+    username: String,
+}
+
+#[derive(Serialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // In a real app, load the secret from the environment — never hardcode it.
+    let jwt = Jwt::hs256(b"demo-secret-change-me");
+
+    let mut app = Ultimo::new_without_defaults();
+
+    // Mount the verifier in *optional* mode so `/` and `/api/login` stay public;
+    // the protected handler (`/api/me`) enforces that claims are present itself.
+    app.use_middleware(jwt.clone().optional().build());
+
+    app.get("/", |ctx: Context| async move { ctx.html(PAGE).await });
+
+    // Issue a token valid for 15 minutes (secure-by-default: short-lived).
+    let signer = jwt.clone();
+    app.post("/api/login", move |ctx: Context| {
+        let signer = signer.clone();
+        async move {
+            let body: LoginBody = ctx.req.json().await?;
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| UltimoError::Internal(e.to_string()))?
+                .as_secs() as usize;
+            let token = signer.sign(&Claims {
+                sub: body.username.clone(),
+                exp: now + 900,
+            })?;
+            ctx.json(json!({ "token": token })).await
+        }
+    });
+
+    // Protected: the optional middleware attached claims iff a valid token was sent.
+    app.get("/api/me", |ctx: Context| async move {
+        match ctx.jwt_claims().await {
+            Some(c) => ctx.json(json!({ "sub": c.get("sub") })).await,
+            None => Err(UltimoError::Unauthorized("login required".into())),
+        }
+    });
+
+    println!("🔑 JWT auth demo: http://127.0.0.1:3000");
+    app.listen("127.0.0.1:3000").await
+}

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -34,6 +34,9 @@ async-trait = "0.1"
 # Session support (optional) — getrandom for secure session ids
 getrandom = { version = "0.3", optional = true }
 
+# JWT auth (optional) — audited impl; pins algorithm, rejects `alg: none`
+jsonwebtoken = { version = "9", optional = true }
+
 # Database support (optional)
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls"], optional = true }
 diesel = { version = "2.3.10", optional = true }  # >=2.3.8: RUSTSEC fix for COPY command injection + unaligned access
@@ -65,6 +68,9 @@ session = ["dep:getrandom"]
 
 # CSRF protection (double-submit cookie)
 csrf = ["dep:getrandom"]
+
+# JWT authentication middleware (HS256)
+jwt = ["dep:jsonwebtoken"]
 
 # Database features
 database = []

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -11,3 +11,164 @@
 //! let jwt = Jwt::hs256(b"super-secret-key".to_vec());
 //! app.use_middleware(jwt.clone().build());
 //! ```
+
+use crate::error::{Result, UltimoError};
+use jsonwebtoken::{
+    decode as jwt_decode, encode as jwt_encode, Algorithm, DecodingKey, EncodingKey, Header,
+    Validation,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Where the middleware looks for the token on an incoming request.
+#[derive(Debug, Clone)]
+enum TokenSource {
+    /// `Authorization: Bearer <token>` (default).
+    Bearer,
+    /// A named cookie carrying the raw token.
+    Cookie(String),
+}
+
+/// JWT auth configuration. Verifies (`build`) and issues (`sign`) tokens using a
+/// shared HS256 secret. Secure-by-default: `exp` is validated, the algorithm is
+/// pinned to HS256, and `alg: none` / algorithm-confusion tokens are rejected.
+#[derive(Clone)]
+pub struct Jwt {
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+    validation: Validation,
+    source: TokenSource,
+    /// When false (default), a missing/invalid token yields 401. When true, the
+    /// request passes through unauthenticated (no claims attached).
+    optional: bool,
+}
+
+impl Jwt {
+    /// Configure HS256 with a symmetric secret. The same secret signs and verifies.
+    pub fn hs256(secret: impl AsRef<[u8]>) -> Self {
+        let secret = secret.as_ref();
+        Self {
+            encoding: EncodingKey::from_secret(secret),
+            decoding: DecodingKey::from_secret(secret),
+            validation: Validation::new(Algorithm::HS256),
+            source: TokenSource::Bearer,
+            optional: false,
+        }
+    }
+
+    /// Require the `iss` claim to equal `issuer`.
+    pub fn issuer(mut self, issuer: impl Into<String>) -> Self {
+        self.validation.set_issuer(&[issuer.into()]);
+        self
+    }
+
+    /// Require the `aud` claim to equal `audience`.
+    pub fn audience(mut self, audience: impl Into<String>) -> Self {
+        self.validation.set_audience(&[audience.into()]);
+        self
+    }
+
+    /// Clock-skew tolerance (seconds) applied to `exp`/`nbf` checks.
+    pub fn leeway(mut self, seconds: u64) -> Self {
+        self.validation.leeway = seconds;
+        self
+    }
+
+    /// Read the token from `Authorization: Bearer <token>` (the default).
+    pub fn from_bearer(mut self) -> Self {
+        self.source = TokenSource::Bearer;
+        self
+    }
+
+    /// Read the token from a named cookie instead of the Authorization header.
+    pub fn from_cookie(mut self, name: impl Into<String>) -> Self {
+        self.source = TokenSource::Cookie(name.into());
+        self
+    }
+
+    /// Make authentication optional: unauthenticated requests pass through with
+    /// no claims attached, instead of receiving a 401. Handlers decide what to do
+    /// when `ctx.jwt_claims()` is `None`.
+    pub fn optional(mut self) -> Self {
+        self.optional = true;
+        self
+    }
+
+    /// Issue a signed HS256 token for the given claims (which must include `exp`).
+    pub fn sign<T: Serialize>(&self, claims: &T) -> Result<String> {
+        jwt_encode(&Header::new(Algorithm::HS256), claims, &self.encoding)
+            .map_err(|e| UltimoError::Internal(format!("JWT signing failed: {e}")))
+    }
+
+    /// Verify a token and deserialize its claims. Errors on bad signature,
+    /// expired/`nbf` violations, wrong `iss`/`aud`, or `alg: none`.
+    pub fn decode<T: DeserializeOwned>(&self, token: &str) -> Result<T> {
+        jwt_decode::<T>(token, &self.decoding, &self.validation)
+            .map(|data| data.claims)
+            .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    fn far_future() -> usize {
+        // Fixed timestamp well beyond any reasonable test clock (year 2100).
+        4_102_444_800
+    }
+
+    #[test]
+    fn sign_then_decode_roundtrip() {
+        let jwt = Jwt::hs256(b"test-secret".to_vec());
+        let token = jwt
+            .sign(&Claims {
+                sub: "ada".into(),
+                exp: far_future(),
+            })
+            .unwrap();
+        // The signed token has three dot-separated segments.
+        assert_eq!(token.split('.').count(), 3);
+
+        let claims: Claims = jwt.decode(&token).unwrap();
+        assert_eq!(
+            claims,
+            Claims {
+                sub: "ada".into(),
+                exp: far_future()
+            }
+        );
+    }
+
+    #[test]
+    fn decode_rejects_bad_signature() {
+        let signer = Jwt::hs256(b"secret-a".to_vec());
+        let verifier = Jwt::hs256(b"secret-b".to_vec());
+        let token = signer
+            .sign(&Claims {
+                sub: "ada".into(),
+                exp: far_future(),
+            })
+            .unwrap();
+        assert!(verifier.decode::<Claims>(&token).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_expired() {
+        let jwt = Jwt::hs256(b"secret".to_vec());
+        // exp in the past (epoch second 1) with zero leeway → expired.
+        let token = jwt
+            .sign(&Claims {
+                sub: "ada".into(),
+                exp: 1,
+            })
+            .unwrap();
+        assert!(jwt.decode::<Claims>(&token).is_err());
+    }
+}

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -141,6 +141,47 @@ fn extract_token(jwt: &Jwt, ctx: &Context) -> Option<String> {
     }
 }
 
+use crate::middleware::{BoxedMiddleware, Next};
+use crate::response::{Response, ResponseBuilder};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+impl Jwt {
+    /// Build the verification middleware. On a valid token it attaches the
+    /// claims to the `Context` and continues; otherwise it returns 401 (unless
+    /// `optional()` was set, in which case it passes through unauthenticated).
+    pub fn build(self) -> BoxedMiddleware {
+        let cfg = Arc::new(self);
+        Arc::new(move |ctx: Context, next: Next| {
+            let cfg = cfg.clone();
+            Box::pin(async move {
+                match extract_token(&cfg, &ctx) {
+                    Some(token) => match cfg.decode::<serde_json::Value>(&token) {
+                        Ok(claims) => {
+                            ctx.set_jwt_claims(claims).await;
+                            next(ctx).await
+                        }
+                        Err(_) if cfg.optional => next(ctx).await,
+                        Err(_) => Ok(unauthorized()),
+                    },
+                    None if cfg.optional => next(ctx).await,
+                    None => Ok(unauthorized()),
+                }
+            }) as Pin<Box<dyn Future<Output = Result<Response>> + Send>>
+        })
+    }
+}
+
+fn unauthorized() -> Response {
+    ResponseBuilder::new()
+        .status(401)
+        .header("WWW-Authenticate", "Bearer")
+        .text("Unauthorized")
+        .build()
+        .unwrap_or_else(|_| crate::response::helpers::text("Unauthorized").unwrap())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,7 +200,7 @@ mod tests {
 
     #[test]
     fn sign_then_decode_roundtrip() {
-        let jwt = Jwt::hs256(b"test-secret".to_vec());
+        let jwt = Jwt::hs256(b"test-secret");
         let token = jwt
             .sign(&Claims {
                 sub: "ada".into(),
@@ -181,8 +222,8 @@ mod tests {
 
     #[test]
     fn decode_rejects_bad_signature() {
-        let signer = Jwt::hs256(b"secret-a".to_vec());
-        let verifier = Jwt::hs256(b"secret-b".to_vec());
+        let signer = Jwt::hs256(b"secret-a");
+        let verifier = Jwt::hs256(b"secret-b");
         let token = signer
             .sign(&Claims {
                 sub: "ada".into(),
@@ -194,7 +235,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_expired() {
-        let jwt = Jwt::hs256(b"secret".to_vec());
+        let jwt = Jwt::hs256(b"secret");
         // exp in the past (epoch second 1) with zero leeway → expired.
         let token = jwt
             .sign(&Claims {

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -113,6 +113,34 @@ impl Jwt {
     }
 }
 
+use crate::Context;
+
+/// Pull the token out of an `Authorization: Bearer <token>` header value.
+/// The scheme match is case-insensitive; an empty token returns `None`.
+fn parse_bearer(header_value: &str) -> Option<String> {
+    let (scheme, token) = header_value.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let token = token.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+/// Read the token from the configured source on this request.
+fn extract_token(jwt: &Jwt, ctx: &Context) -> Option<String> {
+    match &jwt.source {
+        TokenSource::Bearer => ctx
+            .req
+            .header("authorization")
+            .and_then(|h| parse_bearer(&h)),
+        TokenSource::Cookie(name) => ctx.cookie(name),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,5 +203,19 @@ mod tests {
             })
             .unwrap();
         assert!(jwt.decode::<Claims>(&token).is_err());
+    }
+
+    #[test]
+    fn bearer_parsing_extracts_token() {
+        assert_eq!(
+            parse_bearer("Bearer abc.def.ghi"),
+            Some("abc.def.ghi".to_string())
+        );
+        // Scheme is case-insensitive.
+        assert_eq!(parse_bearer("bearer xyz"), Some("xyz".to_string()));
+        // Non-bearer schemes and missing tokens are rejected.
+        assert_eq!(parse_bearer("Basic abc"), None);
+        assert_eq!(parse_bearer("Bearer"), None);
+        assert_eq!(parse_bearer("Bearer "), None);
     }
 }

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -4,12 +4,17 @@
 //! Verification is delegated to the audited `jsonwebtoken` crate, which pins the
 //! expected algorithm and rejects `alg: none` and HS/RS confusion attacks.
 //!
-//! ```no_run
-//! # use ultimo::Ultimo;
-//! # use ultimo::auth::jwt::Jwt;
-//! let mut app = Ultimo::new_without_defaults();
-//! let jwt = Jwt::hs256(b"super-secret-key".to_vec());
-//! app.use_middleware(jwt.clone().build());
+//! ```
+//! use ultimo::auth::jwt::Jwt;
+//!
+//! let jwt = Jwt::hs256(b"super-secret-key");
+//! // Issue a token (claims must include `exp`).
+//! let token = jwt
+//!     .sign(&serde_json::json!({ "sub": "ada", "exp": 4_102_444_800u64 }))
+//!     .unwrap();
+//! // Verify it and read the claims back.
+//! let claims: serde_json::Value = jwt.decode(&token).unwrap();
+//! assert_eq!(claims["sub"], "ada");
 //! ```
 
 use crate::error::{Result, UltimoError};

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -1,0 +1,13 @@
+//! JWT auth middleware (HS256) — verifies signed bearer/cookie tokens, attaches
+//! validated claims to the request `Context`, and can issue tokens via `sign`.
+//!
+//! Verification is delegated to the audited `jsonwebtoken` crate, which pins the
+//! expected algorithm and rejects `alg: none` and HS/RS confusion attacks.
+//!
+//! ```no_run
+//! # use ultimo::Ultimo;
+//! # use ultimo::auth::jwt::Jwt;
+//! let mut app = Ultimo::new_without_defaults();
+//! let jwt = Jwt::hs256(b"super-secret-key".to_vec());
+//! app.use_middleware(jwt.clone().build());
+//! ```

--- a/ultimo/src/auth/mod.rs
+++ b/ultimo/src/auth/mod.rs
@@ -1,0 +1,6 @@
+//! Authentication middleware.
+//!
+//! Currently provides JWT (JSON Web Token) verification + signing behind the
+//! `jwt` feature. API-key auth and authorization guards are planned follow-ups.
+
+pub mod jwt;

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -230,6 +230,8 @@ pub struct Context {
     trust_proxy: bool,
     #[cfg(feature = "session")]
     session: Arc<RwLock<Option<crate::session::Session>>>,
+    #[cfg(feature = "jwt")]
+    jwt_claims: Arc<RwLock<Option<serde_json::Value>>>,
 
     #[cfg(feature = "database")]
     database: Option<Database>,
@@ -252,6 +254,8 @@ impl Context {
             trust_proxy: false,
             #[cfg(feature = "session")]
             session: Arc::new(RwLock::new(None)),
+            #[cfg(feature = "jwt")]
+            jwt_claims: Arc::new(RwLock::new(None)),
             #[cfg(feature = "database")]
             database: None,
         }
@@ -409,6 +413,30 @@ impl Context {
     #[cfg(feature = "session")]
     pub(crate) async fn set_session(&self, s: crate::session::Session) {
         *self.session.write().await = Some(s);
+    }
+
+    /// The validated JWT claims for this request, if the `jwt` middleware ran
+    /// and accepted a token. Returns a clone of the raw claims object.
+    #[cfg(feature = "jwt")]
+    pub async fn jwt_claims(&self) -> Option<serde_json::Value> {
+        self.jwt_claims.read().await.clone()
+    }
+
+    /// Deserialize the validated JWT claims into a typed struct. Errors if no
+    /// claims are present (unauthenticated) or the shape doesn't match.
+    #[cfg(feature = "jwt")]
+    pub async fn jwt<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        let claims =
+            self.jwt_claims.read().await.clone().ok_or_else(|| {
+                crate::error::UltimoError::Unauthorized("no JWT claims".to_string())
+            })?;
+        serde_json::from_value(claims).map_err(crate::error::UltimoError::from)
+    }
+
+    /// Store validated claims on the context (used by the jwt middleware).
+    #[cfg(feature = "jwt")]
+    pub(crate) async fn set_jwt_claims(&self, claims: serde_json::Value) {
+        *self.jwt_claims.write().await = Some(claims);
     }
 
     /// Set the response status code
@@ -757,6 +785,48 @@ mod context_response_tests {
         assert_eq!(c.req.queries().get("a").unwrap().len(), 2);
         assert_eq!(c.req.path(), "/x");
         assert_eq!(c.req.method(), &hyper::Method::GET);
+    }
+}
+
+#[cfg(all(test, feature = "jwt"))]
+mod jwt_claims_tests {
+    use super::*;
+    use serde::Deserialize;
+
+    fn ctx() -> Context {
+        let req = HyperRequest::builder()
+            .method("GET")
+            .uri("/")
+            .body(())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+        Context::from_parts(parts, Bytes::new(), Params::new())
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Claims {
+        sub: String,
+    }
+
+    #[tokio::test]
+    async fn claims_absent_by_default() {
+        let c = ctx();
+        assert!(c.jwt_claims().await.is_none());
+        assert!(c.jwt::<Claims>().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn set_then_read_typed_claims() {
+        let c = ctx();
+        c.set_jwt_claims(serde_json::json!({ "sub": "ada" })).await;
+        assert_eq!(
+            c.jwt_claims().await,
+            Some(serde_json::json!({ "sub": "ada" }))
+        );
+        assert_eq!(
+            c.jwt::<Claims>().await.unwrap(),
+            Claims { sub: "ada".into() }
+        );
     }
 }
 

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -56,6 +56,9 @@ pub mod session;
 #[cfg(feature = "csrf")]
 pub mod csrf;
 
+#[cfg(feature = "jwt")]
+pub mod auth;
+
 // Re-exports for convenience
 pub use app::Ultimo;
 pub use context::Context;

--- a/ultimo/tests/jwt.rs
+++ b/ultimo/tests/jwt.rs
@@ -1,0 +1,133 @@
+//! Integration tests for the JWT auth middleware (feature `jwt`).
+#![cfg(feature = "jwt")]
+
+use http_body_util::Full;
+use hyper::Request as HyperRequest;
+use serde::{Deserialize, Serialize};
+use ultimo::auth::jwt::Jwt;
+use ultimo::{Context, Ultimo};
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+}
+
+fn far_future() -> usize {
+    4_102_444_800 // ~year 2100
+}
+
+fn empty() -> Full<bytes::Bytes> {
+    Full::new(bytes::Bytes::new())
+}
+
+fn app(jwt: Jwt) -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(jwt.build());
+    app.get("/me", |ctx: Context| async move {
+        let sub: String = ctx
+            .jwt_claims()
+            .await
+            .and_then(|c| c.get("sub").and_then(|v| v.as_str().map(String::from)))
+            .unwrap_or_else(|| "anonymous".to_string());
+        ctx.json(serde_json::json!({ "sub": sub })).await
+    });
+    app
+}
+
+#[tokio::test]
+async fn valid_token_is_accepted_and_claims_attached() {
+    let jwt = Jwt::hs256(b"secret");
+    let token = jwt
+        .sign(&Claims {
+            sub: "ada".into(),
+            exp: far_future(),
+        })
+        .unwrap();
+
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(empty())
+        .unwrap();
+    let res = app(jwt).oneshot(req).await;
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn missing_token_is_rejected_with_401() {
+    let jwt = Jwt::hs256(b"secret");
+    let req = HyperRequest::builder().uri("/me").body(empty()).unwrap();
+    let res = app(jwt).oneshot(req).await;
+    assert_eq!(res.status(), 401);
+    assert_eq!(
+        res.headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+}
+
+#[tokio::test]
+async fn bad_signature_is_rejected_with_401() {
+    let signer = Jwt::hs256(b"secret-a");
+    let verifier = Jwt::hs256(b"secret-b");
+    let token = signer
+        .sign(&Claims {
+            sub: "ada".into(),
+            exp: far_future(),
+        })
+        .unwrap();
+
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(empty())
+        .unwrap();
+    let res = app(verifier).oneshot(req).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn alg_none_token_is_rejected() {
+    // Hand-crafted unsigned token with "alg":"none". jsonwebtoken must reject it
+    // because the validation pins HS256.
+    // header {"alg":"none","typ":"JWT"} . payload {"sub":"ada","exp":4102444800} . (empty sig)
+    let token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.\
+eyJzdWIiOiJhZGEiLCJleHAiOjQxMDI0NDQ4MDB9.";
+    let jwt = Jwt::hs256(b"secret");
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(empty())
+        .unwrap();
+    let res = app(jwt).oneshot(req).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn optional_mode_passes_through_without_token() {
+    let jwt = Jwt::hs256(b"secret").optional();
+    let req = HyperRequest::builder().uri("/me").body(empty()).unwrap();
+    let res = app(jwt).oneshot(req).await;
+    assert_eq!(res.status(), 200); // handler returns "anonymous"
+}
+
+#[tokio::test]
+async fn cookie_source_reads_token_from_cookie() {
+    let jwt = Jwt::hs256(b"secret").from_cookie("token");
+    let signed = jwt
+        .sign(&Claims {
+            sub: "ada".into(),
+            exp: far_future(),
+        })
+        .unwrap();
+
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("cookie", format!("token={signed}"))
+        .body(empty())
+        .unwrap();
+    let res = app(jwt).oneshot(req).await;
+    assert_eq!(res.status(), 200);
+}


### PR DESCRIPTION
Adds Ultimo's flagship auth primitive — a JWT middleware behind an opt-in `jwt` feature. First Wave 2 deliverable of the v0.4.0 Security epic (#53).

## What's included
- **`ultimo::auth::jwt::Jwt`** (HS256) — one config type that both **verifies** (`.build()` → middleware) and **issues** (`.sign(&claims)`) tokens from a shared secret. Builder: `hs256`, `issuer`, `audience`, `leeway`, `from_bearer`, `from_cookie`, `optional`.
- **Secure-by-default:** algorithm pinned to HS256 (so `alg: none` and HS/RS confusion are rejected), `exp` validated by default. Verification delegates to the audited `jsonwebtoken` crate rather than hand-rolled crypto.
- **Claims on `Context`:** `ctx.jwt_claims()` (raw `serde_json::Value`) and typed `ctx.jwt::<T>()` — mirrors the session-slot pattern.
- **401 + `WWW-Authenticate: Bearer`** on missing/invalid tokens; `.optional()` mode passes through unauthenticated for mixed public/private routes.
- **`examples/jwt-auth`** — runnable login → protected-route full-stack demo (`cargo run -p jwt-auth-example`).

## Tests
Unit (sign/verify roundtrip, bad-signature, expired) + integration via `Ultimo::oneshot` (valid→200, missing→401 with header, bad-sig→401, **`alg:none`→401**, optional pass-through, cookie source). All green; clippy `-D warnings` clean across the full feature combo.

## Docs (all four surfaces)
New `authentication.mdx` + sidebar entry, `api-reference.mdx` (Context + Middleware + Feature Flags), `README.md` (Available Now), `roadmap.mdx` (JWT shipped). Security notes cover short-TTL expiry guidance, env-loaded secrets, the stateless-revocation caveat, and the `jsonwebtoken` audience gotcha.

## Scope
HS256 only; RS256/EdDSA, API-key auth, and authz guards are explicitly deferred to later Wave 2 PRs. Additive change (new opt-in feature + new `pub` items) — `semver-checks` should confirm.

Design + plan: `docs/superpowers/specs/2026-06-07-jwt-auth-design.md`, `docs/superpowers/plans/2026-06-07-jwt-auth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)