### PR TITLE
feat(cli): make `ultimo generate` run the project's generate-client bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +258,17 @@ checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -711,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +862,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1797,6 +1838,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2139,36 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3200,6 +3277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,10 +3694,13 @@ name = "ultimo-cli"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "colored",
+ "predicates",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/docs-site/docs/pages/cli.mdx
+++ b/docs-site/docs/pages/cli.mdx
@@ -39,16 +39,25 @@ Short form:
 ultimo generate -p ./backend -o ./frontend/src/client.ts
 ```
 
-This command:
+This runs a **`generate-client` binary** in your project
+(`cargo run --bin generate-client -- <output>`), so the client is produced by
+your real RPC registry — no source parsing, no guessing.
 
-1. Builds the project at `--project` (`cargo build --release`)
-2. Locates the TypeScript client your app emits (call
-   `rpc.generate_client_file(path)` in your binary — see
-   [TypeScript Clients](/typescript))
-3. Copies it to the `--output` path
+Add `src/bin/generate-client.rs` to your project:
 
-> The client is produced by your app's RPC registry at build time, not by static
-> source analysis. A more integrated `generate` is on the roadmap.
+```rust
+// src/bin/generate-client.rs
+fn main() {
+    let out = std::env::args().nth(1).expect("usage: generate-client <output>");
+    let rpc = my_app::build_registry(); // build the same RpcRegistry your server uses
+    rpc.generate_client_file(&out).expect("failed to write client");
+}
+```
+
+The binary receives the `--output` path as its first argument and writes the
+client there (see [TypeScript Clients](/typescript) for building the registry).
+Derive your RPC types with `#[derive(ultimo::rpc::TS)]` and enable the
+`client-gen` feature so the client carries real types.
 
 ### Example Output
 

--- a/ultimo-cli/Cargo.toml
+++ b/ultimo-cli/Cargo.toml
@@ -21,3 +21,8 @@ serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"
 colored = "2.1"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"

