### PR TITLE
docs(roadmap): defer hot reload (0.7.0) + multi-language clients (0.8.0)

### DIFF
--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -81,11 +81,11 @@ Upcoming features and improvements planned for Ultimo.
 | Perf CI Regression Guard  | ✅ Available     | 0.4.0   |
 | Static Files + SPA Fallback | ✅ Available   | 0.4.1   |
 | Compression (gzip/brotli) | ✅ Available     | 0.4.1   |
-| Hot Reload                | 📋 Planned       | 0.5.0   |
 | Development Dashboard     | 📋 Planned       | 0.5.0   |
-| Multi-language Clients    | 📋 Planned       | 0.5.0   |
 | Deployment Guides         | 📋 Planned       | 0.5.0   |
 | MCP Server                | 📋 Planned       | 0.6.0   |
+| Hot Reload                | 📋 Planned       | 0.7.0   |
+| Multi-language Clients    | 📋 Planned       | 0.8.0   |
 
 ## Version Timeline
 
@@ -145,9 +145,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 ### v0.5.0
 
-- Hot reload development mode
 - Development dashboard with live metrics and debugging tools
-- Multi-language client generation (Python/Go/Dart/Swift)
 - **Deployment guides** — Docker, AWS (ECS/Fargate, Lambda + API Gateway, EC2), DigitalOcean (App Platform/Droplet), Azure Container Apps, Google Cloud Run, Fly.io/Railway, Kubernetes — each with ready-to-use config
 - Production-ready optimizations
 
@@ -156,6 +154,14 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - MCP Server for AI-assisted development
 - Enhanced developer tools
 - Smart code generation
+
+### v0.7.0
+
+- Hot reload development mode (`ultimo dev` with file-watching auto-restart)
+
+### v0.8.0
+
+- Multi-language client generation (Python / Go / Dart / Swift)
 
 ### v1.0.0
 


### PR DESCRIPTION
Slims the 0.5.0 milestone per maintainer direction.

- **Hot Reload** → 0.7.0
- **Multi-language Clients** → 0.8.0
- 0.5.0 now scopes to: Development Dashboard, Deployment Guides, Production optimizations

Updates both the Feature Status table and the Version Timeline (adds v0.7.0 + v0.8.0 sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)