### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-09
+
+### Added
+
+- **Static file serving** (`static-files` feature): `serve_static` serves assets from disk with automatic `Content-Type`, `ETag`, and `304 Not Modified`; `serve_spa` adds Single Page Application fallback routing; path traversal is blocked at the filesystem level. Adds catch-all (`*name`) wildcard segments to the router. (#101)
+- **Response compression** (`compression` feature): automatic gzip/brotli middleware (brotli preferred), pure Rust with no C dependencies, configurable via the `Compression` builder. Skips binary content types, already-encoded responses, and small bodies; always sets `Vary: Accept-Encoding`. (#101)
+
+### Changed
+
+- Crate install snippets (`ultimo = "…"`) across the README and docs pages are now derived from the workspace version and enforced by the `version-sync` CI gate, eliminating version drift. (#102)
+
 ## [0.4.0] - 2026-06-08
 
 The **Security & Performance** milestone.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3576,7 +3576,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-09
+
+### Added
+
+- **Static file serving** (`static-files` feature): `serve_static` serves assets from disk with automatic `Content-Type`, `ETag`, and `304 Not Modified`; `serve_spa` adds Single Page Application fallback routing; path traversal is blocked at the filesystem level. Adds catch-all (`*name`) wildcard segments to the router. (#101)
+- **Response compression** (`compression` feature): automatic gzip/brotli middleware (brotli preferred), pure Rust with no C dependencies, configurable via the `Compression` builder. Skips binary content types, already-encoded responses, and small bodies; always sets `Vary: Accept-Encoding`. (#101)
+
+### Changed
+
+- Crate install snippets (`ultimo = "…"`) across the README and docs pages are now derived from the workspace version and enforced by the `version-sync` CI gate, eliminating version drift. (#102)
+
 ## [0.4.0] - 2026-06-08
 
 The **Security & Performance** milestone.

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -79,8 +79,8 @@ Upcoming features and improvements planned for Ultimo.
 | Auth: authorization guards | ✅ Available    | 0.4.0   |
 | Benchmark Suite (criterion) | ✅ Available  | 0.4.0   |
 | Perf CI Regression Guard  | ✅ Available     | 0.4.0   |
-| Static Files + SPA Fallback | ✅ Available   | 0.5.0   |
-| Compression (gzip/brotli) | ✅ Available     | 0.5.0   |
+| Static Files + SPA Fallback | ✅ Available   | 0.4.1   |
+| Compression (gzip/brotli) | ✅ Available     | 0.4.1   |
 | Hot Reload                | 📋 Planned       | 0.5.0   |
 | Development Dashboard     | 📋 Planned       | 0.5.0   |
 | Multi-language Clients    | 📋 Planned       | 0.5.0   |
@@ -138,10 +138,13 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - ⚡ Published comparison vs axum / actix / hono / express / fastapi
 - ✅ `/performance` page with reproducible methodology + self-serve recipe
 
-### v0.5.0
+### v0.4.1
 
 - ✅ **Static file serving + SPA fallback** — `serve_static`, `serve_spa`, ETag caching, path-traversal protection (`static-files` feature)
 - ✅ **Response compression** — automatic brotli/gzip middleware, pure Rust, builder API (`compression` feature)
+
+### v0.5.0
+
 - Hot reload development mode
 - Development dashboard with live metrics and debugging tools
 - Multi-language client generation (Python/Go/Dart/Swift)

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.4.0 Now Available
+          v0.4.1 Now Available
         </div>
 
         <h1 className="text-4xl sm:text-6xl md:text-7xl font-bold tracking-tight mb-6 max-w-4xl text-balance">

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `ultimo-cli`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).