### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-09
+
+### Added
+
+- **TypeScript client type derivation** (`client-gen` feature): RPC client types are now derived from your Rust types via `ts-rs`. `#[derive(TS)]` on your input/output structs and the generated client emits real `type X = {...}` declarations — no more hand-written type strings or dangling references. `ts_rs::TS` is re-exported as `ultimo::rpc::TS`. (#107)
+
+### Changed
+
+- **BREAKING:** `RpcRegistry::query` / `mutation` now take `(name, handler)` and derive their TypeScript input/output types from the Rust types (bounds `I: TS, O: TS`, gated behind `client-gen`). The previous string-typed signatures are preserved as `query_with_types` / `mutation_with_types`. (#107)
+- `ts-rs` is now an optional dependency behind `client-gen` (previously an unused hard dependency) and was upgraded 8.1 → 12. Default builds no longer pull it. (#107)
+- Removed the hardcoded `User` interface that was previously injected into every generated client. (#107)
+
 ## [0.4.1] - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3570,7 +3570,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the framework is 100% safe Rust (`#![forbid(unsafe_code)]`).
 
 ```toml
 [dependencies]
-ultimo = "0.4"
+ultimo = "0.5"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```
@@ -119,7 +119,7 @@ Everything is opt-in (`default = []`):
 | `diesel-postgres` · `diesel-mysql` · `diesel-sqlite` | Diesel integration per backend |
 
 ```toml
-ultimo = { version = "0.4", features = ["websocket", "jwt", "sqlx-postgres"] }
+ultimo = { version = "0.5", features = ["websocket", "jwt", "sqlx-postgres"] }
 ```
 
 ## CLI

--- a/docs-site/docs/pages/api-keys.mdx
+++ b/docs-site/docs/pages/api-keys.mdx
@@ -19,7 +19,7 @@ clients on purpose.
 
 ```toml
 [dependencies]
-ultimo = { version = "0.4", features = ["api-key"] }
+ultimo = { version = "0.5", features = ["api-key"] }
 ```
 
 ## Quick start

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -862,7 +862,7 @@ Enable optional functionality through Cargo features:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.4", features = ["sqlx-postgres"] }
+ultimo = { version = "0.5", features = ["sqlx-postgres"] }
 ```
 
 ### Available Features
@@ -883,7 +883,7 @@ All features are off by default (`default = []`).
 - `diesel-postgres` / `diesel-mysql` / `diesel-sqlite` - Diesel integration per backend
 
 ```toml
-ultimo = { version = "0.4", features = ["websocket", "session", "sqlx-postgres"] }
+ultimo = { version = "0.5", features = ["websocket", "session", "sqlx-postgres"] }
 ```
 
 ---

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-09
+
+### Added
+
+- **TypeScript client type derivation** (`client-gen` feature): RPC client types are now derived from your Rust types via `ts-rs`. `#[derive(TS)]` on your input/output structs and the generated client emits real `type X = {...}` declarations — no more hand-written type strings or dangling references. `ts_rs::TS` is re-exported as `ultimo::rpc::TS`. (#107)
+
+### Changed
+
+- **BREAKING:** `RpcRegistry::query` / `mutation` now take `(name, handler)` and derive their TypeScript input/output types from the Rust types (bounds `I: TS, O: TS`, gated behind `client-gen`). The previous string-typed signatures are preserved as `query_with_types` / `mutation_with_types`. (#107)
+- `ts-rs` is now an optional dependency behind `client-gen` (previously an unused hard dependency) and was upgraded 8.1 → 12. Default builds no longer pull it. (#107)
+- Removed the hardcoded `User` interface that was previously injected into every generated client. (#107)
+
 ## [0.4.1] - 2026-06-09
 
 ### Added

--- a/docs-site/docs/pages/diesel.mdx
+++ b/docs-site/docs/pages/diesel.mdx
@@ -18,7 +18,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.4", features = ["diesel-postgres"] }
+ultimo = { version = "0.5", features = ["diesel-postgres"] }
 diesel = { version = "2", features = ["postgres", "r2d2"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/docs-site/docs/pages/getting-started.mdx
+++ b/docs-site/docs/pages/getting-started.mdx
@@ -8,7 +8,7 @@ Add Ultimo to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = "0.4"
+ultimo = "0.5"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/docs-site/docs/pages/jwt.mdx
+++ b/docs-site/docs/pages/jwt.mdx
@@ -16,7 +16,7 @@ JWT support is opt-in:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.4", features = ["jwt"] }
+ultimo = { version = "0.5", features = ["jwt"] }
 ```
 
 ## Quick start

--- a/docs-site/docs/pages/middleware.mdx
+++ b/docs-site/docs/pages/middleware.mdx
@@ -86,7 +86,7 @@ no C dependencies). Prefers brotli over gzip when the client accepts both, skips
 already-encoded responses and binary MIME types, and always sets `Vary: Accept-Encoding`.
 
 ```toml
-ultimo = { version = "0.4", features = ["compression"] }
+ultimo = { version = "0.5", features = ["compression"] }
 ```
 
 Quick start with sensible defaults (brotli + gzip, 1 KB minimum body):

--- a/docs-site/docs/pages/security.mdx
+++ b/docs-site/docs/pages/security.mdx
@@ -81,7 +81,7 @@ middleware issues a random token in a (non-HttpOnly) cookie; on unsafe methods
 are compared in **constant time** (mismatch → 403). Safe methods are exempt.
 
 ```rust
-// Cargo.toml: ultimo = { version = "0.4", features = ["csrf"] }
+// Cargo.toml: ultimo = { version = "0.5", features = ["csrf"] }
 app.use_middleware(ultimo::csrf::csrf());
 
 // or customized:

--- a/docs-site/docs/pages/sessions.mdx
+++ b/docs-site/docs/pages/sessions.mdx
@@ -7,7 +7,7 @@ Cookies are a core helper; sessions are middleware over a pluggable store.
 
 ```toml
 [dependencies]
-ultimo = { version = "0.4", features = ["session"] }
+ultimo = { version = "0.5", features = ["session"] }
 ```
 
 ## Register the middleware

--- a/docs-site/docs/pages/sqlx.mdx
+++ b/docs-site/docs/pages/sqlx.mdx
@@ -18,7 +18,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.4", features = ["sqlx-postgres"] }
+ultimo = { version = "0.5", features = ["sqlx-postgres"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/docs-site/docs/pages/static-files.mdx
+++ b/docs-site/docs/pages/static-files.mdx
@@ -6,7 +6,7 @@ support Single Page Application (SPA) routing with a fallback to `index.html`.
 Requires the `static-files` Cargo feature:
 
 ```toml
-ultimo = { version = "0.4", features = ["static-files"] }
+ultimo = { version = "0.5", features = ["static-files"] }
 ```
 
 ## Serving a directory

--- a/docs-site/docs/pages/testing.mdx
+++ b/docs-site/docs/pages/testing.mdx
@@ -10,7 +10,7 @@ Add `ultimo` with the `testing` feature as a **dev-dependency**:
 
 ```toml
 [dev-dependencies]
-ultimo = { version = "0.4", features = ["testing"] }
+ultimo = { version = "0.5", features = ["testing"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.4.1 Now Available
+          v0.5.0 Now Available
         </div>
 
         <h1 className="text-4xl sm:text-6xl md:text-7xl font-bold tracking-tight mb-6 max-w-4xl text-balance">

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `ultimo-cli`: 0.4.1 -> 0.5.0

### ⚠ `ultimo` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  ultimo::rpc::RpcRegistry::query takes 4 parameters in /tmp/.tmpGPG7pD/ultimo/src/rpc.rs:115, but now takes 2 parameters in /tmp/.tmpkDuwsi/ultimo/ultimo/src/rpc.rs:215
  ultimo::rpc::RpcRegistry::mutation takes 4 parameters in /tmp/.tmpGPG7pD/ultimo/src/rpc.rs:131, but now takes 2 parameters in /tmp/.tmpkDuwsi/ultimo/ultimo/src/rpc.rs:236
  ultimo::prelude::RpcRegistry::query takes 4 parameters in /tmp/.tmpGPG7pD/ultimo/src/rpc.rs:115, but now takes 2 parameters in /tmp/.tmpkDuwsi/ultimo/ultimo/src/rpc.rs:215
  ultimo::prelude::RpcRegistry::mutation takes 4 parameters in /tmp/.tmpGPG7pD/ultimo/src/rpc.rs:131, but now takes 2 parameters in /tmp/.tmpkDuwsi/ultimo/ultimo/src/rpc.rs:236
  ultimo::RpcRegistry::query takes 4 parameters in /tmp/.tmpGPG7pD/ultimo/src/rpc.rs:115, but now takes 2 parameters in /tmp/.tmpkDuwsi/ultimo/ultimo/src/rpc.rs:215
  ultimo::RpcRegistry::mutation takes 4 parameters in /tmp/.tmpGPG7pD/ultimo/src/rpc.rs:131, but now takes 2 parameters in /tmp/.tmpkDuwsi/ultimo/ultimo/src/rpc.rs:236
```

<details><summary><i><b>Changelog</b></i></summary><p>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).