### PR TITLE
fix(cli): stop dev/build/generate from over-promising

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ TypeScript client — no hand-written types, no drift.
 
 ```bash
 # Generate a TypeScript client from your RPC definitions
-cargo run -p ultimo-cli -- generate --path ./src --output ./client
+cargo run -p ultimo-cli -- generate --project ./backend --output ./client
 ```
 
 ```typescript
@@ -126,12 +126,12 @@ ultimo = { version = "0.4", features = ["websocket", "jwt", "sqlx-postgres"] }
 ```bash
 cargo install ultimo-cli   # installs the `ultimo` binary
 
-ultimo new my-app --template fullstack         # scaffold a new project
-ultimo generate --path ./src --output ./client # generate the TypeScript client
-ultimo build --profile release                 # production build
+ultimo new my-app --template fullstack                 # scaffold a new project
+ultimo generate --project ./backend --output ./client  # generate the TypeScript client
 ```
 
-> `ultimo dev` (hot-reload dev server) is experimental — see the [roadmap](https://docs.ultimo.dev/roadmap).
+> `ultimo dev` and `ultimo build` are **not implemented yet** — use `cargo run` and
+> `cargo build --release` for now. See the [roadmap](https://docs.ultimo.dev/roadmap).
 
 ## Documentation
 

--- a/docs-site/docs/pages/cli.mdx
+++ b/docs-site/docs/pages/cli.mdx
@@ -20,7 +20,7 @@ Verify installation:
 
 ```bash
 ultimo --version
-# ultimo 0.3.0
+# ultimo 0.4.1
 ```
 
 ## Commands
@@ -41,10 +41,14 @@ ultimo generate -p ./backend -o ./frontend/src/client.ts
 
 This command:
 
-1. Analyzes your Rust RPC definitions
-2. Extracts type information
-3. Generates a type-safe TypeScript client
-4. Writes it to the specified output file
+1. Builds the project at `--project` (`cargo build --release`)
+2. Locates the TypeScript client your app emits (call
+   `rpc.generate_client_file(path)` in your binary — see
+   [TypeScript Clients](/typescript))
+3. Copies it to the `--output` path
+
+> The client is produced by your app's RPC registry at build time, not by static
+> source analysis. A more integrated `generate` is on the roadmap.
 
 ### Example Output
 
@@ -203,77 +207,28 @@ Then use:
 ultimo generate  # Uses config file settings
 ```
 
+### Create a new project
+
+Scaffold a new Ultimo project:
+
+```bash
+ultimo new my-app --template fullstack
+```
+
+Available templates: `basic`, `fullstack`, `api-only`, `rpc`, `production`.
+
 ## Future Commands
 
-These commands are coming soon:
+> ⚠️ **Not implemented yet.** These commands exist as placeholders and currently
+> print a notice. The flags below are tentative sketches, not a stable interface.
+> Until they land, use the cargo equivalents.
 
-### New Project
-
-```bash
-# Create new Ultimo project
-ultimo new my-app --template fullstack
-
-# Templates available:
-# - api: REST API server
-# - rpc: RPC-only server
-# - fullstack: Backend + frontend
-# - minimal: Bare bones setup
-```
-
-### Development Server
-
-```bash
-# Start with hot reload
-ultimo dev --port 3000
-
-# Watch and restart on changes
-ultimo dev --watch
-
-# With frontend proxy
-ultimo dev --proxy http://localhost:5173
-```
-
-### Build
-
-```bash
-# Production build
-ultimo build --profile release
-
-# With optimizations
-ultimo build --profile release --strip --lto
-
-# Cross-compilation
-ultimo build --target x86_64-unknown-linux-musl
-```
-
-### Test
-
-```bash
-# Run all tests
-ultimo test
-
-# Run specific test
-ultimo test integration
-
-# With coverage
-ultimo test --coverage
-```
-
-### Format & Lint
-
-```bash
-# Format code
-ultimo fmt
-
-# Check formatting
-ultimo fmt --check
-
-# Run linter
-ultimo lint
-
-# Fix linting issues
-ultimo lint --fix
-```
+| Command | Status | Use instead |
+| --- | --- | --- |
+| `ultimo dev` | Planned (0.7.0) — file-watching dev server | `cargo run` |
+| `ultimo build` | Planned — production build wrapper | `cargo build --release` |
+| `ultimo test` | Not planned yet | `cargo test` |
+| `ultimo fmt` / `ultimo lint` | Not planned yet | `cargo fmt` / `cargo clippy` |
 
 ## CLI Help
 

--- a/ultimo-cli/src/main.rs
+++ b/ultimo-cli/src/main.rs
@@ -40,14 +40,14 @@ enum Commands {
         template: String,
     },
 
-    /// Start development server with hot reload
+    /// [not implemented yet] Development server with hot reload (planned for 0.7.0)
     Dev {
         /// Port to run on
         #[arg(short, long, default_value = "3000")]
         port: u16,
     },
 
-    /// Build for production
+    /// [not implemented yet] Production build — use `cargo build --release` for now
     Build {
         /// Build profile (debug or release)
         #[arg(short, long, default_value = "release")]
@@ -73,18 +73,19 @@ async fn main() -> anyhow::Result<()> {
         Commands::New { name, template } => {
             new::run(name, template).await?;
         }
-        Commands::Dev { port } => {
+        Commands::Dev { port: _ } => {
             println!(
-                "🔥 Starting development server on port {}",
-                port.to_string().green()
+                "{}",
+                "`ultimo dev` is not implemented yet (planned for 0.7.0).".yellow()
             );
-            println!();
-            println!("{}", "Coming soon!".yellow());
+            println!("Run your app directly for now:  {}", "cargo run".cyan());
         }
-        Commands::Build { profile } => {
-            println!("🔨 Building with profile: {}", profile.green());
-            println!();
-            println!("{}", "Coming soon!".yellow());
+        Commands::Build { profile: _ } => {
+            println!("{}", "`ultimo build` is not implemented yet.".yellow());
+            println!(
+                "Build with cargo for now:  {}",
+                "cargo build --release".cyan()
+            );
         }
     }
 


### PR DESCRIPTION
Addresses Codex review items #1 (CLI maturity) and #3 (docs↔CLI drift) — making the CLI honest about what it actually does.

## What was wrong
- `ultimo dev` and `ultimo build` printed `"Coming soon!"` but were presented as working commands (README even listed `ultimo build --profile release` as a production build).
- README used `generate --path` — the real flag is `--project`.
- `cli.mdx` showed `ultimo 0.3.0`, listed the **shipped** `new` command under "Future Commands", claimed `generate` does static source analysis (it doesn't), and documented fictional flags (`--watch`, `--proxy`, `--strip`, `--lto`, `--coverage`, `--fix`).

## What changed
- `dev`/`build` now plainly say they're not implemented yet and point to `cargo run` / `cargo build --release`; `--help` text marked `[not implemented yet]`.
- README: `--path` → `--project`; removed the false `build` line, added an honest note.
- `cli.mdx`: fixed `--version`; described what `generate` really does (builds the project, copies the client your app emits via `rpc.generate_client_file`); moved `new` to shipped; replaced fictional flag examples with a status table.

No public API change to the `ultimo` crate. Follow-ups (separate): the codegen mechanism decision (#4) and CLI integration tests (#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)