### PR TITLE
docs: remove fabricated perf numbers from README + correct rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@
 
 ---
 
-⚡ **Industry-leading performance** (158k+ req/sec, 0.6ms latency) - Lightweight, type-safe Rust web framework with **automatic TypeScript client generation** for type-safe full-stack development.
+A lightweight, **secure**, type-safe Rust web framework with **automatic TypeScript client generation** — built on Hyper + Tokio for native speed and full-stack type safety.
 
 ## ✨ Key Features
 
 ### Available Now
 
-- ⚡ **Blazing Fast Performance** - Industry-leading speed: 158k+ req/sec, sub-millisecond latency
+- ⚡ **Fast** - Native Rust on the Hyper + Tokio core, O(1) constant-time routing, regression-guarded benchmarks ([performance](https://docs.ultimo.dev/performance))
 - 🚀 **Automatic TypeScript Generation** - RPC endpoints automatically generate type-safe TypeScript clients
 - 📋 **OpenAPI Support** - Generate OpenAPI 3.0 specs from your RPC procedures for Swagger UI, Prism, and OpenAPI Generator
 - 🔄 **Hybrid RPC Modes** - Choose between REST (individual endpoints) or JSON-RPC (single endpoint) style
@@ -49,7 +49,7 @@
 - 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), CSRF protection, request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
 - 🧪 **Testing Utilities** - In-process `TestClient`, response assertions, middleware/DB/fixture helpers
 - 🔥 **Developer Experience First** - Ergonomic APIs, helpful errors, minimal boilerplate
-- 💪 **Production Ready** - Built-in validation, authentication, rate limiting, CORS
+- 💪 **Production Ready** - Built-in validation, authentication, CORS
 
 ### Coming Soon 🚧
 
@@ -62,17 +62,15 @@ See the [full roadmap](https://docs.ultimo.dev/roadmap) for upcoming features:
 
 ## 📊 Performance
 
-Ultimo delivers exceptional performance, matching industry-leading frameworks:
+Performance is a headline pillar — measured honestly and regression-guarded, not
+cherry-picked. Ultimo is a thin layer over **Hyper + Tokio**, with **O(1)
+constant-time routing** and a benchmark suite that runs on every PR.
 
-| Framework   | Throughput       | Avg Latency | vs Python      |
-| ----------- | ---------------- | ----------- | -------------- |
-| **Ultimo**  | **158k req/sec** | **0.6ms**   | **15x faster** |
-| Axum (Rust) | 153k req/sec     | 0.6ms       | 15x faster     |
-| Hono (Bun)  | 132k req/sec     | 0.8ms       | 13x faster     |
-| Hono (Node) | 62k req/sec      | 1.6ms       | 6x faster      |
-| FastAPI     | 10k req/sec      | 9.5ms       | baseline       |
-
-**Zero performance penalty** for automatic RPC generation, OpenAPI docs, and client SDK generation.
+Run the micro-benchmarks yourself with `make bench`, and see
+**[docs.ultimo.dev/performance](https://docs.ultimo.dev/performance)** for the
+methodology plus a reproducible `oha` recipe for head-to-head comparisons on your
+own hardware. (We don't publish cloud-VM numbers as if they were controlled
+measurements.)
 
 ## 📚 Documentation
 
@@ -516,7 +514,7 @@ ultimo generate -p ./backend -o ./frontend/src/lib/client.ts
 - **Hybrid API Design**: Support both traditional REST endpoints and RPC-style procedures
 - **Type Safety Everywhere**: From Rust backend to TypeScript frontend with automatic type export
 - **Developer Experience First**: Ergonomic APIs, helpful error messages, minimal boilerplate
-- **Production Ready**: Built-in validation, authentication, rate limiting, file uploads
+- **Production Ready**: Built-in validation, authentication, file uploads
 
 ## Tech Stack Requirements
 
@@ -907,7 +905,7 @@ curl http://localhost:3000/protected -H "Authorization: Bearer token123"
 
 ### Phase 4: Features
 
-10. Built-in middleware (logger, CORS, rate limiting)
+10. Built-in middleware (logger, CORS, security headers)
 11. Validation helpers
 12. File upload support
 13. Authentication guards

--- a/docs-site/docs/pages/index.mdx
+++ b/docs-site/docs/pages/index.mdx
@@ -82,6 +82,6 @@ console.log(user.name); // ✅ Fully type-safe!
 
 ✅ **Single Source of Truth** - Types defined in Rust, auto-sync to TypeScript  
 ✅ **Zero Boilerplate** - No manual API typing or client code  
-✅ **Production Ready** - Built-in validation, auth, rate limiting  
+✅ **Production Ready** - Built-in validation, auth, CORS  
 ✅ **Great DX** - Full IDE autocomplete and type checking  
 ✅ **Performance** - Rust speed with modern async runtime

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -68,7 +68,7 @@ Upcoming features and improvements planned for Ultimo.
 | **OpenAPI Support**       | ✅ Available     | 0.1.0   |
 | **CLI Tools**             | ✅ Available     | 0.1.0   |
 | **CORS**                  | ✅ Available     | 0.1.0   |
-| **Rate Limiting**         | ✅ Available     | 0.1.0   |
+| **Rate Limiting**         | 📋 Planned       | 0.4.0   |
 | **Database Integration**  | ✅ Available     | 0.1.0   |
 | **WebSocket Support**     | ✅ Available     | 0.2.1   |
 | **Sessions & Cookies**    | ✅ Available     | 0.3.0   |


### PR DESCRIPTION
Integrity follow-up to #63. Two corrections to claims that aren't backed by the code:

## 1. Fabricated performance numbers in the README (crates.io landing page)
The README carried the *same* invented benchmarks I just removed from the website — "158k+ req/sec / 0.6ms / 15× faster" in the intro + feature bullet, and a full "📊 Performance" comparison table beating Axum/Hono/FastAPI. On crates.io this is the most-scrutinized surface of all. Replaced with honest, reproducible framing (O(1) routing, Hyper+Tokio, regression-guarded, `make bench` + the `oha` recipe) pointing at docs/performance. README is now clean of fabricated figures.

## 2. Rate limiting claimed as shipped — it isn't
No `rate_limit`/`RateLimiter`/throttle anywhere in `ultimo/src`; builtins are logger, cors, powered_by, server_headers, security_headers. Corrected:
- roadmap Feature Status: **Rate Limiting** ✅ Available 0.1.0 → 📋 Planned 0.4.0 (it's in the security epic's "enhanced rate limiting").
- Dropped "rate limiting" from the README + docs `index.mdx` "built-in" capability one-liners.

## Deeper docs accuracy → filed as #94
`middleware.mdx` documents several non-existent/incorrect APIs (`rate_limit()`, lowercase `cors::new()`, wrong `next()` signature, `ctx.set`/`ctx.res`) and the README has a stale embedded build-spec. That needs a proper rewrite against the real API (with compiling examples), tracked in #94 rather than half-fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)