### PR TITLE
docs(site): group Sessions + JWT under an Authentication nav section

### DIFF
--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -240,7 +240,7 @@ let claims = ctx.jwt_claims().await;          // Option<serde_json::Value>
 let mine: MyClaims = ctx.jwt::<MyClaims>().await?;
 ```
 
-See [Authentication (JWT)](/authentication).
+See [JWT Authentication](/jwt).
 
 ### `Request`
 
@@ -503,7 +503,7 @@ HS256 JWT auth — verifies signed bearer/cookie tokens, attaches claims to the
 `Context`, and issues tokens. The algorithm is pinned (`alg: none` rejected) and
 `exp` is validated by default. Builder: `hs256(secret)`, `issuer(s)`,
 `audience(s)`, `leeway(secs)`, `from_bearer()`, `from_cookie(name)`, `optional()`,
-`sign(&claims)`, `build()`. See [Authentication (JWT)](/authentication).
+`sign(&claims)`, `build()`. See [JWT Authentication](/jwt).
 
 ```rust
 use ultimo::auth::jwt::Jwt;
@@ -766,7 +766,7 @@ All features are off by default (`default = []`).
 - `websocket` - RFC 6455 WebSocket support (zero extra dependencies)
 - `session` - Cookie-based session management ([Sessions](/sessions))
 - `csrf` - Double-submit-cookie CSRF protection ([Security](/security))
-- `jwt` - HS256 JWT authentication middleware ([Authentication](/authentication))
+- `jwt` - HS256 JWT authentication middleware ([JWT Authentication](/jwt))
 - `testing` - Testing utilities: `TestClient`, assertions, helpers ([Testing](/testing))
 - `test-helpers` - WebSocket test helpers (for integration tests)
 - `sqlx-postgres` / `sqlx-mysql` / `sqlx-sqlite` - SQLx integration per backend

--- a/docs-site/docs/pages/jwt.mdx
+++ b/docs-site/docs/pages/jwt.mdx
@@ -1,4 +1,4 @@
-# Authentication (JWT)
+# JWT Authentication
 
 Ultimo ships a JWT (JSON Web Token) auth middleware that verifies signed bearer
 tokens, attaches the validated claims to the request `Context`, and can issue

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -60,12 +60,18 @@ export default defineConfig({
           link: "/security",
         },
         {
-          text: "Sessions",
-          link: "/sessions",
-        },
-        {
-          text: "Authentication (JWT)",
-          link: "/authentication",
+          text: "Authentication",
+          collapsed: false,
+          items: [
+            {
+              text: "Sessions",
+              link: "/sessions",
+            },
+            {
+              text: "JWT",
+              link: "/jwt",
+            },
+          ],
         },
         {
           text: "WebSocket",


### PR DESCRIPTION
Refines the docs-site information architecture for auth.

- New **"Authentication"** sidebar group under Features containing **Sessions** (stateful) and **JWT** (stateless) — the two answers to "how does the server know who the user is?". Leaves room for API-key auth + authz guards (Wave 2) to slot in.
- Renames the JWT page: `/authentication` → `/jwt`, title "JWT Authentication", nav label just "JWT" (so it reads cleanly alongside future siblings).
- Updates the three `api-reference.mdx` links.

Docs-only; Vercel preview will render the new nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)