### PR TITLE
docs(readme): concise, accurate front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,1056 +27,130 @@
 
 ---
 
-A lightweight, **secure**, type-safe Rust web framework with **automatic TypeScript client generation** — built on Hyper + Tokio for native speed and full-stack type safety.
+**Ultimo** is a modern Rust web framework built on **Hyper + Tokio**:
+secure-by-default, fast, and type-safe end to end — with **automatic TypeScript
+client generation** from your Rust API. REST and JSON-RPC live in one app, and
+the framework is 100% safe Rust (`#![forbid(unsafe_code)]`).
 
-## ✨ Key Features
+## Why Ultimo
 
-### Available Now
+- 🚀 **Automatic TypeScript clients** — define your API in Rust, get a fully typed TS client generated for you.
+- 🔄 **REST + JSON-RPC in one app** — plain HTTP routes and RPC procedures side by side.
+- 🔌 **WebSockets** — RFC 6455 with a built-in pub/sub system (zero extra deps).
+- 🔐 **Auth, built in** — JWT and API-key middleware plus scope-based [authorization guards](https://docs.ultimo.dev/authorization).
+- 🛡️ **Secure by default** — 100% safe Rust, secure sessions/cookies, CSRF, security-headers middleware, request body-size limits, and supply-chain CI.
+- ⚡ **Fast** — native Rust on the Hyper + Tokio core, O(1) constant-time routing, benchmarks regression-guarded in CI ([details](https://docs.ultimo.dev/performance)).
+- 🗄️ **Databases** — first-class SQLx and Diesel integration (PostgreSQL / MySQL / SQLite).
+- 🧪 **Testing utilities** — in-process `TestClient`, response assertions, and fixtures.
 
-- ⚡ **Fast** - Native Rust on the Hyper + Tokio core, O(1) constant-time routing, regression-guarded benchmarks ([performance](https://docs.ultimo.dev/performance))
-- 🚀 **Automatic TypeScript Generation** - RPC endpoints automatically generate type-safe TypeScript clients
-- 📋 **OpenAPI Support** - Generate OpenAPI 3.0 specs from your RPC procedures for Swagger UI, Prism, and OpenAPI Generator
-- 🔄 **Hybrid RPC Modes** - Choose between REST (individual endpoints) or JSON-RPC (single endpoint) style
-- 🔌 **WebSocket Support** - Zero-dependency RFC 6455 compliant implementation with built-in pub/sub
-- 🔧 **CLI Tools** - Build, develop, and generate clients with the `ultimo` CLI
-- 🎯 **Hybrid API Design** - Support both REST endpoints and type-safe RPC procedures
-- 🛡️ **Type Safety Everywhere** - From Rust backend to TypeScript frontend
-- 🔒 **100% Safe Rust** - The framework enforces `#![forbid(unsafe_code)]` — zero `unsafe`
-- 🎫 **Sessions & Cookies** - Secure-by-default cookie sessions (HttpOnly/Secure/SameSite, 256-bit ids, anti session-fixation) over a pluggable store
-- 🔑 **JWT Authentication** - HS256 JWT middleware (opt-in `jwt` feature): pins the algorithm (`alg: none` rejected), validates `exp`, attaches claims to the request — sign + verify
-- 🗝️ **API-Key Authentication** - API-key middleware (opt-in `api-key` feature) with a pluggable store; keys are SHA-256 hashed and compared in constant time, resolving to an identity (id + scopes)
-- 🛂 **Authorization Guards** - declare per-route access with `ctx.require_scope(…)` / `require_any_scope` / `require_all_scopes`; works uniformly across JWT and API-key auth via a normalized `Principal`
-- 🧱 **Security Hardening** - Security-headers middleware (HSTS/CSP/…), CSRF protection, request body-size limits, and supply-chain CI (`cargo-audit` + `cargo-deny`)
-- 🧪 **Testing Utilities** - In-process `TestClient`, response assertions, middleware/DB/fixture helpers
-- 🔥 **Developer Experience First** - Ergonomic APIs, helpful errors, minimal boilerplate
-- 💪 **Production Ready** - Built-in validation, authentication, CORS
+## Quick start
 
-### Coming Soon 🚧
-
-See the [full roadmap](https://docs.ultimo.dev/roadmap) for upcoming features:
-
-- ⚡ Performance suite + published benchmarks (the "fast" half of the pitch)
-- 📡 Streaming & SSE
-- 🌍 Multi-language Client Generation
-- And more...
-
-## 📊 Performance
-
-Performance is a headline pillar — measured honestly and regression-guarded, not
-cherry-picked. Ultimo is a thin layer over **Hyper + Tokio**, with **O(1)
-constant-time routing** and a benchmark suite that runs on every PR.
-
-Run the micro-benchmarks yourself with `make bench`, and see
-**[docs.ultimo.dev/performance](https://docs.ultimo.dev/performance)** for the
-methodology plus a reproducible `oha` recipe for head-to-head comparisons on your
-own hardware. (We don't publish cloud-VM numbers as if they were controlled
-measurements.)
-
-## 📚 Documentation
-
-> **📖 [Complete documentation available at docs.ultimo.dev →](https://docs.ultimo.dev)**
->
-> Comprehensive guides covering:
->
-> - Getting Started & Installation
-> - Routing & Middleware
-> - RPC System & TypeScript Clients
-> - OpenAPI Support
-> - Database Integration (SQLx/Diesel)
-> - Testing Patterns
-> - CLI Tools
-> - And more...
-
-## 🎯 Quick Examples
-
-## Quick Start
-
-### Simple REST API
-
-Create a basic REST API with routes and JSON responses:
+```toml
+[dependencies]
+ultimo = "0.4"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+```
 
 ```rust
 use ultimo::prelude::*;
-use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct User {
     id: u32,
     name: String,
-    email: String,
-}
-
-#[derive(Deserialize)]
-struct CreateUserInput {
-    name: String,
-    email: String,
 }
 
 #[tokio::main]
 async fn main() -> ultimo::Result<()> {
     let mut app = Ultimo::new();
 
-    // GET /users - List all users
-    app.get("/users", |ctx: Context| async move {
-        let users = vec![
-            User { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
-            User { id: 2, name: "Bob".to_string(), email: "bob@example.com".to_string() },
-        ];
-        ctx.json(users).await
-    });
-
-    // GET /users/:id - Get user by ID
     app.get("/users/:id", |ctx: Context| async move {
-        let id: u32 = ctx.param("id")?.parse()?;
-        let user = User {
-            id,
-            name: format!("User {}", id),
-            email: format!("user{}@example.com", id),
-        };
-        ctx.json(user).await
+        let id: u32 = ctx
+            .req
+            .param("id")?
+            .parse()
+            .map_err(|_| UltimoError::BadRequest("invalid id".into()))?;
+        ctx.json(User { id, name: format!("User {id}") }).await
     });
 
-    // POST /users - Create new user
-    app.post("/users", |ctx: Context| async move {
-        let input: CreateUserInput = ctx.req.json().await?;
-        let user = User {
-            id: 3,
-            name: input.name,
-            email: input.email,
-        };
-        ctx.json(user).await
-    });
-
-    println!("🚀 Server running on http://127.0.0.1:3000");
+    println!("→ http://127.0.0.1:3000");
     app.listen("127.0.0.1:3000").await
 }
 ```
 
-Test it:
+> **MSRV:** Rust 1.86. Everything beyond the core is opt-in via Cargo features (see below).
+
+## Type-safe clients
+
+Ultimo's headline feature: define an API once in Rust and generate a typed
+TypeScript client — no hand-written types, no drift.
 
 ```bash
-# List users
-curl http://localhost:3000/users
-
-# Get specific user
-curl http://localhost:3000/users/1
-
-# Create user
-curl -X POST http://localhost:3000/users \
-  -H "Content-Type: application/json" \
-  -d '{"name":"Charlie","email":"charlie@example.com"}'
+# Generate a TypeScript client from your RPC definitions
+cargo run -p ultimo-cli -- generate --path ./src --output ./client
 ```
 
-### 1. Add Ultimo to your project
+```typescript
+// Generated, fully typed — autocomplete + compile-time checks
+const user = await client.getUser({ id: 1 });
+console.log(user.name);
+```
+
+See [TypeScript Clients](https://docs.ultimo.dev/typescript) for the full workflow.
+
+## Feature flags
+
+Everything is opt-in (`default = []`):
+
+| Feature | What it enables |
+|---|---|
+| `websocket` | RFC 6455 WebSocket support + pub/sub |
+| `session` | Cookie-based session management |
+| `jwt` | JWT authentication middleware (HS256) |
+| `api-key` | API-key authentication with a pluggable store |
+| `csrf` | CSRF protection (double-submit cookie) |
+| `testing` | In-process `TestClient`, assertions, fixtures |
+| `test-helpers` | WebSocket test helpers (for integration tests) |
+| `sqlx-postgres` · `sqlx-mysql` · `sqlx-sqlite` | SQLx integration per backend |
+| `diesel-postgres` · `diesel-mysql` · `diesel-sqlite` | Diesel integration per backend |
 
 ```toml
-[dependencies]
-ultimo = "0.3"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-
-# Optional features:
-# ultimo = { version = "0.3", features = ["websocket", "session", "sqlx-postgres"] }
+ultimo = { version = "0.4", features = ["websocket", "jwt", "sqlx-postgres"] }
 ```
 
-### 2. Create your API with RPC
-
-Ultimo supports two RPC modes:
-
-#### REST Mode (Individual Endpoints)
-
-```rust
-use ultimo::prelude::*;
-use ultimo::rpc::RpcMode;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let mut app = Ultimo::new();
-
-    // Create RPC registry in REST mode
-    let rpc = RpcRegistry::new_with_mode(RpcMode::Rest);
-
-    // Register query (will use GET)
-    rpc.query(
-        "getUser",
-        |input: GetUserInput| async move {
-            Ok(User {
-                id: input.id,
-                name: "Alice".to_string(),
-                email: "alice@example.com".to_string(),
-            })
-        },
-        "{ id: number }".to_string(),
-        "User".to_string(),
-    );
-
-    // Register mutation (will use POST)
-    rpc.mutation(
-        "createUser",
-        |input: CreateUserInput| async move {
-            Ok(User { /* ... */ })
-        },
-        "{ name: string; email: string }".to_string(),
-        "User".to_string(),
-    );
-
-    // Generate TypeScript client with REST endpoints
-    rpc.generate_client_file("../frontend/src/lib/ultimo-client.ts")?;
-
-    // Mount individual endpoints
-    app.get("/api/getUser", /* handler */);
-    app.post("/api/createUser", /* handler */);
-
-    app.listen("127.0.0.1:3000").await
-}
-```
-
-#### JSON-RPC Mode (Single Endpoint)
-
-```rust
-use ultimo::prelude::*;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let mut app = Ultimo::new();
-
-    // Create RPC registry (JSON-RPC is default)
-    let rpc = RpcRegistry::new();
-
-    // Register procedures
-    rpc.register_with_types(
-        "getUser",
-        |input: GetUserInput| async move {
-            Ok(User {
-                id: input.id,
-                name: "Alice".to_string(),
-                email: "alice@example.com".to_string(),
-            })
-        },
-        "{ id: number }".to_string(),
-        "User".to_string(),
-    );
-
-    // Generate TypeScript client
-    rpc.generate_client_file("../frontend/src/lib/ultimo-client.ts")?;
-
-    // Single RPC endpoint
-    app.post("/rpc", move |ctx: Context| {
-        let rpc = rpc.clone();
-        async move {
-            let req: RpcRequest = ctx.req.json().await?;
-            let result = rpc.call(&req.method, req.params).await?;
-            ctx.json(result).await
-        }
-    });
-
-    app.listen("127.0.0.1:3000").await
-}
-```
-
-**When to use each mode:**
-
-- **REST Mode**: Public APIs, HTTP caching important, clear URLs in browser DevTools
-- **JSON-RPC Mode**: Internal APIs, simple routing, easy request batching
-
-[Learn more about RPC →](https://docs.ultimo.dev/rpc)
-
-### 3. Use the generated TypeScript client
-
-The generated client works the same way regardless of RPC mode:
-
-```typescript
-import { UltimoRpcClient } from "./lib/ultimo-client";
-
-// REST mode: client uses GET/POST to /api/getUser, /api/createUser
-// JSON-RPC mode: client uses POST to /rpc with method dispatch
-const client = new UltimoRpcClient(); // Uses appropriate base URL
-
-// Same API for both modes - fully type-safe!
-const user = await client.getUser({ id: 1 });
-console.log(user.name); // ✅ TypeScript autocomplete works!
-
-const newUser = await client.createUser({
-  name: "Bob",
-  email: "bob@example.com",
-});
-```
-
-### 4. Generate OpenAPI Specification
-
-Automatically generate OpenAPI 3.0 specs from your RPC procedures:
-
-```rust
-use ultimo::prelude::*;
-use ultimo::rpc::RpcMode;
-
-let rpc = RpcRegistry::new_with_mode(RpcMode::Rest);
-
-// Register procedures
-rpc.query("getUser", handler, "{ id: number }", "User");
-rpc.mutation("createUser", handler, "{ name: string }", "User");
-
-// Generate OpenAPI spec
-let openapi = rpc.generate_openapi("My API", "1.0.0", "/api");
-openapi.write_to_file("openapi.json")?;
-```
-
-**Use with external tools:**
+## CLI
 
 ```bash
-# View in Swagger UI
-docker run -p 8080:8080 -e SWAGGER_JSON=/openapi.json \
-  -v $(pwd)/openapi.json:/openapi.json swaggerapi/swagger-ui
+cargo install ultimo-cli   # installs the `ultimo` binary
 
-# Run Prism mock server
-npx @stoplight/prism-cli mock openapi.json
-
-# Generate clients in any language
-npx @openapitools/openapi-generator-cli generate \
-  -i openapi.json -g typescript-fetch -o ./client
+ultimo new my-app --template fullstack         # scaffold a new project
+ultimo generate --path ./src --output ./client # generate the TypeScript client
+ultimo build --profile release                 # production build
 ```
 
-[Learn more about OpenAPI →](https://docs.ultimo.dev/openapi)
+> `ultimo dev` (hot-reload dev server) is experimental — see the [roadmap](https://docs.ultimo.dev/roadmap).
 
-## 🔧 CLI Tools
+## Documentation
 
-Install the Ultimo CLI:
+Full guides at **[docs.ultimo.dev](https://docs.ultimo.dev)** — getting started,
+routing, middleware, RPC + TypeScript clients, OpenAPI, sessions, authentication,
+WebSockets, database integration, testing, and [performance](https://docs.ultimo.dev/performance).
+
+## Examples
+
+Runnable examples live in [`examples/`](https://github.com/ultimo-rs/ultimo/tree/main/examples)
+— including `session-auth` and `jwt-auth` full-stack demos. Run one with:
 
 ```bash
-cargo install --path ultimo-cli
+cargo run -p jwt-auth-example
 ```
 
-### Generate TypeScript Client
+## Contributing
 
-```bash
-# Generate client from your Rust backend
-ultimo generate --project ./backend --output ./frontend/src/lib/client.ts
+Issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[roadmap](https://docs.ultimo.dev/roadmap). Security policy: [SECURITY.md](SECURITY.md).
 
-# Short form
-ultimo generate -p ./backend -o ./frontend/src/client.ts
-```
+## License
 
-### Coming Soon
-
-```bash
-ultimo new my-app --template fullstack  # Create new project
-ultimo dev --port 3000                   # Development server with hot reload
-ultimo build --profile release           # Production build
-```
-
-[Learn more about CLI →](https://docs.ultimo.dev/cli)
-
-## 📦 Installation & Demo
-
-### Quick Demo
-
-Run the included demo script to see everything in action:
-
-```bash
-./demo.sh
-```
-
-This will:
-
-1. Build the Ultimo CLI
-2. Start the backend server (auto-generates TypeScript client)
-3. Test RPC endpoints
-4. Verify generated client
-5. Demonstrate CLI usage
-
-### Manual Installation
-
-```bash
-# Install CLI
-./install-cli.sh
-
-# Or build manually
-cargo build --release --manifest-path ultimo-cli/Cargo.toml
-
-# Verify installation
-ultimo --help
-```
-
-### Run Examples
-
-```bash
-# Backend with auto-generation
-cd examples/react-backend
-cargo run --release
-
-# Frontend
-cd examples/react-app
-npm install
-npm run dev
-
-# Generate client manually
-ultimo generate -p ./examples/react-backend -o /tmp/client.ts
-```
-
-## 🔄 Complete Workflow
-
-### Backend (Rust)
-
-```rust
-use ultimo::prelude::*;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let mut app = Ultimo::new();
-    let rpc = RpcRegistry::new();
-
-    // 1. Register RPC procedures with TypeScript types
-    rpc.register_with_types(
-        "listUsers",
-        |_params: ()| async move {
-            Ok(json!({"users": [...], "total": 2}))
-        },
-        "{}".to_string(),
-        "{ users: User[]; total: number }".to_string(),
-    );
-
-    // 2. Auto-generate TypeScript client on startup
-    rpc.generate_client_file("../frontend/src/lib/ultimo-client.ts")?;
-    println!("✅ TypeScript client generated");
-
-    // 3. Add RPC endpoint
-    app.post("/rpc", move |mut c: Context| {
-        let rpc = rpc.clone();
-        async move {
-            let req: RpcRequest = c.req.json().await?;
-            let result = rpc.call(&req.method, req.params).await?;
-            c.json(RpcResponse { result })
-        }
-    });
-
-    app.listen("127.0.0.1:3000").await
-}
-```
-
-### Frontend (TypeScript/React)
-
-```typescript
-// src/lib/ultimo-client.ts - Auto-generated, don't edit!
-export class UltimoRpcClient {
-  async listUsers(params: {}): Promise<{ users: User[]; total: number }> {
-    return this.call("listUsers", params);
-  }
-}
-
-// src/App.tsx - Use the generated client
-import { UltimoRpcClient } from "./lib/ultimo-client";
-import { useQuery } from "@tanstack/react-query";
-
-const client = new UltimoRpcClient("/api/rpc");
-
-function UserList() {
-  const { data } = useQuery({
-    queryKey: ["users"],
-    queryFn: () => client.listUsers({}), // ✅ Fully type-safe!
-  });
-
-  return (
-    <div>
-      {data?.users.map((user) => (
-        <div key={user.id}>{user.name}</div>
-      ))}
-    </div>
-  );
-}
-```
-
-### Development Flow
-
-```bash
-# Terminal 1: Start backend (auto-generates client)
-cd backend
-cargo run --release
-# ✅ TypeScript client generated
-
-# Terminal 2: Start frontend
-cd frontend
-npm run dev
-
-# Terminal 3: Regenerate client manually if needed
-ultimo generate -p ./backend -o ./frontend/src/lib/client.ts
-```
-
-### Benefits
-
-✅ **Single Source of Truth** - Types defined in Rust, automatically propagate to TypeScript  
-✅ **No Manual Typing** - TypeScript types generated automatically from Rust  
-✅ **Type Safety** - Catch API mismatches at compile time  
-✅ **Great DX** - Full IDE autocomplete and type checking  
-✅ **Zero Maintenance** - Client updates automatically when backend changes
-
-## Core Philosophy
-
-- **Hybrid API Design**: Support both traditional REST endpoints and RPC-style procedures
-- **Type Safety Everywhere**: From Rust backend to TypeScript frontend with automatic type export
-- **Developer Experience First**: Ergonomic APIs, helpful error messages, minimal boilerplate
-- **Production Ready**: Built-in validation, authentication, file uploads
-
-## Tech Stack Requirements
-
-- **Runtime**: Tokio for async execution
-- **HTTP Server**: Hyper for high-performance HTTP handling
-- **Serialization**: Serde for JSON handling
-- **Validation**: validator crate for request validation
-- **File Uploads**: multer for multipart form data
-- **Type Export**: ts-rs for TypeScript type generation
-- **Logging**: tracing for structured logging
-- **Testing**: tokio-test for async testing utilities
-
-## Minimum Supported Rust Version (MSRV)
-
-- Rust 1.75.0 or higher
-
-## Project Structure
-
-```
-ultimo-rs/
-├── Cargo.toml (workspace)
-├── ultimo/
-│   ├── Cargo.toml
-│   └── src/
-│       ├── lib.rs (public API)
-│       ├── app.rs (main application)
-│       ├── context.rs (request/response context)
-│       ├── error.rs (error handling)
-│       ├── response.rs (response builder)
-│       ├── router.rs (routing engine)
-│       ├── handler.rs (handler traits)
-│       ├── middleware.rs (middleware system)
-│       ├── validation.rs (validation helpers)
-│       ├── upload.rs (file upload handling)
-│       ├── guard.rs (authentication guards)
-│       └── rpc.rs (RPC system)
-└── examples/
-    └── basic/
-        └── src/main.rs
-```
-
-## Feature Requirements
-
-### 1. Error Handling System
-
-Create a comprehensive error system that returns structured JSON responses with proper HTTP status codes. Support validation errors with field-level details, authentication errors, authorization errors, and general HTTP errors.
-
-### 2. Response Builder (via Context)
-
-Provide response methods directly on Context (like Hono's `c.json()`, `c.text()`, `c.html()`). Support for JSON, text, HTML, redirects, custom headers, and status codes. Methods should be chainable where appropriate.
-
-### 3. Request Context
-
-Wrap incoming HTTP requests with a context object that provides:
-
-- Easy access via `c.req.param()` for path parameters
-- `c.req.query()` for query parameters
-- `c.req.json()`, `c.req.text()`, `c.req.parse_body()` for request bodies
-- `c.req.header()` for headers
-- `c.set()` / `c.get()` for passing values between middleware
-- Response methods: `c.json()`, `c.text()`, `c.html()`, `c.redirect()`
-- `c.status()` and `c.header()` for setting response metadata
-
-### 4. Fast Router
-
-Implement efficient path-based routing with support for:
-
-- Static paths (`/users`)
-- Path parameters (`/users/:id`)
-- Multiple parameters (`/users/:userId/posts/:postId`)
-- HTTP method matching (GET, POST, PUT, DELETE, etc.)
-
-### 5. Handler System
-
-Create a trait-based system for request handlers that supports async functions. Handlers receive a Context and return a Result<Response>.
-
-### 6. Middleware Chain
-
-Implement composable middleware that can:
-
-- Execute before and after handlers via `next()` await point
-- Access and modify context with `c.set()` / `c.get()`
-- Short-circuit by returning early without calling `next()`
-- Access response after handler via `await next()` then modify `c.res`
-- Include built-in middleware for:
-  - Logging (request/response details)
-  - CORS (configurable origins, methods, headers)
-  - Request timing
-
-### 7. Request Validation
-
-Integrate with the validator crate to provide automatic request body validation with custom error messages. Convert validation failures into structured JSON error responses.
-
-### 8. File Upload Handling
-
-Support multipart form data parsing with:
-
-- Automatic separation of files and text fields
-- File metadata (name, size, content type)
-- Easy saving to disk
-- Type checking helpers (is_image, is_pdf, etc.)
-
-### 9. Authentication Guards
-
-Create a guard system for protecting routes with:
-
-- Bearer token authentication (validate tokens from Authorization header)
-- API key authentication (validate X-API-Key header)
-- Custom guard implementations via trait
-- Composable guards using middleware pattern
-  - Multiple guards execute in order (AND logic by default)
-  - Early return on first failure
-  - Can implement OR logic via custom guard composition
-
-### 10. Rate Limiting
-
-Implement rate limiting middleware with:
-
-- Time-window based limiting (sliding window algorithm)
-- Per-client tracking (identified by IP address from socket)
-- Configurable limits (requests per window duration)
-- In-memory storage with automatic cleanup via background task
-- Returns 429 (Too Many Requests) when limit exceeded
-
-### 11. RPC System
-
-Build a type-safe RPC system where:
-
-- Procedures have strongly-typed inputs and outputs
-- Automatic JSON serialization/deserialization
-- Automatic TypeScript type export (via ts-rs)
-- RPC endpoints accessible at `/rpc/{procedure-name}` (POST method)
-- TypeScript types exported to `./bindings/` directory
-- Support for nested namespaces: `/rpc/{namespace}.{procedure}`
-
-### 12. Main Application
-
-Tie everything together in an Ultimo struct that:
-
-- Manages routes and middleware
-- Starts an HTTP server
-- Handles incoming requests
-- Applies middleware chain
-- Routes to appropriate handlers
-- Returns structured error responses on failures
-
-## API Design Patterns
-
-### Simple Route Definition (Hono-style)
-
-```rust
-use ultimo::prelude::*;
-
-// GET request with JSON response
-app.get("/users", |c| async move {
-    c.json(json!({"users": ["Alice", "Bob"]}))
-});
-
-// Path parameters
-app.get("/users/:id", |c| async move {
-    let id = c.req.param("id")?;
-    c.json(json!({"id": id}))
-});
-
-// Query parameters
-app.get("/search", |c| async move {
-    let q = c.req.query("q")?;
-    c.json(json!({"query": q}))
-});
-```
-
-### Request Body Parsing
-
-```rust
-#[derive(Deserialize, Validate, TS)]
-#[ts(export)]
-struct CreateUser {
-    #[validate(length(min = 3, max = 50))]
-    name: String,
-    #[validate(email)]
-    email: String,
-}
-
-app.post("/users", |mut c| async move {
-    // Parse and validate in one step
-    let input: CreateUser = c.req.json().await?;
-    validate(&input)?;
-
-    // Use the validated data
-    let user = create_user(input);
-    c.status(201);
-    c.json(user)
-});
-```
-
-### Middleware Usage
-
-```rust
-use ultimo::middleware::{logger, cors};
-
-// Global middleware
-app.use_middleware(logger());
-app.use_middleware(cors::new()
-    .allow_origin("https://example.com")
-    .allow_methods(vec!["GET", "POST"]));
-
-// Custom middleware
-app.use_middleware(|c, next| async move {
-    c.set("request_id", generate_id());
-    let start = Instant::now();
-
-    next().await?;
-
-    let duration = start.elapsed();
-    c.res.headers.append("X-Response-Time", duration.as_millis().to_string());
-    Ok(())
-});
-```
-
-### Authentication Guards
-
-```rust
-use ultimo::guards::{bearer_auth, api_key_auth};
-
-// Protect specific routes
-let auth = bearer_auth(vec!["secret_token_123"]);
-
-app.get("/protected", auth, |c| async move {
-    c.json(json!({"message": "You are authenticated!"}))
-});
-
-// Or use as middleware for a group
-app.use_middleware(api_key_auth(vec!["api_key_123"]));
-```
-
-### File Uploads
-
-```rust
-app.post("/upload", |mut c| async move {
-    let form_data = c.req.parse_body().await?;
-
-    for (field_name, file) in form_data.files {
-        if file.is_image() {
-            let path = format!("./uploads/{}", file.name);
-            file.save(&path).await?;
-        }
-    }
-
-    c.json(json!({"uploaded": form_data.files.len()}))
-});
-```
-
-### RPC Procedures
-
-```rust
-#[derive(Deserialize, TS)]
-#[ts(export)]
-struct CalculateInput {
-    a: i32,
-    b: i32,
-}
-
-#[derive(Serialize, TS)]
-#[ts(export)]
-struct CalculateOutput {
-    result: i32,
-}
-
-app.rpc("calculate", |input: CalculateInput| async move {
-    Ok(CalculateOutput {
-        result: input.a + input.b,
-    })
-});
-
-// Access at: POST /rpc/calculate
-// TypeScript types auto-generated in ./bindings/
-```
-
-### Sharing Data Between Middleware
-
-```rust
-// Set data in middleware
-app.use_middleware(|c, next| async move {
-    let user = authenticate(&c).await?;
-    c.set("user", user);
-    next().await
-});
-
-// Access in handler
-app.get("/profile", |c| async move {
-    let user: User = c.get("user")?;
-    c.json(user)
-});
-```
-
-## Expected Behavior
-
-### Error Responses
-
-All errors return JSON with structure:
-
-```json
-{
-  "error": "Error Type",
-  "message": "Human readable message",
-  "details": [] // Optional, for validation errors
-}
-```
-
-### Path Parameter Matching
-
-- `/users/:id` matches `/users/123` → `{id: "123"}`
-- `/users/:userId/posts/:postId` matches `/users/1/posts/2` → `{userId: "1", postId: "2"}`
-
-### Middleware Execution
-
-Middleware executes in order, each can call next() to continue the chain or return early to short-circuit.
-
-### Rate Limiting
-
-Track requests per client within a time window. Reject requests exceeding the limit with 429 (Too Many Requests) status code.
-
-### TypeScript Export
-
-Types decorated with `#[ts(export)]` automatically generate `.ts` files in the `./bindings/` directory for frontend use.
-
-## Quality Requirements
-
-- **Type Safety**: Leverage Rust's type system fully
-- **Async Throughout**: All I/O operations must be async
-- **Error Handling**: Use Result types, avoid panics
-- **Documentation**: Public APIs need doc comments
-- **Testing**: Include unit tests for core logic
-- **Performance**: Efficient routing and minimal allocations
-
-## Success Criteria
-
-When complete, this code should work:
-
-```rust
-#[tokio::main]
-async fn main() -> ultimo::Result<()> {
-    let mut app = Ultimo::new();
-
-    app.use_middleware(ultimo::middleware::logger());
-
-    app.get("/", |ctx| async move {
-        Ok(Context::json(json!({"message": "Hello Ultimo!"}))?)
-    });
-
-    app.post("/users", |mut ctx| async move {
-        let input: CreateUser = ctx.req.json().await?;
-        validate(&input)?;
-        Ok(Context::json(create_user(input))?)
-    });
-
-    app.listen("127.0.0.1:3000").await
-}
-```
-
-And support curl commands like:
-
-```bash
-curl http://localhost:3000/
-curl -X POST http://localhost:3000/users -H "Content-Type: application/json" -d '{"name":"Alice"}'
-curl http://localhost:3000/protected -H "Authorization: Bearer token123"
-```
-
-## Implementation Guidelines
-
-### Phase 1: Core Types
-
-1. Error types and Result alias
-2. Response builder (used internally by Context)
-3. Request wrapper (HonoRequest-style)
-
-### Phase 2: Context & Router
-
-4. Context with request/response methods (c.json(), c.text(), etc.)
-5. Router with path matching and parameter extraction
-6. Handler trait for async functions
-
-### Phase 3: Middleware & App
-
-7. Middleware trait and chain execution
-8. Main Ultimo app struct
-9. HTTP server integration with Hyper
-
-### Phase 4: Features
-
-10. Built-in middleware (logger, CORS, security headers)
-11. Validation helpers
-12. File upload support
-13. Authentication guards
-14. RPC system with TypeScript export
-
-### Phase 5: Polish
-
-15. Comprehensive examples
-16. Documentation with examples
-17. Unit and integration tests
-
-## Design Principles
-
-- **Hono.js-inspired API**: Method names and patterns match Hono.js (c.json(), c.req.param(), etc.)
-- **Type Safety**: Leverage Rust's type system, use generics for flexibility
-- **Async First**: All I/O operations are async, handlers return futures
-- **Zero Panics**: Use Result types throughout, no unwrap() in library code
-- **Composability**: Middleware and guards can be chained and combined
-- **Error Messages**: Provide helpful, actionable error messages
-- **Performance**: Efficient routing, minimal allocations, lazy evaluation where possible
-
-Focus on clean abstractions and excellent developer experience. The framework should feel natural to Rust developers while being immediately familiar to those coming from Hono.js or Express.
-
-## Development
-
-This project uses [Moonrepo](https://moonrepo.dev/) for monorepo management. See [MOONREPO.md](./docs/MOONREPO.md) for detailed commands.
-
-**Quick Start:**
-
-```bash
-# Install Moonrepo
-curl -fsSL https://moonrepo.dev/install/moon.sh | bash
-
-# Install git hooks (recommended)
-./scripts/install-hooks.sh
-
-# Build core framework
-moon run ultimo:build
-
-# Run all tests
-moon run :test
-
-# Check code quality
-moon run ultimo:clippy
-
-# Build documentation
-moon run docs-site:build
-```
-
-### Git Hooks
-
-We provide pre-commit and pre-push hooks to ensure code quality:
-
-```bash
-# Install hooks
-./scripts/install-hooks.sh
-```
-
-**What the hooks do:**
-
-- **pre-commit**: Checks code formatting with `cargo fmt`
-- **pre-push**: Runs tests, clippy, and verifies coverage threshold (60%)
-
-### Testing & Coverage
-
-The Ultimo framework maintains **high test coverage standards** with a custom coverage tool built for **security and transparency**.
-
-#### Why Custom Coverage Tool?
-
-We built **ultimo-coverage** instead of using external tools because:
-
-- 🔒 **Security First**: External tools with low GitHub adoption (< 500 stars) posed trust concerns
-- 🎯 **Project-Only Coverage**: Filters out dependency code for accurate metrics
-- 🔍 **Transparent**: Simple 200-line Rust tool with only 3 dependencies
-- ⚡ **Fast**: Uses Rust's built-in LLVM instrumentation directly
-- 🛠️ **Maintainable**: Full control over coverage reporting and thresholds
-
-#### Quick Start
-
-```bash
-# Run tests with coverage report
-cargo coverage
-
-# Or use make
-make coverage
-
-# View HTML report (modern UI with Tailwind CSS)
-open target/coverage/html/index.html
-```
-
-#### Current Coverage Stats
-
-**Overall: 63.58%** ✅ (exceeds 60% minimum threshold)
-
-| Module         | Coverage | Status        |
-| -------------- | -------- | ------------- |
-| database/error | 100%     | ✅ Excellent  |
-| validation     | 95.12%   | ✅ Excellent  |
-| response       | 92.35%   | ✅ Excellent  |
-| rpc            | 85.07%   | ✅ Excellent  |
-| router         | 82.41%   | ✅ Excellent  |
-| openapi        | 76.21%   | ✅ Good       |
-| context        | 40.18%   | ⚠️ Improved   |
-| app            | 25.62%   | ⚠️ Needs work |
-
-**Test Stats:**
-
-- 89 unit tests across all modules
-- All critical paths tested
-- Comprehensive middleware, RPC, and OpenAPI coverage
-
-#### Coverage Standards
-
-- ✅ **Minimum 60% overall coverage required**
-- ✅ **Core modules (router, RPC, OpenAPI) target 70%+**
-- ✅ **All new features must include tests**
-- ✅ **CI fails if coverage drops below threshold**
-
-#### Coverage Tool Details
-
-**ultimo-coverage** is our custom LLVM-based coverage tool:
-
-```bash
-# How it works
-cd coverage-tool
-cargo build --release
-
-# The tool:
-# 1. Instruments code with LLVM coverage
-# 2. Runs tests and collects profiling data
-# 3. Merges .profraw files with llvm-profdata
-# 4. Generates reports with llvm-cov
-# 5. Filters out dependency code (.cargo/registry, .rustup)
-```
-
-**Why it's trustworthy:**
-
-- ✅ Only 3 dependencies (serde, serde_json, walkdir)
-- ✅ Uses Rust's official LLVM tools (bundled with rustc)
-- ✅ Auditable source code (~200 lines)
-- ✅ No network access or external data collection
-- ✅ Generates local HTML/JSON reports only
-
-**Key Features:**
-
-- 📊 HTML report with line-by-line coverage
-- 📈 JSON output for CI integration
-- 🎯 Filters dependency coverage automatically
-- 🚀 Fast incremental builds
-- 🔄 Cross-platform (macOS, Linux, Windows)
-- 🎨 **Modern UI with Tailwind CSS** - Beautiful, color-coded coverage visualization
-
-#### For Contributors
-
-Run tests before submitting PRs:
-
-```bash
-# Run all tests
-cargo test --lib
-
-# Check coverage
-cargo coverage
-
-# Ensure coverage meets standards
-# Overall must be ≥60%, new code should increase coverage
-```
-
-**Project Structure:**
-
-- `ultimo/` - Core framework
-- `ultimo-cli/` - CLI tool for project scaffolding and TypeScript generation
-- `examples/` - Example projects demonstrating features
-- `docs-site/` - Documentation website (Vocs)
-- `scripts/` - Development and testing scripts
+MIT © Ultimo Contributors. See [LICENSE](LICENSE).

--- a/docs/superpowers/plans/2026-06-08-readme-cleanup.md
+++ b/docs/superpowers/plans/2026-06-08-readme-cleanup.md
@@ -1,0 +1,115 @@
+# README Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Single-file editorial rewrite — the "tests" are grep assertions + a compile-check of the quick-start snippet.
+
+**Goal:** Replace the 1082-line `README.md` with a concise, accurate front-door README (~200–250 lines): keep the user-facing top, delete the embedded build-spec, fix every API/version inaccuracy.
+
+**Architecture:** One file rewrite of `README.md` to the 8-section structure in the spec. Verify by grepping for stale/fictional strings and by compiling the quick-start example against the real 0.4.0 API.
+
+**Tech Stack:** Markdown; the real `ultimo` 0.4.0 public API.
+
+---
+
+## Task 1: Rewrite README.md
+
+**Files:** Modify `README.md` (full rewrite, preserving the existing logo + badge block at the top).
+
+- [ ] **Step 1: Preserve the header.** Keep the existing `<div align="center">` logo + badge row + nav links block (lines ~1–28) verbatim — those are correct.
+
+- [ ] **Step 2: Replace everything from the intro down** with the 8 sections from the spec (`docs/superpowers/specs/2026-06-08-readme-cleanup-design.md`): intro → Why Ultimo → Quick start → Type-safe clients → Feature flags → CLI → Docs/Examples/Contributing/License. **Delete** Core Philosophy, Tech Stack Requirements, standalone MSRV section, Project Structure, and the entire "Feature Requirements" build-spec (### 1–11) and everything after it that is build-spec/duplicate.
+
+- [ ] **Step 3: The quick-start code block MUST be this (compiles against 0.4.0 — note `ctx.req.param`, explicit parse error mapping):**
+
+````markdown
+```rust
+use ultimo::prelude::*;
+
+#[derive(Serialize, Deserialize)]
+struct User {
+    id: u32,
+    name: String,
+}
+
+#[tokio::main]
+async fn main() -> ultimo::Result<()> {
+    let mut app = Ultimo::new();
+
+    app.get("/users/:id", |ctx: Context| async move {
+        let id: u32 = ctx
+            .req
+            .param("id")?
+            .parse()
+            .map_err(|_| UltimoError::BadRequest("invalid id".into()))?;
+        ctx.json(User { id, name: format!("User {id}") }).await
+    });
+
+    println!("→ http://127.0.0.1:3000");
+    app.listen("127.0.0.1:3000").await
+}
+```
+````
+
+Install snippet uses `ultimo = "0.4"`; mention **MSRV 1.86** in one line near Quick start.
+
+- [ ] **Step 4: Feature-flags section — the real opt-in list:**
+  `websocket`, `session`, `jwt`, `api-key`, `csrf`, `testing`, `test-helpers`,
+  `sqlx-postgres` / `sqlx-mysql` / `sqlx-sqlite`, `diesel-postgres` / `diesel-mysql` / `diesel-sqlite` (all `default = []`).
+
+- [ ] **Step 5: CLI section — real subcommands only:**
+  `ultimo new <name> --template <...>`, `ultimo generate --path <dir> --output <dir> [--watch]`, `ultimo build --profile <debug|release>`. Note `ultimo dev` is experimental (hot-reload is on the roadmap). No fabricated flags.
+
+- [ ] **Step 6: "Why Ultimo" bullets — true claims only:** automatic TypeScript client generation; REST + JSON-RPC in one app; WebSocket + pub/sub; auth (JWT, API-key, scope guards) + security hardening (safe Rust, sessions, CSRF, security headers); O(1) routing; SQLx/Diesel integration. **No** throughput numbers (link to docs `/performance`). **No** file uploads (not implemented).
+
+- [ ] **Step 7: Commit.**
+```bash
+git add README.md
+git commit -m "docs(readme): trim to a concise, accurate front door (closes #94)"
+```
+
+---
+
+## Task 2: Verify accuracy
+
+**Files:** none (assertions)
+
+- [ ] **Step 1: No stale/fictional strings remain.** Run:
+```bash
+grep -nE "1\.75|version = \"0\.3\"|ultimo = \"0\.3\"|ctx\.param\(|bearer_auth|rate_limit|upload|c\.res|158|152|0\.6ms|15x|req/sec" README.md || echo "CLEAN"
+```
+Expected: `CLEAN` (or only legitimate prose, e.g. the word "upload" must NOT appear as a claimed feature).
+
+- [ ] **Step 2: Compile-check the quick-start snippet** against the real API by dropping it into a scratch binary in the workspace and checking it builds:
+```bash
+mkdir -p /tmp/ultimo-readme-check/src
+cat > /tmp/ultimo-readme-check/Cargo.toml <<'EOF'
+[package]
+name = "readme-check"
+version = "0.0.0"
+edition = "2021"
+[dependencies]
+ultimo = { path = "REPLACE_WITH_ABS_PATH/ultimo" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+EOF
+# copy the quick-start main.rs into src/main.rs, then:
+cargo check --manifest-path /tmp/ultimo-readme-check/Cargo.toml
+```
+Expected: compiles. (Alternatively, paste the snippet into `examples/basic` temporarily and `cargo check -p basic`, then revert.) If it doesn't compile, fix the README snippet and re-check.
+
+- [ ] **Step 3: Line count sanity.** `wc -l README.md` → roughly 150–260 lines (down from 1082).
+
+---
+
+## Task 3: Ship
+
+- [ ] Push the branch, open the PR (`docs(readme): concise, accurate front door`), watch CI, `gh pr merge --squash --admin --delete-branch`, sync `main`, and confirm **#94 closes**.
+
+---
+
+## Self-review
+
+**Spec coverage:** intro/why/quick-start/type-safe/feature-flags/CLI/links → Task 1 Steps 2–6 ✓. Claim audit (no uploads, MSRV 1.86, version 0.4, `ctx.req.param`, delete build-spec) → Steps 2–3,6 + Task 2 grep ✓. Success criteria (compiles, no fabricated numbers/fictional APIs, ~200 lines) → Task 2 ✓.
+
+**Placeholder scan:** the only intentional placeholder is `REPLACE_WITH_ABS_PATH` in the throwaway scratch check (Task 2 Step 2) — substitute `/Users/ruslanelishaev/Desktop/projects/ultimo`. README content itself has no placeholders.
+
+**Consistency:** the quick-start uses `ctx.req.param("id")?` (real) + `.map_err(...)` for the parse (since `UltimoError` has no `From<ParseIntError>`), `ctx.json(...).await`, `Ultimo::new()`, `ultimo::Result` — all real 0.4.0 API surfaced by the prelude.

--- a/docs/superpowers/specs/2026-06-08-readme-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-08-readme-cleanup-design.md
@@ -1,0 +1,81 @@
+# README cleanup — Design
+
+**Date:** 2026-06-08
+**Issue:** #94 (remaining half — README editorial cleanup)
+**Status:** Approved, pre-implementation
+
+## Goal
+
+Turn the 1082-line `README.md` into a concise, **accurate** front door for the
+crates.io + GitHub landing page. Today the bottom half is an internal build-spec
+with stale/fictional content; the top half has API and version bugs. Trim it to
+what a Rust developer actually wants, and make every retained claim and code
+example true.
+
+## Approach (chosen: A — trim to a front-door README)
+
+Keep and refine the user-facing top; **delete the embedded build-spec**; fix API
+bugs and stale strings; verify each retained claim against the code; lean on
+docs.ultimo.dev for depth. (Rejected: full rewrite — discards good copy; minimal
+delete-only — leaves redundancy/fluff.)
+
+## Claim audit (verified against the codebase)
+
+| Claim in current README | Reality | Action |
+|---|---|---|
+| "158k+ req/sec / 0.6ms / 15× faster" + perf table | already removed in #95 | (n/a — gone) |
+| File uploads (multer; `upload.rs`; "is_image/is_pdf"; "### 8 File Upload Handling") | **not implemented** (no multipart in `ultimo/src`) | **remove all upload claims** |
+| Rate limiting / `bearer_auth` / `c.res` / typed `c.get` | not implemented / fictional | already cut from docs; **remove from README** |
+| `ctx.param("id")?.parse()?` (quick start) | real is `ctx.req.param`; `parse()?` needs explicit error mapping | **fix the example so it compiles** |
+| MSRV "1.75.0" | real MSRV is **1.86.0** | **fix** |
+| `version = "0.3"` install snippets | current release is **0.4.0** | **fix to "0.4"** |
+| `Project Structure` lists `upload.rs`, `guard.rs` | those files don't exist | **delete the section** |
+| Auth (JWT/API-key/guards), sessions, CSRF, security headers, WebSocket, OpenAPI, RPC, TS client gen, CORS, validation, SQLx/Diesel | real | **keep (refined)** |
+| CLI `generate` / `new` / `build` | real; `dev` is a stub (hot-reload is #15, planned) | keep `generate`/`new`/`build`; don't claim hot-reload |
+
+## Target structure
+
+The rewritten README, in order:
+
+1. **Header** — logo, tagline, badges (keep the existing badge row), nav links.
+2. **Intro** — one paragraph: secure-by-default, fast (Hyper + Tokio), type-safe
+   full-stack with automatic TypeScript client generation.
+3. **Why Ultimo** — a short honest bullet list: auto TS clients, REST + JSON-RPC,
+   WebSocket + pub/sub, auth (JWT/API-key/guards) + security hardening, O(1)
+   routing, SQLx/Diesel. No throughput numbers (link to `/performance`).
+4. **Quick start** — install (`ultimo = "0.4"`) + a minimal `main.rs` that
+   **compiles** against the real API (`use ultimo::prelude::*;`, `ctx.req.param`,
+   `ctx.req.json`, `ctx.json(...).await`). MSRV note: 1.86.
+5. **Type-safe clients** — the headline feature: define in Rust → generated TS
+   client, short illustration + `ultimo generate` command.
+6. **Feature flags** — the real opt-in list: `websocket`, `session`, `jwt`,
+   `api-key`, `csrf`, `testing`, `sqlx-postgres|mysql|sqlite`,
+   `diesel-postgres|mysql|sqlite` (all `default = []`).
+7. **CLI** — `ultimo new`, `ultimo generate`, `ultimo build` (note `dev` is
+   experimental). Real flags only.
+8. **Docs · Examples · Contributing · License** — links; depth lives at
+   docs.ultimo.dev. Keep the `examples/` pointer.
+
+**Deleted outright:** "Core Philosophy", "Tech Stack Requirements", "Minimum
+Supported Rust Version" (as a standalone stale section — fold 1.86 into Quick
+start), "Project Structure", the entire "Feature Requirements" build-spec
+(### 1–11) and anything after it that is build-spec/duplicate. The real
+architecture already lives in `docs-site` + `CLAUDE.md`.
+
+## Constraints
+
+- **version-sync CI gate**: the root `CHANGELOG.md` version is what the gate
+  reads, not the README — but keep README install snippets at `0.4` for accuracy.
+- Preserve the existing badge row and logo block (they're correct).
+- Every code block must compile against the real 0.4.0 API. No fabricated numbers
+  (the no-unsubstantiated-benchmarks rule from #63/#95 holds).
+
+## Success criteria
+
+- README is a concise front door (~200–250 lines), no build-spec.
+- Every retained claim is true; every code example compiles against 0.4.0.
+- No fabricated performance numbers; no fictional APIs (uploads, `bearer_auth`,
+  rate limiting, `c.res`).
+- `grep` for `1.75`, `version = "0.3"`, `ctx.param(`, `upload`, `bearer_auth`,
+  `rate_limit` in README → none remain (except where legitimately part of prose).
+- Vercel docs-site build unaffected (README isn't part of it); GitHub renders cleanly.


### PR DESCRIPTION
Closes #94. Rewrites `README.md` from **1082 lines → 156**, removing the internal build-spec and fixing every accuracy bug.

## Removed (stale / fictional / internal)
- The entire "Feature Requirements" build-spec (### 1–11), "Core Philosophy", "Tech Stack Requirements", "Project Structure" (listed non-existent `upload.rs`/`guard.rs`) — internal spec, not user docs.
- **File-upload** claims (`is_image`/`is_pdf`/"File Upload Handling") — not implemented in the framework.
- Stale **MSRV 1.75** (real: 1.86) and `version = "0.3"` snippets (now 0.4).
- The `ctx.param("id")?.parse()?` quick-start bug (real: `ctx.req.param`, and `parse()` needs explicit error mapping).
- (Fabricated perf numbers were already removed in #95.)

## Now a real front door
Intro · Why Ultimo (true claims only) · Quick start · Type-safe clients · Feature flags (the real opt-in list) · CLI (real subcommands; `dev` noted experimental) · Docs/Examples/Contributing/License — depth lives at docs.ultimo.dev.

## Verified
- `grep` for stale/fictional strings → **CLEAN**; no "upload" feature claims.
- The quick-start example **compiles** against `ultimo` 0.4.0 (checked in a scratch crate).
- Linked files (CONTRIBUTING.md, LICENSE, SECURITY.md) all exist.

That closes the docs-accuracy sweep: middleware (#97) + README (this) are now both truthful and compile-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)