### PR TITLE
feat(auth): API-key authentication middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       # --all-targets here lints lib, integration tests and benches together,
       # all of which compile once websocket+test-helpers are enabled.
       # Database features are linted in the `test-db` job (needs system libs).
-      - name: clippy (websocket + test-helpers + testing + session + csrf, all targets)
-        run: cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session,csrf" -- -D warnings
+      - name: clippy (websocket + test-helpers + testing + session + csrf + jwt + api-key, all targets)
+        run: cargo clippy -p ultimo --all-targets --features "websocket,test-helpers,testing,session,csrf,jwt,api-key" -- -D warnings
 
   # ── Unit + integration tests (no DB system deps) ──────────────────────
   test:
@@ -89,6 +89,17 @@ jobs:
           cargo test -p ultimo --features "csrf,testing" --test csrf
           cargo test -p ultimo --features "session" --lib session
           cargo test -p ultimo --features "session,testing" --test session
+
+      # Auth features: JWT (sign/verify) + API-key (pluggable store). Unit,
+      # integration, and doctests — run explicitly so they don't rot silently.
+      - name: Auth tests (jwt + api-key)
+        run: |
+          cargo test -p ultimo --features "jwt" --lib auth::jwt
+          cargo test -p ultimo --features "jwt" --test jwt
+          cargo test -p ultimo --features "jwt" --doc
+          cargo test -p ultimo --features "api-key" --lib auth::api_key
+          cargo test -p ultimo --features "api-key" --test api_key
+          cargo test -p ultimo --features "api-key" --doc
           cargo test -p ultimo --features "session" --doc
 
       # websocket_pubsub_bench uses test_helpers::ChannelManager, so benches

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,6 +3498,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2",
  "sqlx",
  "tokio",
  "tokio-test",

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - 🔒 **100% Safe Rust** - The framework enforces `#![forbid(unsafe_code)]` — zero `unsafe`
 - 🎫 **Sessions & Cookies** - Secure-by-default cookie sessions (HttpOnly/Secure/SameSite, 256-bit ids, anti session-fixation) over a pluggable store
 - 🔑 **JWT Authentication** - HS256 JWT middleware (opt-in `jwt` feature): pins the algorithm (`alg: none` rejected), validates `exp`, attaches claims to the request — sign + verify
+- 🗝️ **API-Key Authentication** - API-key middleware (opt-in `api-key` feature) with a pluggable store; keys are SHA-256 hashed and compared in constant time, resolving to an identity (id + scopes)
 - 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), CSRF protection, request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
 - 🧪 **Testing Utilities** - In-process `TestClient`, response assertions, middleware/DB/fixture helpers
 - 🔥 **Developer Experience First** - Ergonomic APIs, helpful errors, minimal boilerplate
