### PR TITLE
perf(bench): framework-overhead benchmark suite + methodology

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,85 @@
+# Benchmarks
+
+Ultimo's performance work has two tiers, for two different purposes. Understanding
+the split matters: **don't compare numbers across tiers or across machines.**
+
+| Tier | Tool | Measures | Where to run | Purpose |
+|---|---|---|---|---|
+| Framework overhead | criterion (in-process) | Ultimo's own cost (routing, dispatch, JSON, middleware) | anywhere, incl. CI | regression detection |
+| End-to-end | `oha` (real HTTP) | req/s & latency over a socket | **controlled hardware only** | published / comparison numbers |
+
+## Tier 1 — framework-overhead micro-benchmarks (criterion)
+
+These drive the app **in-process** via `Ultimo::oneshot`, so they isolate
+framework cost from network and OS scheduling noise. That makes them low-variance
+and reproducible — the right basis for a regression gate. The numbers are
+*relative* (compare routing vs dispatch, or this commit vs a baseline); the
+absolute microseconds are only meaningful within one machine/run.
+
+Source: [`ultimo/benches/http_bench.rs`](ultimo/benches/http_bench.rs). Benches:
+
+- **dispatch_text** — full request → minimal text handler.
+- **dispatch_json** — dispatch → JSON-serialized response.
+- **routing/{static,param}/{10,100,500}** — radix-tree lookup as the table grows.
+- **middleware_chain/{0,1,5,10}** — per-layer pass-through overhead.
+
+### Running
+
+```bash
+make bench                              # all benches (incl. websocket)
+cargo bench -p ultimo --bench http_bench   # just the HTTP-overhead suite
+```
+
+### Detecting regressions (the basis for the CI gate, #13)
+
+criterion compares against a saved baseline:
+
+```bash
+# On main / a known-good commit:
+cargo bench -p ultimo --bench http_bench -- --save-baseline main
+
+# On your change — criterion reports % change vs the baseline:
+cargo bench -p ultimo --bench http_bench -- --baseline main
+```
+
+A future CI job (#13) will save a baseline from the target branch and fail/flag
+when a change regresses beyond a threshold (~10%, advisory first to calibrate
+runner noise).
+
+## Tier 2 — end-to-end load benchmarks (`oha`)
+
+Real requests-per-second over a socket, for the published numbers and the
+framework comparison on the `/performance` page. **These are only trustworthy on
+controlled hardware** — never a shared CI runner. Always report the machine,
+Rust version, build profile, and tool version alongside the numbers.
+
+### Protocol
+
+1. Build the target server in release mode: `cargo run --release -p <example>`
+   (e.g. a minimal JSON endpoint). Pin it to dedicated cores if possible.
+2. Run the load from a **separate machine** (or at least a separate core set) to
+   avoid the client starving the server:
+
+   ```bash
+   # https://github.com/hatoo/oha
+   oha -z 30s -c 100 --no-tui http://<server>:3000/
+   ```
+
+   - `-z 30s` — sustained 30-second run (ignore the first few seconds of warm-up).
+   - `-c 100` — concurrent connections; sweep (e.g. 50/100/200/500) to find the knee.
+3. Record: req/s (mean), latency p50/p95/p99, and error count (must be 0).
+4. For comparisons, run the **identical** endpoint + load profile against each
+   framework (axum, actix, hono, express, fastapi) on the **same** hardware in the
+   same session. Publish the methodology, not just the bar chart.
+
+### Why not in CI
+
+Cloud CI VMs are shared and noisy (±20–50% throughput swings), so absolute req/s
+there is meaningless and would make any comparison dishonest. CI is for Tier-1
+regression detection only.
+
+## Known findings
+
+- **Routing scales ~linearly with route count** (≈1.7µs at 10 routes → ≈26µs at
+  500 in `routing/static`), suggesting an O(N) match rather than the intended
+  O(L) radix-tree lookup. Tracked for investigation — see the issues list.

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ test-watch: ## Run tests in watch mode
 test-summary: ## Show test statistics
 	@./scripts/test-summary.sh
 
+bench: ## Run performance benchmarks (criterion)
+	cargo bench -p ultimo --features "websocket,test-helpers"
+
 coverage: ## Generate coverage report
 	@cargo run --release -p ultimo-coverage
 

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -79,7 +79,8 @@ Upcoming features and improvements planned for Ultimo.
 | Auth: JWT middleware      | ✅ Available     | 0.4.0   |
 | Auth: API keys            | ✅ Available     | 0.4.0   |
 | Auth: authorization guards | ✅ Available    | 0.4.0   |
-| Benchmark Suite + CI Guard | ⚡ Planned      | 0.4.0   |
+| Benchmark Suite (criterion) | ✅ Available  | 0.4.0   |
+| Perf CI Regression Guard  | ⚡ Planned       | 0.4.0   |
 | Static Files              | 📋 Planned       | 0.5.0   |
 | Compression               | 📋 Planned       | 0.5.0   |
 | Hot Reload                | 📋 Planned       | 0.5.0   |
@@ -135,7 +136,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 **Performance** (proven · regression-guarded)
 
-- ⚡ Continuous benchmarking in CI (no perf regressions merge)
+- ✅ Framework-overhead benchmark suite (criterion, in-process) + methodology (BENCHMARKS.md); ⚡ CI regression guard next
 - ⚡ Published comparison vs axum / actix / hono / express / fastapi
 - ⚡ `/performance` page with reproducible methodology
 

--- a/docs/superpowers/specs/2026-06-07-perf-benchmarks-design.md
+++ b/docs/superpowers/specs/2026-06-07-perf-benchmarks-design.md
@@ -1,0 +1,71 @@
+# Performance Benchmark Suite — Design
+
+**Date:** 2026-06-07
+**Milestone:** v0.4.0 (Security & Performance — Performance pillar)
+**Epic:** #54 (Performance: prove & regression-guard the speed claim)
+**Status:** Approved, pre-implementation
+
+## Goal
+
+Establish the foundation for Ultimo's performance pillar: reproducible benchmarks
+that (a) measure the framework's own overhead with low enough noise to base a CI
+regression gate on, and (b) define a credible methodology for the published
+comparison numbers. This first deliverable is the *suite + methodology*; the CI
+gate (#13) and the `/performance` page (#62) are follow-ups.
+
+## Key decision: two benchmark tiers for two purposes
+
+CI runners are noisy shared VMs (±20–50% throughput swings), so a single approach
+can't serve both regression detection and headline numbers.
+
+1. **Framework-overhead micro-benchmarks — criterion, in-process via `Ultimo::oneshot`.**
+   Driving the app in-process isolates framework cost from network/OS noise, so
+   these are low-variance and reproducible — the right basis for a regression gate.
+   This is what this PR ships. Benches:
+   - **routing** — radix-tree lookup across many registered routes (static + param).
+   - **dispatch_text** — full request → minimal text handler.
+   - **dispatch_json** — dispatch → serialized JSON response.
+   - **middleware_chain** — dispatch through N pass-through middlewares (overhead).
+
+2. **End-to-end load benchmarks — `oha` over real HTTP, on controlled hardware.**
+   Real req/s vs axum/actix/etc. — the marketing figures. Only trustworthy off
+   CI, so this PR ships a documented, reproducible *methodology + script*; the
+   actual numbers are generated on a controlled machine for the `/performance`
+   page.
+
+This split avoids both flaky CI perf gates and dishonest cloud-VM "benchmarks."
+
+## Deliverables (this PR)
+
+- `ultimo/benches/http_bench.rs` — criterion (`harness = false`, no required
+  features; uses `oneshot`). Uses the `async_tokio` criterion feature already in
+  dev-deps.
+- `[[bench]]` entry in `ultimo/Cargo.toml` for `http_bench`.
+- `make bench` target (runs `cargo bench -p ultimo --features "websocket,test-helpers"`
+  so all benches, incl. the existing websocket ones, run).
+- `BENCHMARKS.md` — methodology: what each micro-bench measures, how to run
+  locally, how to capture a criterion `--baseline` (sets up the #13 gate), and
+  the controlled-hardware `oha` protocol for e2e/comparison numbers.
+- Roadmap note.
+
+## Non-goals (follow-ups)
+
+- **CI regression gate (#13)** — criterion baseline compare with a generous (~10%)
+  threshold, advisory before enforced. Separate PR.
+- **`/performance` page (#62)** — published numbers + comparison, from controlled
+  hardware. Separate PR.
+- **Advertising (#63).**
+
+## CI
+
+No `ci.yml` change needed: the existing `test` job already builds all benches
+(`cargo build -p ultimo --benches --features "websocket,test-helpers"`), which
+will compile `http_bench` (it has no required features). Benches are **not run**
+in CI here — running criterion is slow and the regression gate is #13.
+
+## Notes
+
+- Benchmarks measure *relative* framework overhead, not absolute machine speed —
+  the numbers are only comparable within the same machine/run, which is exactly
+  what regression detection needs.
+- No SemVer impact (benches are not part of the public API).

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -91,3 +91,9 @@ diesel-sqlite = ["database", "diesel", "diesel/sqlite", "diesel/r2d2", "r2d2"]
 name = "websocket_bench"
 harness = false
 required-features = ["websocket", "test-helpers"]
+
+# Framework-overhead benchmarks (routing, dispatch, JSON, middleware). No feature
+# gate — runs on default features via in-process `Ultimo::oneshot`.
+[[bench]]
+name = "http_bench"
+harness = false

--- a/ultimo/benches/http_bench.rs
+++ b/ultimo/benches/http_bench.rs
@@ -1,0 +1,144 @@
+//! Framework-overhead benchmarks — measure what Ultimo itself costs, isolated
+//! from network/OS noise by driving the app in-process via `Ultimo::oneshot`.
+//!
+//! These are deliberately *relative* measurements (routing vs dispatch vs JSON
+//! vs middleware overhead), low-variance enough to base a regression gate on.
+//! Absolute numbers are only comparable within the same machine/run. Real req/s
+//! comparisons live in the end-to-end load tests — see `BENCHMARKS.md`.
+//!
+//! Run with: `cargo bench -p ultimo --bench http_bench`
+
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use http_body_util::Full;
+use hyper::Request as HyperRequest;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use ultimo::middleware::{BoxedMiddleware, Next};
+use ultimo::response::Response;
+use ultimo::{Context, Result, Ultimo};
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn request(uri: &str) -> HyperRequest<Full<Bytes>> {
+    HyperRequest::builder()
+        .uri(uri)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+/// A pass-through middleware that does nothing but call the next handler — used
+/// to measure per-layer chain overhead.
+fn passthrough() -> BoxedMiddleware {
+    Arc::new(|ctx: Context, next: Next| {
+        Box::pin(async move { next(ctx).await })
+            as Pin<Box<dyn Future<Output = Result<Response>> + Send>>
+    })
+}
+
+/// Full request → minimal text handler.
+fn bench_dispatch_text(c: &mut Criterion) {
+    let rt = runtime();
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+
+    c.bench_function("dispatch_text", |b| {
+        b.to_async(&rt).iter(|| async {
+            let res = app.oneshot(black_box(request("/"))).await;
+            black_box(res.status());
+        });
+    });
+}
+
+/// Full request → JSON-serialized response.
+fn bench_dispatch_json(c: &mut Criterion) {
+    let rt = runtime();
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/", |ctx: Context| async move {
+        ctx.json(serde_json::json!({ "message": "hello", "ok": true, "n": 42 }))
+            .await
+    });
+
+    c.bench_function("dispatch_json", |b| {
+        b.to_async(&rt).iter(|| async {
+            let res = app.oneshot(black_box(request("/"))).await;
+            black_box(res.status());
+        });
+    });
+}
+
+/// Radix-tree route lookup as the routing table grows. Dispatches to a route in
+/// the middle of the table plus a parameterized route.
+fn bench_routing(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("routing");
+
+    for n in [10usize, 100, 500] {
+        let mut app = Ultimo::new_without_defaults();
+        for i in 0..n {
+            let path = format!("/route/{i}");
+            app.get(&path, |ctx: Context| async move { ctx.text("ok").await });
+        }
+        app.get("/users/:id", |ctx: Context| async move {
+            let id = ctx.req.param("id")?;
+            ctx.text(id.to_string()).await
+        });
+
+        // Look up a static route in the middle of the table.
+        let mid = format!("/route/{}", n / 2);
+        group.bench_with_input(BenchmarkId::new("static", n), &mid, |b, mid| {
+            b.to_async(&rt).iter(|| async {
+                let res = app.oneshot(black_box(request(mid))).await;
+                black_box(res.status());
+            });
+        });
+
+        // Look up the parameterized route.
+        group.bench_with_input(BenchmarkId::new("param", n), &n, |b, _| {
+            b.to_async(&rt).iter(|| async {
+                let res = app.oneshot(black_box(request("/users/123"))).await;
+                black_box(res.status());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Per-layer middleware overhead: dispatch through a chain of pass-through layers.
+fn bench_middleware_chain(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("middleware_chain");
+
+    for layers in [0usize, 1, 5, 10] {
+        let mut app = Ultimo::new_without_defaults();
+        for _ in 0..layers {
+            app.use_middleware(passthrough());
+        }
+        app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+
+        group.bench_with_input(BenchmarkId::from_parameter(layers), &layers, |b, _| {
+            b.to_async(&rt).iter(|| async {
+                let res = app.oneshot(black_box(request("/"))).await;
+                black_box(res.status());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_dispatch_text,
+    bench_dispatch_json,
+    bench_routing,
+    bench_middleware_chain
+);
+criterion_main!(benches);


### PR DESCRIPTION
First deliverable of the Performance pillar (#54): reproducible benchmarks + methodology. CI regression gate (#13) and `/performance` page (#62) are follow-ups.

## Two tiers, two purposes
CI runners are noisy (±20–50%), so benchmarking splits by purpose:
- **Tier 1 — criterion, in-process via `Ultimo::oneshot`** (this PR): measures *framework overhead* (routing, dispatch, JSON, middleware chain) with low variance — the right basis for a regression gate.
- **Tier 2 — `oha` over real HTTP on controlled hardware** (methodology only here): the published/comparison req/s numbers. Documented in `BENCHMARKS.md`; never run in CI.

## Included
- `ultimo/benches/http_bench.rs` (criterion, `harness=false`, no feature gate).
- `[[bench]]` entry + `make bench`.
- `BENCHMARKS.md` — both tiers, how to run, how to capture a criterion `--baseline` (sets up #13), and the controlled-hardware `oha` protocol.
- Roadmap updated.

No `ci.yml` change: the existing `test` job already builds all benches (`--benches`), so `http_bench` is compile-checked. Benches aren't *run* in CI (that's #13). No SemVer impact.

## Finding 🔎
The benches immediately surfaced that **routing scales ~linearly with route count** (≈1.7µs @10 routes → ≈26µs @500 in `routing/static`), i.e. an O(N) match rather than the intended O(L) radix-tree lookup. Flagged in `BENCHMARKS.md`; worth a follow-up investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)