### PR TITLE
feat(auth): authorization guards via a unified Principal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           cargo test -p ultimo --features "api-key" --lib auth::api_key
           cargo test -p ultimo --features "api-key" --test api_key
           cargo test -p ultimo --features "api-key" --doc
+          cargo test -p ultimo --features "jwt" --test authz
           cargo test -p ultimo --features "session" --doc
 
       # websocket_pubsub_bench uses test_helpers::ChannelManager, so benches

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - 🎫 **Sessions & Cookies** - Secure-by-default cookie sessions (HttpOnly/Secure/SameSite, 256-bit ids, anti session-fixation) over a pluggable store
 - 🔑 **JWT Authentication** - HS256 JWT middleware (opt-in `jwt` feature): pins the algorithm (`alg: none` rejected), validates `exp`, attaches claims to the request — sign + verify
 - 🗝️ **API-Key Authentication** - API-key middleware (opt-in `api-key` feature) with a pluggable store; keys are SHA-256 hashed and compared in constant time, resolving to an identity (id + scopes)
+- 🛂 **Authorization Guards** - declare per-route access with `ctx.require_scope(…)` / `require_any_scope` / `require_all_scopes`; works uniformly across JWT and API-key auth via a normalized `Principal`
 - 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), CSRF protection, request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
 - 🧪 **Testing Utilities** - In-process `TestClient`, response assertions, middleware/DB/fixture helpers
 - 🔥 **Developer Experience First** - Ergonomic APIs, helpful errors, minimal boilerplate