--- a/ultimo-cli/src/generate.rs
+++ b/ultimo-cli/src/generate.rs
@@ -1,112 +1,101 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
-use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Run the project's `generate-client` binary to emit a TypeScript client.
+///
+/// Convention: the project defines `src/bin/generate-client.rs` which builds its
+/// `RpcRegistry` and calls `rpc.generate_client_file(<output>)`. This command
+/// runs that binary (`cargo run --bin generate-client -- <output>`) so the
+/// client is produced by the real registry — no source parsing, no guessing.
 pub async fn run(project: PathBuf, output: PathBuf, watch: bool) -> Result<()> {
     println!("📂 Project: {}", project.display().to_string().cyan());
     println!("📝 Output: {}", output.display().to_string().cyan());
 
     if watch {
-        println!("👀 Watch mode enabled");
-        println!();
         println!(
             "{}",
-            "Coming soon! Use the generate command without --watch for now.".yellow()
+            "Watch mode is not implemented yet — run without --watch.".yellow()
         );
         return Ok(());
     }
 
-    println!();
-    println!("{}", "🔍 Analyzing Rust project...".bold());
-
-    // Step 1: Check if Cargo.toml exists
+    // The project must be a Cargo package.
     let cargo_toml = project.join("Cargo.toml");
     if !cargo_toml.exists() {
         anyhow::bail!("No Cargo.toml found in {}", project.display());
     }
 
-    println!("✅ Found Cargo.toml");
+    // Resolve the output path to an absolute path *before* changing the child's
+    // working directory, so a relative `--output` stays relative to where the
+    // user invoked the command, not to the project dir.
+    let output_abs = absolutize(&output)?;
+    if let Some(parent) = output_abs.parent() {
+        std::fs::create_dir_all(parent).context("Failed to create output directory")?;
+    }
 
-    // Step 2: Build the project to extract RPC metadata
-    println!("{}", "🔨 Building project...".bold());
+    println!();
+    println!("{}", "🔨 Running generate-client binary...".bold());
 
-    let output_result = Command::new("cargo")
-        .arg("build")
-        .arg("--release")
+    let status = Command::new("cargo")
+        .arg("run")
+        .arg("--quiet")
+        .arg("--bin")
+        .arg("generate-client")
         .current_dir(&project)
-        .output()
-        .context("Failed to build project")?;
+        .arg("--")
+        .arg(&output_abs)
+        .status()
+        .context("Failed to invoke `cargo run --bin generate-client`")?;
 
-    if !output_result.status.success() {
-        let error = String::from_utf8_lossy(&output_result.stderr);
-        anyhow::bail!("Build failed:\n{}", error);
-    }
-
-    println!("✅ Build successful");
-
-    // Step 3: Look for TypeScript client code in build artifacts or generated files
-    println!("{}", "🔍 Searching for RPC definitions...".bold());
-
-    // Check common locations for generated client code
-    let possible_locations = vec![
-        project.join("target/ultimo-client.ts"),
-        project.join("ultimo-client.ts"),
-    ];
-
-    let mut client_code = None;
-    for location in possible_locations {
-        if location.exists() {
-            client_code = Some(fs::read_to_string(&location)?);
-            println!("✅ Found TypeScript client at {}", location.display());
-            break;
-        }
-    }
-
-    // If no pre-generated client found, try to extract from running the binary
-    if client_code.is_none() {
-        println!("⚠️  No pre-generated client found");
-        println!("💡 Tip: Make sure your main.rs calls rpc.generate_typescript_client()");
-        println!();
-        println!("Add this to your main.rs:");
-        println!(
-            "{}",
-            "    let client = rpc.generate_typescript_client();".bright_black()
-        );
-        println!(
-            "{}",
-            "    fs::write(\"ultimo-client.ts\", client)?;".bright_black()
+    if !status.success() {
+        anyhow::bail!(
+            "`cargo run --bin generate-client` failed in {project}.\n\n\
+             `ultimo generate` runs a `generate-client` binary in your project. \
+             Add `src/bin/generate-client.rs`:\n\n\
+             {snippet}\n\n\
+             It must accept the output path as its first argument.",
+            project = project.display(),
+            snippet = EXAMPLE_BIN.trim_end(),
         );
     }
 
-    // Step 4: Create output directory if needed
-    if let Some(parent) = output.parent() {
-        fs::create_dir_all(parent).context("Failed to create output directory")?;
-    }
-
-    // Step 5: Write the TypeScript client
-    if let Some(code) = client_code {
-        fs::write(&output, code).context("Failed to write TypeScript client")?;
-
-        println!();
-        println!(
-            "{}",
-            "✨ TypeScript client generated successfully!"
-                .green()
-                .bold()
+    if !output_abs.exists() {
+        anyhow::bail!(
+            "generate-client ran but did not write {}. Make sure your \
+             generate-client binary writes the client to the path given as its \
+             first CLI argument (e.g. `rpc.generate_client_file(&args[1])`).",
+            output_abs.display()
         );
-        println!("📄 {}", output.display().to_string().cyan());
     }
 
+    println!();
+    println!(
+        "{}",
+        "✨ TypeScript client generated successfully!"
+            .green()
+            .bold()
+    );
+    println!("📄 {}", output_abs.display().to_string().cyan());
     Ok(())
 }
 
-/// Generate TypeScript client from RPC registry at runtime
-#[allow(dead_code)]
-pub fn generate_from_code(rpc_definitions: &str) -> Result<String> {
-    // Parse RPC definitions and generate TypeScript code
-    // This would be called during the build process
+/// Example `src/bin/generate-client.rs` shown in the error message.
+const EXAMPLE_BIN: &str = r#"    // src/bin/generate-client.rs
+    fn main() {
+        let out = std::env::args().nth(1).expect("usage: generate-client <output>");
+        let rpc = my_app::build_registry(); // build the same RpcRegistry your server uses
+        rpc.generate_client_file(&out).expect("failed to write client");
+    }"#;
 
-    Ok(rpc_definitions.to_string())
+/// Make `path` absolute relative to the current working directory, without
+/// requiring it to exist yet (so the output file need not exist).
+fn absolutize(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        let cwd = std::env::current_dir().context("Failed to read current directory")?;
+        Ok(cwd.join(path))
+    }
 }

--- a/ultimo-cli/tests/cli.rs
+++ b/ultimo-cli/tests/cli.rs
@@ -1,0 +1,113 @@
+//! CLI integration tests — guard the command surface (flags, help, scaffolding,
+//! and the `generate` convention) against drift.
+//! Run with: cargo test -p ultimo-cli
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+
+fn ultimo() -> Command {
+    Command::cargo_bin("ultimo").expect("ultimo binary builds")
+}
+
+#[test]
+fn help_lists_the_real_subcommands() {
+    ultimo()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("generate"))
+        .stdout(contains("new"))
+        .stdout(contains("dev"))
+        .stdout(contains("build"));
+}
+
+#[test]
+fn version_flag_prints_version() {
+    ultimo()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(contains("ultimo "));
+}
+
+#[test]
+fn dev_and_build_report_not_implemented() {
+    ultimo()
+        .arg("dev")
+        .assert()
+        .success()
+        .stdout(contains("not implemented"));
+    ultimo()
+        .arg("build")
+        .assert()
+        .success()
+        .stdout(contains("not implemented"));
+}
+
+#[test]
+fn new_scaffolds_a_project() {
+    let tmp = tempfile::tempdir().unwrap();
+    ultimo()
+        .current_dir(tmp.path())
+        .args(["new", "demo-app", "--template", "basic"])
+        .assert()
+        .success();
+
+    assert!(tmp.path().join("demo-app/Cargo.toml").exists());
+    assert!(tmp.path().join("demo-app/src/main.rs").exists());
+}
+
+#[test]
+fn generate_runs_the_convention_bin_and_writes_output() {
+    // A minimal cargo project whose generate-client bin writes its first arg.
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path().join("proj");
+    fs::create_dir_all(proj.join("src/bin")).unwrap();
+    fs::write(
+        proj.join("Cargo.toml"),
+        "[package]\nname = \"proj\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\n[[bin]]\nname = \"generate-client\"\npath = \"src/bin/generate-client.rs\"\n",
+    )
+    .unwrap();
+    fs::write(
+        proj.join("src/bin/generate-client.rs"),
+        "fn main() {\n    let out = std::env::args().nth(1).expect(\"output path\");\n    std::fs::write(&out, \"// generated client\\n\").unwrap();\n}\n",
+    )
+    .unwrap();
+
+    let out = tmp.path().join("client.ts");
+    ultimo()
+        .args(["generate", "--project"])
+        .arg(&proj)
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success();
+
+    let written = fs::read_to_string(&out).expect("client written");
+    assert!(written.contains("generated client"));
+}
+
+#[test]
+fn generate_errors_helpfully_without_the_bin() {
+    // A cargo project with no generate-client bin.
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path().join("proj");
+    fs::create_dir_all(proj.join("src")).unwrap();
+    fs::write(
+        proj.join("Cargo.toml"),
+        "[package]\nname = \"proj\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    fs::write(proj.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+    let out = tmp.path().join("client.ts");
+    ultimo()
+        .args(["generate", "--project"])
+        .arg(&proj)
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .failure()
+        .stderr(contains("generate-client"));
+}


### PR DESCRIPTION
Phase 2a of TS client codegen — make `ultimo generate` *actually run* instead of hunting for an artifact.

## What changed
- `ultimo generate --project P --output O` now runs `cargo run --bin generate-client -- O` in the project. The client is produced by the real `RpcRegistry`, not by source parsing or artifact-hunting.
- Helpful failure when the convention bin is missing (or doesn't write the output) — shows the expected `src/bin/generate-client.rs`.
- `--watch` reports not-implemented honestly (Phase 3).
- **assert_cmd CLI tests** (closes Codex review #10): `--help`, `--version`, dev/build notices, `new` scaffolding, end-to-end `generate`, and the missing-bin error path.
- CLI docs updated to the convention-bin flow.

## Out of scope
- Scaffolding `generate-client` into `ultimo new` templates → **Phase 2b** (entangled with the 5 existing templates).
- Full TypeScript docs-page rewrite → **Phase 3**.

## Test plan
- [x] `cargo test -p ultimo-cli` (6 integration tests)
- [x] fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)