### PR TITLE
fix(cli): add --version/-V flag

### DIFF
--- a/ultimo-cli/src/main.rs
+++ b/ultimo-cli/src/main.rs
@@ -7,6 +7,7 @@ mod new;
 
 #[derive(Parser)]
 #[command(name = "ultimo")]
+#[command(version)]
 #[command(about = "Ultimo Framework CLI - Build modern Rust web applications", long_about = None)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
`ultimo --version` errored (`unexpected argument '--version' found`) because the CLI never defined a version flag — even though `cli.mdx` documents it. Adds `#[command(version)]`; clap derives it from `CARGO_PKG_VERSION`, so it auto-tracks releases.

```
$ ultimo --version
ultimo 0.4.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)