@@ -54,7 +55,7 @@
 
 See the [full roadmap](https://docs.ultimo.dev/roadmap) for upcoming features:
 
-- 🛡️ Authorization guards (roles/scopes) — JWT + API-key auth already shipped
+- ⚡ Performance suite + published benchmarks (the "fast" half of the pitch)
 - 📡 Streaming & SSE
 - 🌍 Multi-language Client Generation
 - And more...

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -255,6 +255,36 @@ if let Some(identity) = ctx.api_key().await {
 }
 ```
 
+#### Authorization guards (requires `jwt` or `api-key` feature)
+
+Both auth middlewares populate a normalized `auth::Principal { id, scopes }`,
+which these guards read. They compose with `?` and short-circuit with 401/403.
+
+##### `principal(&self) -> Option<Principal>`
+
+The normalized authenticated caller, if any.
+
+##### `require_auth(&self) -> Result<Principal>`
+
+The `Principal`, or **401 Unauthorized**.
+
+##### `require_scope(&self, scope: &str) -> Result<()>`
+
+**401** if unauthenticated, **403 Forbidden** if the scope is missing.
+
+##### `require_any_scope(&self, scopes: &[&str]) -> Result<()>` · `require_all_scopes(&self, scopes: &[&str]) -> Result<()>`
+
+403 unless (respectively) at least one / all of the scopes are present.
+
+```rust
+app.get("/admin", |ctx: Context| async move {
+    ctx.require_scope("admin").await?;
+    ctx.json(json!({ "ok": true })).await
+});
+```
+
+See [Authorization (Guards)](/authorization).
+
 ### `Request`
 
 Access request data through `ctx.req`.

--- a/docs-site/docs/pages/authorization.mdx
+++ b/docs-site/docs/pages/authorization.mdx
@@ -1,0 +1,81 @@
+# Authorization (Guards)
+
+Authentication tells you *who* the caller is; authorization decides *what they
+may do*. Ultimo's guards let a handler declare its access requirements and enforce
+them uniformly — regardless of whether the caller was authenticated by
+[JWT](/jwt) or an [API key](/api-keys).
+
+## How it works: the `Principal`
+
+Each auth middleware normalizes its result into a single `auth::Principal` on the
+request `Context`:
+
+```rust
+pub struct Principal {
+    pub id: Option<String>,   // subject (JWT `sub`) or API-key id
+    pub scopes: Vec<String>,  // what the caller is allowed to do
+}
+```
+
+- The **API-key** middleware fills it from the matched `ApiKeyIdentity` (id + scopes).
+- The **JWT** middleware fills it from the token: `id` from `sub`, and `scopes`
+  parsed from the OAuth2-standard `scope` (space-delimited string) plus `scopes` /
+  `scp` (array or string).
+
+Because guards read only the `Principal`, your authorization logic doesn't care
+which method authenticated the request. Model **roles as scopes** if you prefer
+(e.g. `"role:admin"`) — scopes are the single concept.
+
+> If your JWT puts scopes/roles in a non-standard claim, read them yourself via
+> [`ctx.jwt_claims()`](/jwt) and apply your own check.
+
+## Guards
+
+All guards are `async` methods on `Context` that return `Result<()>` (or the
+`Principal`), so they compose with `?` at the top of a handler:
+
+| Guard | Behavior |
+|---|---|
+| `ctx.principal()` | `Option<Principal>` — the caller, if authenticated. |
+| `ctx.require_auth()` | The `Principal`, or **401 Unauthorized**. |
+| `ctx.require_scope("admin")` | **401** if unauthenticated, **403 Forbidden** if missing the scope. |
+| `ctx.require_any_scope(&["a", "b"])` | 403 unless at least one scope is present. |
+| `ctx.require_all_scopes(&["read", "write"])` | 403 unless all scopes are present. |
+
+```rust
+use ultimo::prelude::*;
+
+// Any authenticated caller.
+app.get("/me", |ctx: Context| async move {
+    let me = ctx.require_auth().await?;          // 401 if not authenticated
+    ctx.json(serde_json::json!({ "id": me.id, "scopes": me.scopes })).await
+});
+
+// Requires a specific scope.
+app.get("/admin", |ctx: Context| async move {
+    ctx.require_scope("admin").await?;           // 401 or 403, else continues
+    ctx.json(serde_json::json!({ "ok": true })).await
+});
+
+// Requires several scopes.
+app.post("/articles", |ctx: Context| async move {
+    ctx.require_all_scopes(&["articles:write", "publish"]).await?;
+    ctx.json(serde_json::json!({ "created": true })).await
+});
+```
+
+A failed guard short-circuits the handler with the appropriate status — `401`
+(`UltimoError::Unauthorized`) when there's no authenticated caller, `403`
+(`UltimoError::Forbidden`) when the caller is known but lacks the scope.
+
+## Availability
+
+Guards are compiled whenever an auth method is enabled — that is, with the `jwt`
+**or** `api-key` feature. No separate feature flag.
+
+## Try it
+
+The [`examples/jwt-auth`](https://github.com/ultimo-rs/ultimo/tree/main/examples/jwt-auth)
+demo issues scoped tokens and guards `/api/admin` with `require_scope("admin")`:
+`cargo run -p jwt-auth-example`, log in as `admin` (granted the scope) vs. any
+other name (gets a `403`).

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -78,7 +78,7 @@ Upcoming features and improvements planned for Ultimo.
 | CSRF Protection           | 🔒 Planned       | 0.4.0   |
 | Auth: JWT middleware      | ✅ Available     | 0.4.0   |
 | Auth: API keys            | ✅ Available     | 0.4.0   |
-| Auth: authorization guards | 🔒 Planned      | 0.4.0   |
+| Auth: authorization guards | ✅ Available    | 0.4.0   |
 | Benchmark Suite + CI Guard | ⚡ Planned      | 0.4.0   |
 | Static Files              | 📋 Planned       | 0.5.0   |
 | Compression               | 📋 Planned       | 0.5.0   |
@@ -128,7 +128,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 - 🔒 Security headers middleware (HSTS, CSP, X-Frame-Options, …)
 - 🔒 CSRF protection (integrates with sessions)
-- ✅ Auth: JWT + API-key middleware — shipped; authorization guards planned
+- ✅ Auth: JWT + API-key middleware + authorization guards (scopes) — shipped
 - 🔒 Request body-size limits, request timeouts, enhanced rate limiting
 - 🔒 `#![forbid(unsafe_code)]` (100% safe Rust), `SECURITY.md` disclosure policy,
   `cargo-deny` + fuzzing in CI, OpenSSF Best Practices

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -75,6 +75,10 @@ export default defineConfig({
               text: "API Keys",
               link: "/api-keys",
             },
+            {
+              text: "Authorization (Guards)",
+              link: "/authorization",
+            },
           ],
         },
         {

--- a/docs/superpowers/specs/2026-06-07-authz-guards-design.md
+++ b/docs/superpowers/specs/2026-06-07-authz-guards-design.md
@@ -1,0 +1,88 @@
+# Authorization Guards — Design
+
+**Date:** 2026-06-07
+**Milestone:** v0.4.0 (Security & Performance — Wave 2: auth & abuse)
+**Epic:** #53 (Security: secure-by-default)
+**Status:** Approved, pre-implementation
+
+## Goal
+
+Make the shipped authentication methods (JWT, API-key) *actionable*: let handlers
+declare per-route access requirements that are enforced uniformly, regardless of
+which auth method established the caller's identity. Capstone of the Wave 2 auth
+arc.
+
+## Key decision: a unified `Principal`
+
+Guards must read identity/scopes from either JWT or API-key. Rather than branch
+on `#[cfg]` in the guards, both auth middlewares normalize their result into a
+single `Principal` stored on the `Context`. Guards read only the `Principal`, so
+they're decoupled from which method ran, a future custom auth can populate the
+same slot, and roles map cleanly onto scopes (e.g. `role:admin`). Scopes is one
+concept, not two.
+
+```rust
+pub struct Principal {
+    pub id: Option<String>,   // subject / key id
+    pub scopes: Vec<String>,
+}
+impl Principal { pub fn has_scope(&self, scope: &str) -> bool; }
+```
+
+Lives in `ultimo::auth` (the module is compiled when `any(feature = "jwt",
+feature = "api-key")`). The `Context` gets a `principal` slot + guards gated the
+same way. No new feature flag — guards exist whenever an auth method does.
+
+## Population
+
+- **API-key middleware** (on success): `Principal { id: Some(identity.id), scopes: identity.scopes }`.
+- **JWT middleware** (on success): `Principal { id: <sub>, scopes: extract_scopes(claims) }`.
+  `extract_scopes` parses the OAuth2-standard **`scope`** (space-delimited string)
+  plus **`scopes`**/**`scp`** (array or string), de-duplicated. Custom claim
+  shapes: read `ctx.jwt_claims()` directly (documented).
+
+Both also keep their existing raw accessors (`ctx.jwt_claims()`, `ctx.api_key()`).
+
+## Guard API (`Context` methods, async, compose with `?`)
+
+| Method | Behavior |
+|---|---|
+| `principal() -> Option<Principal>` | The normalized caller identity, if authenticated. |
+| `require_auth() -> Result<Principal>` | The principal, or **401** if unauthenticated. |
+| `require_scope(s) -> Result<()>` | **401** if unauthenticated, **403** if authenticated but missing `s`. |
+| `require_any_scope(&[s]) -> Result<()>` | 403 unless at least one scope matches. |
+| `require_all_scopes(&[s]) -> Result<()>` | 403 unless all scopes are present. |
+
+```rust
+app.get("/admin", |ctx: Context| async move {
+    ctx.require_scope("admin").await?;          // 401 or 403, else proceeds
+    ctx.json(json!({ "ok": true })).await
+});
+```
+
+401 → `UltimoError::Unauthorized`, 403 → `UltimoError::Forbidden` (existing variants).
+
+## Non-goals (deferred)
+
+- Per-route middleware / declarative attribute guards (Ultimo routing takes a
+  single handler; `Context` guards are the idiomatic fit and more flexible).
+- Role hierarchies / policy engines / RBAC tables — model roles as scopes for now.
+- Configurable JWT scope-claim name — standard `scope`/`scopes`/`scp` covered;
+  custom shapes read `jwt_claims()`.
+
+## Testing
+
+- Unit (`jwt.rs`): `extract_scopes` handles `scope` string, `scopes`/`scp` arrays,
+  combined + de-dup.
+- Integration `tests/authz.rs` (`#![cfg(feature = "jwt")]`): unauthenticated → 401;
+  authenticated without scope → 403; with scope → 200; `require_any`/`require_all`.
+- `tests/api_key.rs`: a guarded route verifying the API-key → `Principal` → guard
+  path (scopes from `ApiKeyIdentity`).
+
+## Surfaces
+
+- Extend `examples/jwt-auth` with a scope-guarded `/api/admin` route (runnable demo).
+- New `docs-site/docs/pages/authorization.mdx` under the Authentication group +
+  sidebar; update `api-reference.mdx`, `README.md`, `roadmap.mdx`.
+- CI: add `cargo test -p ultimo --features "jwt" --test authz` to the test job.
+- Additive change → release-plz bumps from the `feat:` commit; `semver-checks` confirms.

--- a/examples/jwt-auth/src/main.rs
+++ b/examples/jwt-auth/src/main.rs
@@ -1,7 +1,10 @@
-//! JWT auth example — a tiny full-stack demo of Ultimo's `jwt` feature.
+//! JWT auth example — a tiny full-stack demo of Ultimo's `jwt` feature and the
+//! authorization guards.
 //!
-//! `/api/login` issues a short-lived HS256 token; the page stores it and sends it
-//! as `Authorization: Bearer <token>` on calls to the protected `/api/me`.
+//! `/api/login` issues a short-lived HS256 token carrying scopes; the page stores
+//! it and sends it as `Authorization: Bearer <token>`. `/api/me` requires any
+//! valid token; `/api/admin` additionally requires the `admin` scope (granted
+//! only to the user "admin"), demonstrating `ctx.require_scope`.
 //!
 //! ```text
 //! cargo run -p jwt-auth-example
@@ -17,26 +20,31 @@ const PAGE: &str = r#"<!doctype html>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ultimo · JWT Auth Demo</title>
   <style>
-    body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 4rem auto; padding: 0 1rem; }
+    body { font-family: system-ui, sans-serif; max-width: 30rem; margin: 4rem auto; padding: 0 1rem; }
     input, button { font: inherit; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #ccc; }
     button { cursor: pointer; border-color: #4f46e5; background: #4f46e5; color: white; }
     #status { margin-top: 1rem; padding: 0.75rem; border-radius: 0.5rem; background: #f4f4f5; }
+    .hint { color: #666; font-size: 0.9rem; }
   </style>
 </head>
 <body>
-  <h1>Ultimo JWT Auth</h1>
-  <p>Log in to receive a bearer token, then call the protected endpoint.</p>
+  <h1>Ultimo JWT Auth + Guards</h1>
+  <p class="hint">Log in as <code>admin</code> to get the <code>admin</code> scope; any other name gets only <code>user</code>.</p>
   <div>
     <input id="username" placeholder="username" value="ada" />
     <button id="login">Log in</button>
-    <button id="me">Call /api/me</button>
-    <button id="logout">Forget token</button>
   </div>
+  <p>
+    <button id="me">Call /api/me</button>
+    <button id="admin">Call /api/admin</button>
+    <button id="logout">Forget token</button>
+  </p>
   <div id="status">…</div>
 
   <script>
     const statusEl = document.getElementById('status');
     let token = null;
+    const authHeaders = () => (token ? { authorization: 'Bearer ' + token } : {});
     document.getElementById('login').onclick = async () => {
       const username = document.getElementById('username').value || 'guest';
       const res = await fetch('/api/login', {
@@ -48,15 +56,19 @@ const PAGE: &str = r#"<!doctype html>
       statusEl.textContent = 'Got token: ' + token.slice(0, 24) + '…';
     };
     document.getElementById('me').onclick = async () => {
-      const res = await fetch('/api/me', {
-        headers: token ? { authorization: 'Bearer ' + token } : {},
-      });
+      const res = await fetch('/api/me', { headers: authHeaders() });
       const body = await res.json();
       statusEl.textContent = res.ok ? ('Hello, ' + body.sub) : ('Rejected (' + res.status + ')');
     };
+    document.getElementById('admin').onclick = async () => {
+      const res = await fetch('/api/admin', { headers: authHeaders() });
+      statusEl.textContent = res.ok
+        ? 'Admin access granted ✅'
+        : (res.status === 403 ? 'Forbidden — missing admin scope (403)' : 'Rejected (' + res.status + ')');
+    };
     document.getElementById('logout').onclick = () => {
       token = null;
-      statusEl.textContent = 'Token forgotten — /api/me will now 401.';
+      statusEl.textContent = 'Token forgotten — protected routes will now 401.';
     };
   </script>
 </body>
@@ -70,6 +82,7 @@ struct LoginBody {
 #[derive(Serialize)]
 struct Claims {
     sub: String,
+    scope: String,
     exp: usize,
 }
 
@@ -83,37 +96,48 @@ async fn main() -> Result<()> {
     let mut app = Ultimo::new_without_defaults();
 
     // Mount the verifier in *optional* mode so `/` and `/api/login` stay public;
-    // the protected handler (`/api/me`) enforces that claims are present itself.
+    // the protected handlers enforce auth (and scopes) themselves.
     app.use_middleware(jwt.clone().optional().build());
 
     app.get("/", |ctx: Context| async move { ctx.html(PAGE).await });
 
-    // Issue a token valid for 15 minutes (secure-by-default: short-lived).
+    // Issue a 15-minute token. "admin" gets the admin scope; everyone gets "user".
     let signer = jwt.clone();
     app.post("/api/login", move |ctx: Context| {
         let signer = signer.clone();
         async move {
             let body: LoginBody = ctx.req.json().await?;
+            let scope = if body.username == "admin" {
+                "user admin"
+            } else {
+                "user"
+            };
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .map_err(|e| UltimoError::Internal(e.to_string()))?
                 .as_secs() as usize;
             let token = signer.sign(&Claims {
                 sub: body.username.clone(),
+                scope: scope.to_string(),
                 exp: now + 900,
             })?;
             ctx.json(json!({ "token": token })).await
         }
     });
 
-    // Protected: the optional middleware attached claims iff a valid token was sent.
+    // Requires any valid token.
     app.get("/api/me", |ctx: Context| async move {
-        match ctx.jwt_claims().await {
-            Some(c) => ctx.json(json!({ "sub": c.get("sub") })).await,
-            None => Err(UltimoError::Unauthorized("login required".into())),
-        }
+        let principal = ctx.require_auth().await?;
+        ctx.json(json!({ "sub": principal.id, "scopes": principal.scopes }))
+            .await
     });
 
-    println!("🔑 JWT auth demo: http://127.0.0.1:3000");
+    // Requires the `admin` scope (401 if unauthenticated, 403 if missing it).
+    app.get("/api/admin", |ctx: Context| async move {
+        ctx.require_scope("admin").await?;
+        ctx.json(json!({ "ok": true, "area": "admin" })).await
+    });
+
+    println!("🔑 JWT auth + guards demo: http://127.0.0.1:3000");
     app.listen("127.0.0.1:3000").await
 }

--- a/ultimo/src/auth/api_key.rs
+++ b/ultimo/src/auth/api_key.rs
@@ -169,7 +169,12 @@ impl<S: ApiKeyStore + 'static> ApiKey<S> {
                 match presented {
                     Some(key) => match cfg.store.validate(&key).await {
                         Some(identity) => {
+                            let principal = crate::auth::Principal {
+                                id: Some(identity.id.clone()),
+                                scopes: identity.scopes.clone(),
+                            };
                             ctx.set_api_key(identity).await;
+                            ctx.set_principal(principal).await;
                             next(ctx).await
                         }
                         None if cfg.optional => next(ctx).await,

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -159,7 +159,12 @@ impl Jwt {
                 match extract_token(&cfg, &ctx) {
                     Some(token) => match cfg.decode::<serde_json::Value>(&token) {
                         Ok(claims) => {
+                            let principal = crate::auth::Principal {
+                                id: claims.get("sub").and_then(|v| v.as_str()).map(String::from),
+                                scopes: extract_scopes(&claims),
+                            };
                             ctx.set_jwt_claims(claims).await;
+                            ctx.set_principal(principal).await;
                             next(ctx).await
                         }
                         Err(_) if cfg.optional => next(ctx).await,
@@ -180,6 +185,33 @@ fn unauthorized() -> Response {
         .text("Unauthorized")
         .build()
         .unwrap_or_else(|_| crate::response::helpers::text("Unauthorized").unwrap())
+}
+
+/// Extract scopes from JWT claims for the normalized [`Principal`](crate::auth::Principal).
+///
+/// Parses the OAuth2-standard `scope` (space-delimited string) plus `scopes` and
+/// `scp` (array of strings, or a space-delimited string), de-duplicated. Apps
+/// with a different claim shape can read [`Context::jwt_claims`](crate::Context::jwt_claims)
+/// directly instead.
+fn extract_scopes(claims: &serde_json::Value) -> Vec<String> {
+    let mut scopes: Vec<String> = Vec::new();
+    if let Some(s) = claims.get("scope").and_then(|v| v.as_str()) {
+        scopes.extend(s.split_whitespace().map(String::from));
+    }
+    for key in ["scopes", "scp"] {
+        match claims.get(key) {
+            Some(serde_json::Value::Array(arr)) => {
+                scopes.extend(arr.iter().filter_map(|v| v.as_str()).map(String::from));
+            }
+            Some(serde_json::Value::String(s)) => {
+                scopes.extend(s.split_whitespace().map(String::from));
+            }
+            _ => {}
+        }
+    }
+    scopes.sort();
+    scopes.dedup();
+    scopes
 }
 
 #[cfg(test)]
@@ -244,6 +276,24 @@ mod tests {
             })
             .unwrap();
         assert!(jwt.decode::<Claims>(&token).is_err());
+    }
+
+    #[test]
+    fn extract_scopes_parses_standard_claims() {
+        // OAuth2 `scope`: space-delimited string.
+        let s = extract_scopes(&serde_json::json!({ "scope": "read write" }));
+        assert_eq!(s, vec!["read".to_string(), "write".to_string()]);
+
+        // `scopes` array.
+        let s = extract_scopes(&serde_json::json!({ "scopes": ["admin", "read"] }));
+        assert_eq!(s, vec!["admin".to_string(), "read".to_string()]);
+
+        // `scp` string + `scope` combined, de-duplicated and sorted.
+        let s = extract_scopes(&serde_json::json!({ "scope": "read", "scp": "read admin" }));
+        assert_eq!(s, vec!["admin".to_string(), "read".to_string()]);
+
+        // No scope claims → empty.
+        assert!(extract_scopes(&serde_json::json!({ "sub": "ada" })).is_empty());
     }
 
     #[test]

--- a/ultimo/src/auth/mod.rs
+++ b/ultimo/src/auth/mod.rs
@@ -1,12 +1,34 @@
-//! Authentication middleware.
+//! Authentication & authorization.
 //!
 //! - `jwt` — stateless JWT (JSON Web Token) verification + signing (feature `jwt`).
 //! - `api_key` — API-key validation against a pluggable store (feature `api-key`).
 //!
-//! Authorization guards that consume these identities are a planned follow-up.
+//! Both middlewares normalize their result into a [`Principal`] on the request
+//! `Context`, which the authorization guards (`Context::require_scope`, etc.)
+//! read — so authorization is decoupled from which method authenticated the call.
 
 #[cfg(feature = "jwt")]
 pub mod jwt;
 
 #[cfg(feature = "api-key")]
 pub mod api_key;
+
+/// The normalized authenticated caller, populated by an auth middleware and read
+/// by the authorization guards on [`crate::Context`].
+///
+/// Roles can be modeled as scopes (e.g. `"role:admin"`) — scopes are the single
+/// authorization concept.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct Principal {
+    /// Subject / key id of the caller (`sub` claim for JWT, key id for API keys).
+    pub id: Option<String>,
+    /// Scopes granted to the caller, used by the guards.
+    pub scopes: Vec<String>,
+}
+
+impl Principal {
+    /// Whether the caller has the given scope.
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.scopes.iter().any(|s| s == scope)
+    }
+}

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -234,6 +234,8 @@ pub struct Context {
     jwt_claims: Arc<RwLock<Option<serde_json::Value>>>,
     #[cfg(feature = "api-key")]
     api_key: Arc<RwLock<Option<crate::auth::api_key::ApiKeyIdentity>>>,
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    principal: Arc<RwLock<Option<crate::auth::Principal>>>,
 
     #[cfg(feature = "database")]
     database: Option<Database>,
@@ -260,6 +262,8 @@ impl Context {
             jwt_claims: Arc::new(RwLock::new(None)),
             #[cfg(feature = "api-key")]
             api_key: Arc::new(RwLock::new(None)),
+            #[cfg(any(feature = "jwt", feature = "api-key"))]
+            principal: Arc::new(RwLock::new(None)),
             #[cfg(feature = "database")]
             database: None,
         }
@@ -454,6 +458,77 @@ impl Context {
     #[cfg(feature = "api-key")]
     pub(crate) async fn set_api_key(&self, identity: crate::auth::api_key::ApiKeyIdentity) {
         *self.api_key.write().await = Some(identity);
+    }
+
+    /// The normalized authenticated caller, if an auth middleware accepted the
+    /// request. Populated by the JWT / API-key middlewares; read by the guards.
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    pub async fn principal(&self) -> Option<crate::auth::Principal> {
+        self.principal.read().await.clone()
+    }
+
+    /// Store the normalized caller (used by the auth middlewares).
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    pub(crate) async fn set_principal(&self, principal: crate::auth::Principal) {
+        *self.principal.write().await = Some(principal);
+    }
+
+    /// Require an authenticated caller, returning the [`Principal`](crate::auth::Principal).
+    /// Errors with **401 Unauthorized** if no auth middleware accepted the request.
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    pub async fn require_auth(&self) -> Result<crate::auth::Principal> {
+        self.principal().await.ok_or_else(|| {
+            crate::error::UltimoError::Unauthorized("authentication required".to_string())
+        })
+    }
+
+    /// Require the caller to have `scope`. **401** if unauthenticated, **403** if
+    /// authenticated but missing the scope.
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    pub async fn require_scope(&self, scope: &str) -> Result<()> {
+        let principal = self.require_auth().await?;
+        if principal.has_scope(scope) {
+            Ok(())
+        } else {
+            Err(crate::error::UltimoError::Forbidden(format!(
+                "missing required scope: {scope}"
+            )))
+        }
+    }
+
+    /// Require the caller to have at least one of `scopes`. **401** if
+    /// unauthenticated, **403** if none of the scopes are present.
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    pub async fn require_any_scope(&self, scopes: &[&str]) -> Result<()> {
+        let principal = self.require_auth().await?;
+        if scopes.iter().any(|s| principal.has_scope(s)) {
+            Ok(())
+        } else {
+            Err(crate::error::UltimoError::Forbidden(format!(
+                "missing any of required scopes: {}",
+                scopes.join(", ")
+            )))
+        }
+    }
+
+    /// Require the caller to have all of `scopes`. **401** if unauthenticated,
+    /// **403** if any scope is missing.
+    #[cfg(any(feature = "jwt", feature = "api-key"))]
+    pub async fn require_all_scopes(&self, scopes: &[&str]) -> Result<()> {
+        let principal = self.require_auth().await?;
+        let missing: Vec<&str> = scopes
+            .iter()
+            .copied()
+            .filter(|s| !principal.has_scope(s))
+            .collect();
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(crate::error::UltimoError::Forbidden(format!(
+                "missing required scopes: {}",
+                missing.join(", ")
+            )))
+        }
     }
 
     /// Set the response status code

--- a/ultimo/tests/api_key.rs
+++ b/ultimo/tests/api_key.rs
@@ -97,6 +97,37 @@ async fn custom_header_name_is_honored() {
     assert_eq!(res.status(), 200);
 }
 
+#[tokio::test]
+async fn guarded_route_uses_api_key_scopes() {
+    // A route guarded by require_scope, behind the api-key middleware. The
+    // identity's scopes flow into the Principal the guard reads.
+    fn guarded() -> Ultimo {
+        let mut app = Ultimo::new_without_defaults();
+        app.use_middleware(ApiKey::new(store()).build());
+        app.get("/admin", |ctx: Context| async move {
+            ctx.require_scope("write").await?;
+            ctx.json(serde_json::json!({ "ok": true })).await
+        });
+        app
+    }
+
+    // key-def has scopes [read, write] → allowed.
+    let req = HyperRequest::builder()
+        .uri("/admin")
+        .header("x-api-key", "key-def")
+        .body(empty())
+        .unwrap();
+    assert_eq!(guarded().oneshot(req).await.status(), 200);
+
+    // key-abc has no scopes → 403.
+    let req = HyperRequest::builder()
+        .uri("/admin")
+        .header("x-api-key", "key-abc")
+        .body(empty())
+        .unwrap();
+    assert_eq!(guarded().oneshot(req).await.status(), 403);
+}
+
 async fn collect(res: ultimo::response::Response) -> String {
     use http_body_util::BodyExt;
     let bytes = res.into_body().collect().await.unwrap().to_bytes();

--- a/ultimo/tests/authz.rs
+++ b/ultimo/tests/authz.rs
@@ -1,0 +1,99 @@
+//! Integration tests for authorization guards (scopes via the JWT principal).
+#![cfg(feature = "jwt")]
+
+use http_body_util::Full;
+use hyper::Request as HyperRequest;
+use serde::Serialize;
+use ultimo::auth::jwt::Jwt;
+use ultimo::{Context, Ultimo};
+
+#[derive(Serialize)]
+struct Claims {
+    sub: String,
+    scope: String,
+    exp: usize,
+}
+
+fn far_future() -> usize {
+    4_102_444_800
+}
+
+fn jwt() -> Jwt {
+    Jwt::hs256(b"secret")
+}
+
+fn token(scope: &str) -> String {
+    jwt()
+        .sign(&Claims {
+            sub: "ada".into(),
+            scope: scope.into(),
+            exp: far_future(),
+        })
+        .unwrap()
+}
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(jwt().build());
+    app.get("/admin", |ctx: Context| async move {
+        ctx.require_scope("admin").await?;
+        ctx.json(serde_json::json!({ "ok": true })).await
+    });
+    app.get("/all", |ctx: Context| async move {
+        ctx.require_all_scopes(&["read", "write"]).await?;
+        ctx.json(serde_json::json!({ "ok": true })).await
+    });
+    app.get("/any", |ctx: Context| async move {
+        ctx.require_any_scope(&["read", "x"]).await?;
+        ctx.json(serde_json::json!({ "ok": true })).await
+    });
+    app
+}
+
+fn get(path: &str, bearer: Option<&str>) -> HyperRequest<Full<bytes::Bytes>> {
+    let mut b = HyperRequest::builder().uri(path);
+    if let Some(t) = bearer {
+        b = b.header("authorization", format!("Bearer {t}"));
+    }
+    b.body(Full::new(bytes::Bytes::new())).unwrap()
+}
+
+#[tokio::test]
+async fn unauthenticated_is_401() {
+    let res = app().oneshot(get("/admin", None)).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn authenticated_without_scope_is_403() {
+    let res = app().oneshot(get("/admin", Some(&token("read")))).await;
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn authenticated_with_scope_is_200() {
+    let res = app()
+        .oneshot(get("/admin", Some(&token("read write admin"))))
+        .await;
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn require_all_scopes_enforced() {
+    // Has both → 200.
+    let res = app().oneshot(get("/all", Some(&token("read write")))).await;
+    assert_eq!(res.status(), 200);
+    // Missing one → 403.
+    let res = app().oneshot(get("/all", Some(&token("read")))).await;
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn require_any_scope_enforced() {
+    // Has one of {read, x} → 200.
+    let res = app().oneshot(get("/any", Some(&token("read")))).await;
+    assert_eq!(res.status(), 200);
+    // Has neither → 403.
+    let res = app().oneshot(get("/any", Some(&token("write")))).await;
+    assert_eq!(res.status(), 403);
+}


### PR DESCRIPTION
Capstone of the Wave 2 auth arc (#53): make JWT + API-key auth *actionable* with per-route authorization.

## What's included
- **Unified `auth::Principal { id, scopes }`** — both auth middlewares normalize their result into it on the `Context`, so guards are decoupled from which method authenticated the request. JWT scopes are parsed from the OAuth2-standard `scope` / `scopes` / `scp` claims; API-key scopes come from the `ApiKeyIdentity`.
- **`Context` guards** (async, compose with `?`): `principal()`, `require_auth()` (401), `require_scope()` / `require_any_scope()` / `require_all_scopes()` (401 unauthenticated, 403 missing). Gated on `any(jwt, api-key)` — no new feature flag.
- Roles map onto scopes (`"role:admin"`) — one concept.

## Tests (run in CI)
- Unit: JWT `extract_scopes` (scope string, scopes/scp arrays, combined + de-dup).
- `tests/authz.rs` (via `oneshot`): unauthenticated→401, missing-scope→403, has-scope→200, `require_any`/`require_all`.
- `tests/api_key.rs`: a guarded route exercising the API-key → Principal → guard path.
- CI runs the new `authz` test target.

## Demo + docs
- `examples/jwt-auth` extended with a scope-guarded `/api/admin` (log in as `admin` → allowed; others → 403).
- New `authorization.mdx` under the Authentication group; `api-reference.mdx`, `README.md`, `roadmap.mdx` updated.

## Scope
Per-route declarative/attribute guards, role hierarchies, and policy engines are deferred — model roles as scopes for now. Additive — `semver-checks` confirms.

Design: `docs/superpowers/specs/2026-06-07-authz-guards-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)