@@ -53,7 +54,7 @@
 
 See the [full roadmap](https://docs.ultimo.dev/roadmap) for upcoming features:
 
-- 🛡️ More auth: API-key middleware & authorization guards (JWT shipped)
+- 🛡️ Authorization guards (roles/scopes) — JWT + API-key auth already shipped
 - 📡 Streaming & SSE
 - 🌍 Multi-language Client Generation
 - And more...

--- a/docs-site/docs/pages/api-keys.mdx
+++ b/docs-site/docs/pages/api-keys.mdx
@@ -1,0 +1,124 @@
+# API-Key Authentication
+
+For server-to-server and programmatic clients, Ultimo ships an API-key middleware
+that validates a presented key against a **pluggable store**, resolves it to an
+**identity** (id + scopes), and attaches that identity to the request `Context`.
+Missing or invalid keys are rejected with **401**.
+
+It's secure-by-default: the built-in store keeps only **SHA-256 digests** of keys
+(never the raw secret) and compares them in **constant time**.
+
+:::tip
+API keys identify *machines*, not browsers. Don't embed an API key in
+front-end JavaScript — anyone can read it. For browser logins use
+[Sessions](/sessions) or [JWT](/jwt). The examples here use `curl` / server-side
+clients on purpose.
+:::
+
+## Enable the feature
+
+```toml
+[dependencies]
+ultimo = { version = "0.3", features = ["api-key"] }
+```
+
+## Quick start
+
+```rust
+use ultimo::auth::api_key::{ApiKey, StaticKeys};
+use ultimo::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Load keys from the environment in production — never hardcode them.
+    let store = StaticKeys::new()
+        .insert("key-abc", "service-a")
+        .with_scopes("key-def", "service-b", ["read", "write"]);
+
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(ApiKey::new(store).build()); // header "x-api-key" by default
+
+    app.get("/me", |ctx: Context| async move {
+        match ctx.api_key().await {
+            Some(id) => ctx.json(serde_json::json!({ "id": id.id, "scopes": id.scopes })).await,
+            None => ctx.json(serde_json::json!({ "id": null })).await,
+        }
+    });
+
+    app.listen("127.0.0.1:3000").await
+}
+```
+
+Call it:
+
+```bash
+# Accepted
+curl -H "x-api-key: key-def" http://127.0.0.1:3000/me
+# → {"id":"service-b","scopes":["read","write"]}
+
+# Rejected
+curl -i http://127.0.0.1:3000/me            # → 401 Unauthorized
+curl -i -H "x-api-key: wrong" http://127.0.0.1:3000/me   # → 401 Unauthorized
+```
+
+## Reading the identity
+
+After the middleware accepts a key, the resolved identity is on the `Context`:
+
+```rust
+if let Some(identity) = ctx.api_key().await {
+    // identity.id     -> the key's label (e.g. "service-b") — never the raw key
+    // identity.scopes -> Vec<String>, for authorization decisions
+}
+```
+
+## Configuration
+
+| Method | Effect |
+|---|---|
+| `ApiKey::new(store)` | Validate keys against `store`, read from the `x-api-key` header. |
+| `.header_name(name)` | Read the key from a different header. |
+| `.from_query(name)` | Read the key from a query-string parameter instead. |
+| `.optional()` | Don't 401 on missing/invalid keys — pass through unauthenticated. |
+| `.build()` | Build the verification middleware. |
+
+## Database-backed keys
+
+`StaticKeys` is for in-memory configuration. For keys stored in a database
+(with owners, scopes, expiry, revocation), implement the `ApiKeyStore` trait:
+
+```rust
+use ultimo::auth::api_key::{ApiKeyStore, ApiKeyIdentity};
+
+struct DbKeys { /* pool, etc. */ }
+
+#[async_trait::async_trait]
+impl ApiKeyStore for DbKeys {
+    async fn validate(&self, presented_key: &str) -> Option<ApiKeyIdentity> {
+        // Hash the presented key and look it up BY HASH — never store or query
+        // the raw key. Return the identity (id + scopes) on a match.
+        let hash = sha256_hex(presented_key);
+        self.lookup_by_hash(&hash).await
+    }
+}
+
+app.use_middleware(ApiKey::new(DbKeys { /* … */ }).build());
+```
+
+## Security notes
+
+- **Hash at rest, compare in constant time.** The built-in `StaticKeys` store
+  hashes keys with SHA-256 at construction and never retains the raw value;
+  comparison runs over every entry without early-return, so neither the match
+  position nor whether a key matched leaks via timing. Custom stores should look
+  up **by hash**, not the raw key.
+- **SHA-256, not bcrypt/argon2.** API keys are high-entropy random secrets, not
+  passwords — a fast cryptographic hash is the correct and standard choice. Password
+  KDFs (bcrypt/argon2) exist to slow down brute-forcing *low-entropy* secrets and
+  would only waste CPU here.
+- **Generate strong keys** (≥128 bits of entropy from a CSPRNG) and transmit them
+  only over HTTPS. Treat them like passwords in transit.
+- **Never put an API key in a browser.** It's a server-to-server credential. For
+  user-facing auth use [Sessions](/sessions) or [JWT](/jwt).
+- **Scope and rotate.** Give each key the least scopes it needs (`with_scopes`),
+  and design your store so keys can be revoked/rotated without redeploying.

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -242,6 +242,19 @@ let mine: MyClaims = ctx.jwt::<MyClaims>().await?;
 
 See [JWT Authentication](/jwt).
 
+#### API-key identity (requires `api-key` feature)
+
+##### `api_key(&self) -> Option<ApiKeyIdentity>`
+
+The API-key identity for this request (`id` + `scopes`), or `None` if no valid
+key was presented. See [API-Key Authentication](/api-keys).
+
+```rust
+if let Some(identity) = ctx.api_key().await {
+    // identity.id, identity.scopes
+}
+```
+
 ### `Request`
 
 Access request data through `ctx.req`.
@@ -512,6 +525,20 @@ app.use_middleware(jwt.clone().build());
 let token = jwt.sign(&claims)?;
 ```
 
+#### `ApiKey` (requires `api-key` feature)
+
+API-key auth — validates a presented key against a pluggable **`ApiKeyStore`**,
+resolving it to an **`ApiKeyIdentity { id, scopes }`** attached to the `Context`;
+401 on missing/invalid. The built-in `StaticKeys` store hashes keys with SHA-256
+and compares in constant time. Builder: `new(store)`, `header_name(name)`,
+`from_query(name)`, `optional()`, `build()`. See [API-Key Authentication](/api-keys).
+
+```rust
+use ultimo::auth::api_key::{ApiKey, StaticKeys};
+let store = StaticKeys::new().insert("key-abc", "service-a");
+app.use_middleware(ApiKey::new(store).build()); // header "x-api-key"
+```
+
 ### Custom Middleware
 
 Create custom middleware by implementing the middleware function signature:
@@ -767,6 +794,7 @@ All features are off by default (`default = []`).
 - `session` - Cookie-based session management ([Sessions](/sessions))
 - `csrf` - Double-submit-cookie CSRF protection ([Security](/security))
 - `jwt` - HS256 JWT authentication middleware ([JWT Authentication](/jwt))
+- `api-key` - API-key authentication with a pluggable store ([API-Key Authentication](/api-keys))
 - `testing` - Testing utilities: `TestClient`, assertions, helpers ([Testing](/testing))
 - `test-helpers` - WebSocket test helpers (for integration tests)
 - `sqlx-postgres` / `sqlx-mysql` / `sqlx-sqlite` - SQLx integration per backend

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -77,7 +77,8 @@ Upcoming features and improvements planned for Ultimo.
 | Security Headers (HSTS/CSP/…) | 🔒 Planned    | 0.4.0   |
 | CSRF Protection           | 🔒 Planned       | 0.4.0   |
 | Auth: JWT middleware      | ✅ Available     | 0.4.0   |
-| Auth: API keys / authz guards | 🔒 Planned   | 0.4.0   |
+| Auth: API keys            | ✅ Available     | 0.4.0   |
+| Auth: authorization guards | 🔒 Planned      | 0.4.0   |
 | Benchmark Suite + CI Guard | ⚡ Planned      | 0.4.0   |
 | Static Files              | 📋 Planned       | 0.5.0   |
 | Compression               | 📋 Planned       | 0.5.0   |
@@ -127,7 +128,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 - 🔒 Security headers middleware (HSTS, CSP, X-Frame-Options, …)
 - 🔒 CSRF protection (integrates with sessions)
-- ✅ Auth: JWT middleware (HS256) — shipped; API-key middleware + authorization guards planned
+- ✅ Auth: JWT + API-key middleware — shipped; authorization guards planned
 - 🔒 Request body-size limits, request timeouts, enhanced rate limiting
 - 🔒 `#![forbid(unsafe_code)]` (100% safe Rust), `SECURITY.md` disclosure policy,
   `cargo-deny` + fuzzing in CI, OpenSSF Best Practices

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
               text: "JWT",
               link: "/jwt",
             },
