### PR TITLE
chore(release): v0.4.0 — Security & Performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-08
+
+The **Security & Performance** milestone.
+
+### Added
+
+- **JWT authentication** (`jwt` feature): HS256 verify + sign, algorithm pinned (`alg: none` rejected), `exp` validated, claims on `Context`. (#84)
+- **API-key authentication** (`api-key` feature): pluggable `ApiKeyStore` + built-in `StaticKeys` (SHA-256 hashed, constant-time), resolving to an identity (id + scopes). (#86)
+- **Authorization guards**: unified `auth::Principal`; `ctx.require_auth` / `require_scope` / `require_any_scope` / `require_all_scopes`, fed by both JWT and API-key. (#87)
+- **Security-headers middleware** (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy; opt-in CSP). (#56, #71)
+- **CSRF protection** (`csrf` feature): double-submit cookie, constant-time compare. (#57, #80)
+- **Request body-size limit** (`max_body_size`) — 413 on oversize, without buffering the whole body. (#58, #72)
+- **Real client IP** (`ctx.client_ip`), trusted-proxy aware via `trust_proxy`. (#65, #76)
+- `#![forbid(unsafe_code)]` (100% safe Rust) + `SECURITY.md` disclosure policy. (#69)
+
+### Performance
+
+- **O(1) static route lookup** via a hash index — was O(N) in route count. (#90)
+- **Framework-overhead benchmark suite** (criterion) + `BENCHMARKS.md` methodology + an advisory CI regression check. (#88, #13)
+
+### Docs
+
+- New `/performance`, `/jwt`, `/api-keys`, and `/authorization` pages; an "Authentication" docs group; and an honest "Secure & Fast" website (removed unsubstantiated benchmark numbers).
+
 ## [0.3.0] - 2026-06-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3478,7 +3478,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-08
+
+The **Security & Performance** milestone.
+
+### Added
+
+- **JWT authentication** (`jwt` feature): HS256 verify + sign, algorithm pinned (`alg: none` rejected), `exp` validated, claims on `Context`. (#84)
+- **API-key authentication** (`api-key` feature): pluggable `ApiKeyStore` + built-in `StaticKeys` (SHA-256 hashed, constant-time), resolving to an identity (id + scopes). (#86)
+- **Authorization guards**: unified `auth::Principal`; `ctx.require_auth` / `require_scope` / `require_any_scope` / `require_all_scopes`, fed by both JWT and API-key. (#87)
+- **Security-headers middleware** (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy; opt-in CSP). (#56, #71)
+- **CSRF protection** (`csrf` feature): double-submit cookie, constant-time compare. (#57, #80)
+- **Request body-size limit** (`max_body_size`) — 413 on oversize, without buffering the whole body. (#58, #72)
+- **Real client IP** (`ctx.client_ip`), trusted-proxy aware via `trust_proxy`. (#65, #76)
+- `#![forbid(unsafe_code)]` (100% safe Rust) + `SECURITY.md` disclosure policy. (#69)
+
+### Performance
+
+- **O(1) static route lookup** via a hash index — was O(N) in route count. (#90)
+- **Framework-overhead benchmark suite** (criterion) + `BENCHMARKS.md` methodology + an advisory CI regression check. (#88, #13)
+
+### Docs
+
+- New `/performance`, `/jwt`, `/api-keys`, and `/authorization` pages; an "Authentication" docs group; and an honest "Secure & Fast" website (removed unsubstantiated benchmark numbers).
+
 ## [0.3.0] - 2026-06-04
 
 ### Added

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,7 +12,7 @@
 # Default: do NOT manage packages. Opt the published crates in below.
 release = false
 # Keep CHANGELOG.md updated from Conventional Commits.
-changelog_update = true
+changelog_update = false
 # Create a GitHub Release (with notes) when publishing.
 git_release_enable = true
 dependencies_update = false

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.3.0 Now Available
+          v0.4.0 Now Available
         </div>
 
         <h1 className="text-4xl sm:text-6xl md:text-7xl font-bold tracking-tight mb-6 max-w-4xl text-balance">

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Cuts the **v0.4.0** release (the Security & Performance milestone), overriding release-plz's computed `0.3.1` so the crate version matches the milestone documented across the roadmap, specs, and website.

## ⚠️ Merging this publishes to crates.io
On merge, the release-plz `release` job detects the manifest (0.4.0) ≠ published (0.3.0) and publishes **`ultimo`** + **`ultimo-cli`** to crates.io, tags them, and creates a GitHub Release. (The two crates are independent — `ultimo-cli` doesn't depend on the `ultimo` lib — so no ordering risk.)

## What's in this PR
- Workspace version `0.3.0` → `0.4.0`.
- Finalized **0.4.0 changelog** in `CHANGELOG.md` + `changelog.mdx` (JWT, API-key, authz guards, security headers, CSRF, body limits, client-IP, forbid-unsafe; O(1) routing + benchmark suite; docs/website honesty).
- Synced site versions + hero badge (`version-sync` gate passes).
- **Reconciled the changelog duplication**: set release-plz `changelog_update = false` so the root `CHANGELOG.md` stays the single canonical changelog (release-plz no longer maintains per-crate ones).

## Pre-flight done
- `cargo publish --dry-run -p ultimo` → packages + verifies clean (71 files).
- `scripts/check-versions.sh` → all six version locations match 0.4.0.

After merge/publish I'll close the now-obsolete release-plz PR #70.

> Crates.io still serves the old 0.3.0 README with the fabricated benchmarks — publishing 0.4.0 is what finally replaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)