+            {
+              text: "API Keys",
+              link: "/api-keys",
+            },
           ],
         },
         {

--- a/docs/superpowers/specs/2026-06-07-api-key-auth-design.md
+++ b/docs/superpowers/specs/2026-06-07-api-key-auth-design.md
@@ -1,0 +1,151 @@
+# API-Key Auth Middleware — Design
+
+**Date:** 2026-06-07
+**Milestone:** v0.4.0 (Security & Performance — Wave 2: auth & abuse)
+**Epic:** #53 (Security: secure-by-default)
+**Status:** Approved, pre-implementation
+
+## Goal
+
+A second authentication method alongside JWT: an API-key middleware that
+validates a presented key, resolves it to an **identity** (id + scopes), attaches
+that identity to the request `Context`, and rejects unauthenticated requests with
+`401`. Designed quality-first — extensible (pluggable store) and leak-resistant
+(hashed, constant-time comparison) — so it is production-grade, not a toy, and so
+it sets up the authorization-guards feature that follows.
+
+## Design principles (why this shape)
+
+1. **Pluggable store, not a static-only set.** Real deployments keep keys in a
+   database with per-key metadata (owner, scopes, expiry, revocation). Matching
+   the framework's existing `SessionStore` precedent, API-key validation goes
+   through an `ApiKeyStore` trait, with a built-in `StaticKeys` store for quick
+   start. This avoids a future breaking change to add DB-backed keys.
+2. **Hashed, constant-time comparison.** Best-in-class systems store a *hash* of
+   the key, never the raw secret, so a memory/config/DB disclosure does not leak
+   usable credentials. API keys are **high-entropy random secrets, not
+   passwords**, so the correct hash is **SHA-256** — *not* bcrypt/argon2 (those
+   are for low-entropy human passwords and would only waste CPU here). Comparison
+   is constant-time over the fixed-length digest.
+3. **Resolve to an identity, not the raw key.** Handlers (and the upcoming
+   authorization guards) receive an `ApiKeyIdentity { id, scopes }` — never the
+   secret. This is the uniform thing guards will check (alongside JWT claims).
+
+## Non-goals (deferred — YAGNI)
+
+- Key generation/minting helpers (prefixes, checksums, secret-scanning formats).
+- Built-in DB/Redis store impls — users implement `ApiKeyStore` for their backend.
+- Rate-limiting / per-key quotas (separate abuse-primitives feature).
+- A browser example: putting an API key in browser JS is an anti-pattern, so the
+  docs demonstrate **`curl` / server-to-server** usage instead. (The
+  frontend-example rule targets *frontend-relevant* features; this isn't one.)
+
+## Public API
+
+New module `ultimo::auth::api_key`, gated by `#[cfg(feature = "api-key")]`
+(`api-key = ["dep:sha2"]`; `async-trait` is already a dependency).
+
+```rust
+use ultimo::auth::api_key::{ApiKey, StaticKeys};
+
+let store = StaticKeys::new()
+    .insert("key-abc", "service-a")
+    .with_scopes("key-def", "service-b", ["read", "write"]);
+
+let api = ApiKey::new(store)        // or ApiKey::new(MyDbStore) — any ApiKeyStore
+    .header_name("x-api-key")       // default; or .from_query("api_key")
+    .optional();                    // optional mode (pass through unauthenticated)
+
+app.use_middleware(api.build());
+
+// In a handler:
+let who = ctx.api_key();            // Option<ApiKeyIdentity> { id, scopes }
+```
+
+### Types
+
+```rust
+#[async_trait]
+pub trait ApiKeyStore: Send + Sync {
+    /// Resolve a presented key to an identity, or None to reject.
+    async fn validate(&self, presented_key: &str) -> Option<ApiKeyIdentity>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApiKeyIdentity {
+    pub id: String,          // a label / key id — NEVER the raw secret
+    pub scopes: Vec<String>, // optional scopes for authorization
+}
+
+pub struct StaticKeys { /* Vec<([u8; 32] sha256, ApiKeyIdentity)> */ }
+impl StaticKeys {
+    pub fn new() -> Self;                                   // + Default
+    pub fn insert(self, key, id) -> Self;                  // builder
+    pub fn with_scopes(self, key, id, scopes) -> Self;     // builder
+}
+
+pub struct ApiKey<S: ApiKeyStore> { /* store, source, optional */ }
+impl<S: ApiKeyStore + 'static> ApiKey<S> {
+    pub fn new(store: S) -> Self;                // header "x-api-key", required
+    pub fn header_name(self, name) -> Self;
+    pub fn from_query(self, name) -> Self;
+    pub fn optional(self) -> Self;
+    pub fn build(self) -> BoxedMiddleware;
+}
+```
+
+### Middleware behavior
+
+1. Read the key from the configured source (header `x-api-key` by default, or a
+   query parameter).
+2. `store.validate(key).await`. On `Some(identity)` → attach to `Context`, call
+   `next`. On `None` → `401` (or pass through in `optional` mode).
+3. Missing key → same as invalid (`401`, or pass through if optional).
+
+No `WWW-Authenticate` header (ApiKey is not a registered HTTP auth scheme).
+
+### `StaticKeys` comparison (constant-time)
+
+Keys are hashed with SHA-256 at construction; only digests are stored. On
+`validate`, the presented key is hashed and compared against every stored digest
+with a constant-time equality check, **without early return**, so neither the
+match position nor whether any key matched leaks via timing.
+
+### Context integration
+
+Feature-gated slot mirroring `session` / `jwt_claims`:
+- `#[cfg(feature = "api-key")] pub async fn api_key(&self) -> Option<ApiKeyIdentity>`
+- `pub(crate) async fn set_api_key(&self, identity: ApiKeyIdentity)`
+
+## Module gating
+
+`ultimo::auth` becomes available when **either** auth feature is on:
+`#[cfg(any(feature = "jwt", feature = "api-key"))] pub mod auth;`, and
+`auth/mod.rs` gates each submodule (`#[cfg(feature = "jwt")] pub mod jwt;`,
+`#[cfg(feature = "api-key")] pub mod api_key;`).
+
+## Testing
+
+Unit (in-module): `StaticKeys` resolves a valid key to its identity (with scopes),
+rejects an unknown key, and an unknown key never matches across a multi-key set.
+Integration (`ultimo/tests/api_key.rs`, via `Ultimo::oneshot`): valid header →
+200 + identity attached; invalid → 401; missing → 401; `optional()` passes
+through; query-param source works; scopes surface on `ctx.api_key()`.
+
+## CI coverage (fix existing gap)
+
+`ci.yml` currently does not *run* the JWT tests (only `--all-features` clippy
+compiles them). Add explicit runs in the `test` job and the non-DB clippy:
+- lint: add `jwt,api-key` to the `clippy --all-targets --features "..."` list.
+- test: `cargo test -p ultimo --features "jwt" --lib auth::jwt`,
+  `--features "jwt" --test jwt`, `--features "jwt" --doc`,
+  `--features "api-key" --lib auth::api_key`,
+  `--features "api-key" --test api_key`.
+
+## Docs & SemVer
+
+- New `docs-site/docs/pages/api-keys.mdx` under the **Authentication** sidebar
+  group; update `api-reference.mdx` (new `ApiKey`/`ApiKeyStore`/`ApiKeyIdentity`,
+  `ctx.api_key()`, `api-key` feature), `README.md`, `roadmap.mdx`.
+- Additive (new opt-in feature + new `pub` items) → release-plz bumps from the
+  `feat:` commit; `semver-checks` confirms no breakage.

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -31,11 +31,14 @@ sha1 = "0.10"
 base64 = "0.21"
 async-trait = "0.1"
 
-# Session support (optional) — getrandom for secure session ids
+# Session support (optional) â getrandom for secure session ids
 getrandom = { version = "0.3", optional = true }
 
-# JWT auth (optional) — audited impl; pins algorithm, rejects `alg: none`
+# JWT auth (optional) â audited impl; pins algorithm, rejects `alg: none`
 jsonwebtoken = { version = "9", optional = true }
+
+# API-key auth (optional) — SHA-256 to hash keys (high-entropy secrets, not passwords)
+sha2 = { version = "0.10", optional = true }
 
 # Database support (optional)
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls"], optional = true }
@@ -71,6 +74,9 @@ csrf = ["dep:getrandom"]
 
 # JWT authentication middleware (HS256)
 jwt = ["dep:jsonwebtoken"]
+
+# API-key authentication middleware (pluggable store, SHA-256 hashed keys)
+api-key = ["dep:sha2"]
 
 # Database features
 database = []

--- a/ultimo/src/auth/api_key.rs
+++ b/ultimo/src/auth/api_key.rs
@@ -1,0 +1,246 @@
+//! API-key authentication — validates a presented key against a pluggable store,
+//! resolves it to an [`ApiKeyIdentity`], and attaches that identity to the
+//! request `Context`. Missing/invalid keys are rejected with **401**.
+//!
+//! Secure-by-default: the built-in [`StaticKeys`] store keeps only **SHA-256
+//! digests** of keys (never the raw secret) and compares in constant time. API
+//! keys are high-entropy random secrets — not passwords — so SHA-256 is the
+//! correct hash here (bcrypt/argon2 are for low-entropy passwords).
+//!
+//! For database-backed keys, implement [`ApiKeyStore`] for your backend; look up
+//! by the key's hash, not the raw value.
+//!
+//! ```
+//! use ultimo::auth::api_key::{ApiKey, StaticKeys};
+//!
+//! let store = StaticKeys::new()
+//!     .insert("key-abc", "service-a")
+//!     .with_scopes("key-def", "service-b", ["read", "write"]);
+//! let _mw = ApiKey::new(store).header_name("x-api-key").build();
+//! ```
+
+use crate::error::Result;
+use crate::middleware::{BoxedMiddleware, Next};
+use crate::response::{Response, ResponseBuilder};
+use crate::Context;
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// The identity a valid API key resolves to. Never contains the raw secret.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApiKeyIdentity {
+    /// A stable label / key id for the caller (e.g. a service or tenant name).
+    pub id: String,
+    /// Optional scopes for authorization decisions.
+    pub scopes: Vec<String>,
+}
+
+/// Validates presented API keys. Implement this for a database/Redis-backed key
+/// store; the built-in [`StaticKeys`] covers in-memory configuration.
+#[async_trait]
+pub trait ApiKeyStore: Send + Sync {
+    /// Resolve a presented key to an identity, or `None` to reject it.
+    ///
+    /// Custom implementations should look the key up by its **hash** (not the
+    /// raw value) and compare in constant time, mirroring [`StaticKeys`].
+    async fn validate(&self, presented_key: &str) -> Option<ApiKeyIdentity>;
+}
+
+/// In-memory key store. Keys are SHA-256 hashed at construction — only digests
+/// are retained — and compared in constant time on each request.
+#[derive(Default)]
+pub struct StaticKeys {
+    entries: Vec<([u8; 32], ApiKeyIdentity)>,
+}
+
+impl StaticKeys {
+    /// An empty store. Add keys with [`insert`](Self::insert) /
+    /// [`with_scopes`](Self::with_scopes).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a key mapped to an identity `id` with no scopes.
+    pub fn insert(mut self, key: impl AsRef<[u8]>, id: impl Into<String>) -> Self {
+        self.entries.push((
+            hash_key(key.as_ref()),
+            ApiKeyIdentity {
+                id: id.into(),
+                scopes: Vec::new(),
+            },
+        ));
+        self
+    }
+
+    /// Add a key mapped to an identity `id` with the given scopes.
+    pub fn with_scopes(
+        mut self,
+        key: impl AsRef<[u8]>,
+        id: impl Into<String>,
+        scopes: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.entries.push((
+            hash_key(key.as_ref()),
+            ApiKeyIdentity {
+                id: id.into(),
+                scopes: scopes.into_iter().map(Into::into).collect(),
+            },
+        ));
+        self
+    }
+}
+
+#[async_trait]
+impl ApiKeyStore for StaticKeys {
+    async fn validate(&self, presented_key: &str) -> Option<ApiKeyIdentity> {
+        let presented = hash_key(presented_key.as_bytes());
+        // Compare against every entry without early-return so neither the match
+        // position nor whether any key matched leaks via timing.
+        let mut found: Option<&ApiKeyIdentity> = None;
+        for (digest, identity) in &self.entries {
+            if ct_eq(&presented, digest) {
+                found = Some(identity);
+            }
+        }
+        found.cloned()
+    }
+}
+
+/// Where the middleware reads the API key from.
+#[derive(Debug, Clone)]
+enum KeySource {
+    /// A request header (default `x-api-key`).
+    Header(String),
+    /// A query-string parameter.
+    Query(String),
+}
+
+/// API-key auth middleware, generic over the [`ApiKeyStore`]. Secure-by-default.
+pub struct ApiKey<S: ApiKeyStore> {
+    store: Arc<S>,
+    source: KeySource,
+    /// When false (default), a missing/invalid key yields 401. When true, the
+    /// request passes through unauthenticated (no identity attached).
+    optional: bool,
+}
+
+impl<S: ApiKeyStore + 'static> ApiKey<S> {
+    /// Validate keys against `store`, read from the `x-api-key` header.
+    pub fn new(store: S) -> Self {
+        Self {
+            store: Arc::new(store),
+            source: KeySource::Header("x-api-key".to_string()),
+            optional: false,
+        }
+    }
+
+    /// Read the key from a different request header.
+    pub fn header_name(mut self, name: impl Into<String>) -> Self {
+        self.source = KeySource::Header(name.into());
+        self
+    }
+
+    /// Read the key from a query-string parameter instead of a header.
+    pub fn from_query(mut self, name: impl Into<String>) -> Self {
+        self.source = KeySource::Query(name.into());
+        self
+    }
+
+    /// Make authentication optional: unauthenticated requests pass through with
+    /// no identity attached, instead of receiving a 401.
+    pub fn optional(mut self) -> Self {
+        self.optional = true;
+        self
+    }
+
+    /// Build the verification middleware.
+    pub fn build(self) -> BoxedMiddleware {
+        let cfg = Arc::new(self);
+        Arc::new(move |ctx: Context, next: Next| {
+            let cfg = cfg.clone();
+            Box::pin(async move {
+                let presented = match &cfg.source {
+                    KeySource::Header(name) => ctx.req.header(name),
+                    KeySource::Query(name) => ctx.req.query(name),
+                };
+                match presented {
+                    Some(key) => match cfg.store.validate(&key).await {
+                        Some(identity) => {
+                            ctx.set_api_key(identity).await;
+                            next(ctx).await
+                        }
+                        None if cfg.optional => next(ctx).await,
+                        None => Ok(unauthorized()),
+                    },
+                    None if cfg.optional => next(ctx).await,
+                    None => Ok(unauthorized()),
+                }
+            }) as Pin<Box<dyn Future<Output = Result<Response>> + Send>>
+        })
+    }
+}
+
+/// SHA-256 digest of a key. API keys are high-entropy secrets, so a fast hash is
+/// the correct choice (not a password KDF).
+fn hash_key(key: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(key);
+    hasher.finalize().into()
+}
+
+/// Constant-time equality over equal-length digests.
+fn ct_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn unauthorized() -> Response {
+    ResponseBuilder::new()
+        .status(401)
+        .text("Unauthorized")
+        .build()
+        .unwrap_or_else(|_| crate::response::helpers::text("Unauthorized").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn valid_key_resolves_to_identity_with_scopes() {
+        let store = StaticKeys::new()
+            .insert("key-abc", "service-a")
+            .with_scopes("key-def", "service-b", ["read", "write"]);
+
+        let a = store.validate("key-abc").await.unwrap();
+        assert_eq!(a.id, "service-a");
+        assert!(a.scopes.is_empty());
+
+        let b = store.validate("key-def").await.unwrap();
+        assert_eq!(b.id, "service-b");
+        assert_eq!(b.scopes, vec!["read".to_string(), "write".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn unknown_key_is_rejected() {
+        let store = StaticKeys::new().insert("key-abc", "service-a");
+        assert!(store.validate("nope").await.is_none());
+        // Empty store rejects everything.
+        assert!(StaticKeys::new().validate("anything").await.is_none());
+    }
+
+    #[test]
+    fn ct_eq_matches_only_identical_digests() {
+        let a = hash_key(b"key-abc");
+        let same = hash_key(b"key-abc");
+        let other = hash_key(b"key-xyz");
+        assert!(ct_eq(&a, &same));
+        assert!(!ct_eq(&a, &other));
+    }
+}

--- a/ultimo/src/auth/mod.rs
+++ b/ultimo/src/auth/mod.rs
@@ -1,6 +1,12 @@
 //! Authentication middleware.
 //!
-//! Currently provides JWT (JSON Web Token) verification + signing behind the
-//! `jwt` feature. API-key auth and authorization guards are planned follow-ups.
+//! - `jwt` — stateless JWT (JSON Web Token) verification + signing (feature `jwt`).
+//! - `api_key` — API-key validation against a pluggable store (feature `api-key`).
+//!
+//! Authorization guards that consume these identities are a planned follow-up.
 
+#[cfg(feature = "jwt")]
 pub mod jwt;
+
+#[cfg(feature = "api-key")]
+pub mod api_key;

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -232,6 +232,8 @@ pub struct Context {
     session: Arc<RwLock<Option<crate::session::Session>>>,
     #[cfg(feature = "jwt")]
     jwt_claims: Arc<RwLock<Option<serde_json::Value>>>,
+    #[cfg(feature = "api-key")]
+    api_key: Arc<RwLock<Option<crate::auth::api_key::ApiKeyIdentity>>>,
 
     #[cfg(feature = "database")]
     database: Option<Database>,
@@ -256,6 +258,8 @@ impl Context {
             session: Arc::new(RwLock::new(None)),
             #[cfg(feature = "jwt")]
             jwt_claims: Arc::new(RwLock::new(None)),
+            #[cfg(feature = "api-key")]
+            api_key: Arc::new(RwLock::new(None)),
             #[cfg(feature = "database")]
             database: None,
         }
@@ -437,6 +441,19 @@ impl Context {
     #[cfg(feature = "jwt")]
     pub(crate) async fn set_jwt_claims(&self, claims: serde_json::Value) {
         *self.jwt_claims.write().await = Some(claims);
+    }
+
+    /// The API-key identity for this request, if the `api-key` middleware ran and
+    /// accepted a key. `None` if unauthenticated (or in optional mode).
+    #[cfg(feature = "api-key")]
+    pub async fn api_key(&self) -> Option<crate::auth::api_key::ApiKeyIdentity> {
+        self.api_key.read().await.clone()
+    }
+
+    /// Store the resolved API-key identity (used by the api-key middleware).
+    #[cfg(feature = "api-key")]
+    pub(crate) async fn set_api_key(&self, identity: crate::auth::api_key::ApiKeyIdentity) {
+        *self.api_key.write().await = Some(identity);
     }
 
     /// Set the response status code

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -56,7 +56,7 @@ pub mod session;
 #[cfg(feature = "csrf")]
 pub mod csrf;
 
-#[cfg(feature = "jwt")]
+#[cfg(any(feature = "jwt", feature = "api-key"))]
 pub mod auth;
 
 // Re-exports for convenience

--- a/ultimo/tests/api_key.rs
+++ b/ultimo/tests/api_key.rs
@@ -1,0 +1,104 @@
+//! Integration tests for the API-key auth middleware (feature `api-key`).
+#![cfg(feature = "api-key")]
+
+use http_body_util::Full;
+use hyper::Request as HyperRequest;
+use ultimo::auth::api_key::{ApiKey, StaticKeys};
+use ultimo::{Context, Ultimo};
+
+fn empty() -> Full<bytes::Bytes> {
+    Full::new(bytes::Bytes::new())
+}
+
+fn store() -> StaticKeys {
+    StaticKeys::new()
+        .insert("key-abc", "service-a")
+        .with_scopes("key-def", "service-b", ["read", "write"])
+}
+
+fn app(api: ApiKey<StaticKeys>) -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(api.build());
+    app.get("/me", |ctx: Context| async move {
+        match ctx.api_key().await {
+            Some(id) => {
+                ctx.json(serde_json::json!({ "id": id.id, "scopes": id.scopes }))
+                    .await
+            }
+            None => ctx.json(serde_json::json!({ "id": null })).await,
+        }
+    });
+    app
+}
+
+#[tokio::test]
+async fn valid_key_is_accepted_and_identity_attached() {
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("x-api-key", "key-def")
+        .body(empty())
+        .unwrap();
+    let res = app(ApiKey::new(store())).oneshot(req).await;
+    assert_eq!(res.status(), 200);
+    let body = collect(res).await;
+    assert!(body.contains("service-b"));
+    assert!(body.contains("read"));
+    assert!(body.contains("write"));
+}
+
+#[tokio::test]
+async fn invalid_key_is_rejected_with_401() {
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("x-api-key", "wrong")
+        .body(empty())
+        .unwrap();
+    let res = app(ApiKey::new(store())).oneshot(req).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn missing_key_is_rejected_with_401() {
+    let req = HyperRequest::builder().uri("/me").body(empty()).unwrap();
+    let res = app(ApiKey::new(store())).oneshot(req).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn optional_mode_passes_through_without_key() {
+    let req = HyperRequest::builder().uri("/me").body(empty()).unwrap();
+    let res = app(ApiKey::new(store()).optional()).oneshot(req).await;
+    assert_eq!(res.status(), 200); // handler sees no identity
+}
+
+#[tokio::test]
+async fn query_source_reads_key_from_query_param() {
+    let req = HyperRequest::builder()
+        .uri("/me?api_key=key-abc")
+        .body(empty())
+        .unwrap();
+    let res = app(ApiKey::new(store()).from_query("api_key"))
+        .oneshot(req)
+        .await;
+    assert_eq!(res.status(), 200);
+    assert!(collect(res).await.contains("service-a"));
+}
+
+#[tokio::test]
+async fn custom_header_name_is_honored() {
+    let req = HyperRequest::builder()
+        .uri("/me")
+        .header("authorization", "key-abc")
+        .body(empty())
+        .unwrap();
+    let res = app(ApiKey::new(store()).header_name("authorization"))
+        .oneshot(req)
+        .await;
+    assert_eq!(res.status(), 200);
+}
+
+async fn collect(res: ultimo::response::Response) -> String {
+    use http_body_util::BodyExt;
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}


### PR DESCRIPTION
Second Wave 2 auth method (after JWT), built quality-first. v0.4.0 Security epic (#53).

## What's included
- **`ultimo::auth::api_key`** behind an opt-in `api-key` feature.
- **Pluggable `ApiKeyStore` trait** (mirrors `SessionStore`) so DB/Redis-backed keys drop in without a breaking change — plus a built-in **`StaticKeys`** store for in-memory config.
- **Secure-by-default:** `StaticKeys` hashes keys with **SHA-256** at construction (never retains the raw secret) and compares in **constant time, without early-return** (no timing leak of match position/presence). SHA-256 — not bcrypt/argon2 — is correct here because API keys are high-entropy secrets, not passwords.
- Resolves to an **`ApiKeyIdentity { id, scopes }`** attached to the `Context` (`ctx.api_key()`), never the raw key — sets up authorization guards next.
- Header (`x-api-key` default) or query source; `.optional()` mode; **401** on missing/invalid.

## Tests (now actually run in CI)
Unit (store resolution, scopes, rejection, constant-time eq) + integration via `Ultimo::oneshot` (valid→200+identity, invalid→401, missing→401, optional pass-through, query source, custom header). **Also wires jwt + api-key test runs into `ci.yml`** — closing a gap where the JWT tests were only *compiled* (via `--all-features` clippy) but never *executed*.

## Docs (all surfaces)
New `api-keys.mdx` under the Authentication group (curl/server-side usage — deliberately **no browser example**, since API keys don't belong in front-end JS), `api-reference.mdx`, `README.md`, `roadmap.mdx`.

## Scope
Static + trait-based stores; key generation/minting, built-in DB stores, and per-key rate limits are deferred. Additive — `semver-checks` confirms.

Design: `docs/superpowers/specs/2026-06-07-api-key-auth-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)