### PR TITLE
docs(roadmap): differentiator-focused revision + reconcile 0.5.0

### DIFF
--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -1,57 +1,56 @@
 # Roadmap
 
-Upcoming features and improvements planned for Ultimo.
+Where Ultimo is headed. The throughline is **type-safe end to end** — define your
+API in Rust, get a fully-typed TypeScript client with no drift — sequenced toward
+a stable **1.0**.
 
 ## Coming Soon 🚧
 
-### Real-time Features
+### Type-safe everything (the differentiator)
 
-- 📡 **Server-Sent Events** - Streaming updates to clients
-- 🔄 **Long Polling** - Fallback for older browsers
-- �️ **WebSocket Compression** - Per-message deflate (RFC 7692)
+- 🧩 **Finish the codegen story** — scaffold `generate-client` into `ultimo new`
+  templates; TypeScript docs/workflow rewrite; `ultimo generate --watch`.
+- 📡 **Typed RPC subscriptions / SSE** — server-push with event types derived
+  from your Rust types (tRPC-style subscriptions, in Rust).
+- ❗ **End-to-end typed errors** — RPC errors surfaced as typed results in the
+  generated client.
+- 🪄 **`#[derive(UltimoType)]`** — a thin wrapper so client types derive without
+  adding `ts-rs` to your own `Cargo.toml`.
 
-### Performance & Streaming
+### Real-time & streaming
 
-- 📡 **Streaming Responses** - Large file streaming support
-- ⚡ **HTTP/2 Push** - Server push for critical resources
+- 🌊 **Streaming responses** — large-body / chunked streaming.
+- 🗜️ **WebSocket compression** — per-message deflate (RFC 7692).
 
-(Response compression shipped in 0.5.0 — see [Compression](/middleware#compression).)
+### Auth & sessions
 
-### Session & Auth
+- 🔐 **OAuth2** — provider integration on top of the existing JWT/API-key auth.
+- 🎫 **Redis sessions** — distributed session storage.
 
-- 🎫 **Redis Sessions** - Distributed session storage
-- 🔐 **OAuth2** - OAuth provider integration
+### Production-readiness
 
-(Sessions shipped in 0.3.0; JWT + API-key auth, authorization guards, CSRF, and security headers shipped in 0.4.0 — see [Authentication](/jwt) and [Security](/security).)
+- 📦 **Deployment guides** — Docker, Fly.io/Railway, AWS, DigitalOcean, Azure,
+  Google Cloud Run, Kubernetes — each with ready-to-use config.
+- 🛡️ **Advanced rate limiting** — per-user, per-endpoint limits.
+- ⏱️ **Request timeouts** + **HTTP graceful shutdown** (WebSocket graceful
+  shutdown already ships).
+- 🔄 **Hot reload** — `ultimo dev` with file-watching auto-restart.
 
-### Testing & Development
+### Toward 1.0
 
-- 🧪 **Mock Server** - Testing utilities
-- 🔄 **Hot Reload** - Development mode with automatic restart
-- 📊 **Request Logging** - Structured request/response logging
-- 🎨 **Development Dashboard** - Web-based dev UI with live metrics, route visualization, request logs, and error tracking
+- 🧱 **API stabilization** — public-API audit, documentation completeness,
+  SemVer freeze.
 
-### Static Files & SPAs
+### Maybe / demand-driven (post-1.0)
 
-(Static file serving, SPA fallback, and response compression shipped in 0.5.0 — see [Static Files](/static-files) and [Compression](/middleware#compression).)
+- 🤖 **MCP server** — Model Context Protocol server for AI-assisted development.
+- 🌍 **Python client generation** — extend the codegen engine beyond TypeScript.
 
-### Security
-
-- 🛡️ **Advanced Rate Limiting** - Per-user, per-endpoint rate limits
-- 🛡️ **Request Validation** - Advanced input validation
-
-### Client Generation
-
-- 🌍 **Python Clients** - Generate Python clients from RPC
-- 🌍 **Go Clients** - Generate Go clients from RPC
-- 🌍 **Dart Clients** - Generate Dart clients from RPC
-- 🌍 **Swift Clients** - Generate Swift clients from RPC
-
-### Developer Experience
-
-- 🤖 **MCP Server** - Model Context Protocol server for AI-assisted development
-- 📝 **Schema Introspection** - AI-powered code generation and refactoring
-- 🧠 **Smart Suggestions** - Context-aware API recommendations
+> Removed from the roadmap: HTTP/2 Push (deprecated in browsers), Long Polling
+> (covered by SSE + WebSockets), the AI dev-UI cluster (Development Dashboard /
+> Schema Introspection / Smart Suggestions), Go/Dart/Swift client generation
+> (focus stays TypeScript-first), and a standalone Mock Server (testing
+> utilities already ship).
 
 ## Feature Status
 
@@ -64,7 +63,6 @@ Upcoming features and improvements planned for Ultimo.
 | **OpenAPI Support**       | ✅ Available     | 0.1.0   |
 | **CLI Tools**             | ✅ Available     | 0.1.0   |
 | **CORS**                  | ✅ Available     | 0.1.0   |
-| **Rate Limiting**         | 📋 Planned       | 0.5.0   |
 | **Database Integration**  | ✅ Available     | 0.1.0   |
 | **WebSocket Support**     | ✅ Available     | 0.2.1   |
 | **Sessions & Cookies**    | ✅ Available     | 0.3.0   |
@@ -81,11 +79,22 @@ Upcoming features and improvements planned for Ultimo.
 | Perf CI Regression Guard  | ✅ Available     | 0.4.0   |
 | Static Files + SPA Fallback | ✅ Available   | 0.4.1   |
 | Compression (gzip/brotli) | ✅ Available     | 0.4.1   |
-| Development Dashboard     | 📋 Planned       | 0.5.0   |
-| Deployment Guides         | 📋 Planned       | 0.5.0   |
-| MCP Server                | 📋 Planned       | 0.6.0   |
-| Hot Reload                | 📋 Planned       | 0.7.0   |
-| Multi-language Clients    | 📋 Planned       | 0.8.0   |
+| TypeScript Type Derivation (`client-gen`) | ✅ Available | 0.5.0 |
+| `ultimo generate` (runs generate-client) | ✅ Available | 0.5.0 |
+| Deployment Guides         | 📋 Planned       | 0.6.0   |
+| Advanced Rate Limiting    | 📋 Planned       | 0.6.0   |
+| Codegen: `ultimo new` scaffold + `--watch` | 📋 Planned | 0.6.0 |
+| Typed RPC Subscriptions / SSE | 📋 Planned   | 0.7.0   |
+| OAuth2                    | 📋 Planned       | 0.7.0   |
+| Streaming Responses       | 📋 Planned       | 0.7.0   |
+| Request Timeouts + HTTP Graceful Shutdown | 📋 Planned | 0.7.0 |
+| Redis Sessions            | 📋 Planned       | 0.8.0   |
+| WebSocket Compression     | 📋 Planned       | 0.8.0   |
+| Hot Reload (`ultimo dev`) | 📋 Planned       | 0.8.0   |
+| `#[derive(UltimoType)]`   | 📋 Planned       | 0.8.0   |
+| End-to-end Typed Errors   | 📋 Planned       | 0.9.0   |
+| MCP Server                | 💡 Demand-driven | post-1.0 |
+| Python Client Generation  | 💡 Demand-driven | post-1.0 |
 
 ## Version Timeline
 
@@ -119,7 +128,7 @@ Upcoming features and improvements planned for Ultimo.
 - ✅ **Router precedence fix**, `Ultimo::oneshot`, `Request::raw_body()`
 - ✅ MSRV 1.86, hardened dependency floors, automated releases + CI guardrails
 
-### v0.4.0 (Current) — Security & Performance
+### v0.4.0 — Security & Performance
 
 Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
@@ -127,15 +136,14 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 - ✅ Security headers middleware (HSTS, CSP, X-Frame-Options, …)
 - ✅ CSRF protection (integrates with sessions)
-- ✅ Auth: JWT + API-key middleware + authorization guards (scopes) — shipped
-- ✅ Request body-size limits + real client IP (trusted-proxy aware); 🔒 request timeouts + enhanced rate limiting (planned)
+- ✅ Auth: JWT + API-key middleware + authorization guards (scopes)
+- ✅ Request body-size limits + real client IP (trusted-proxy aware)
 - ✅ `#![forbid(unsafe_code)]` (100% safe Rust), `SECURITY.md` disclosure policy,
-  `cargo-deny` + `cargo-audit` in CI; 🔒 fuzzing + OpenSSF Best Practices (planned)
+  `cargo-deny` + `cargo-audit` in CI
 
 **Performance** (proven · regression-guarded)
 
 - ✅ Framework-overhead benchmark suite (criterion) + methodology (BENCHMARKS.md) + advisory CI regression check
-- ⚡ Published comparison vs axum / actix / hono / express / fastapi
 - ✅ `/performance` page with reproducible methodology + self-serve recipe
 
 ### v0.4.1
@@ -143,31 +151,46 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - ✅ **Static file serving + SPA fallback** — `serve_static`, `serve_spa`, ETag caching, path-traversal protection (`static-files` feature)
 - ✅ **Response compression** — automatic brotli/gzip middleware, pure Rust, builder API (`compression` feature)
 
-### v0.5.0
+### v0.5.0 (Current) — Type-safe clients, for real
 
-- Development dashboard with live metrics and debugging tools
-- **Deployment guides** — Docker, AWS (ECS/Fargate, Lambda + API Gateway, EC2), DigitalOcean (App Platform/Droplet), Azure Container Apps, Google Cloud Run, Fly.io/Railway, Kubernetes — each with ready-to-use config
-- Production-ready optimizations
+- ✅ **TypeScript type derivation** (`client-gen` feature) — RPC client types are
+  derived from your Rust types via `ts-rs`; the generated client emits real
+  `type X = {...}` declarations instead of hand-written strings. `ts_rs::TS`
+  re-exported as `ultimo::rpc::TS`.
+- ✅ **Derived `query`/`mutation`** (breaking) — infer input/output types from
+  `#[derive(TS)]` structs; string-typed `query_with_types`/`mutation_with_types`
+  remain as escape hatches.
+- ✅ **`ultimo generate` runs for real** — executes the project's
+  `generate-client` binary (no more artifact-hunting); `assert_cmd` CLI tests.
 
-### v0.6.0
+### v0.6.0 — Finish the codegen story + ship-readiness
 
-- MCP Server for AI-assisted development
-- Enhanced developer tools
-- Smart code generation
+- Codegen: scaffold `generate-client` into `ultimo new` templates; TypeScript
+  docs rewrite; `ultimo generate --watch`
+- Deployment guides (Docker, Fly.io/Railway, AWS, DigitalOcean, Azure, GCR, K8s)
+- Advanced rate limiting (per-user, per-endpoint)
 
-### v0.7.0
+### v0.7.0 — Real-time & production gaps
 
-- Hot reload development mode (`ultimo dev` with file-watching auto-restart)
+- Typed RPC subscriptions / SSE (derived event types)
+- OAuth2 provider integration
+- Streaming responses
+- Request timeouts + HTTP graceful shutdown
 
-### v0.8.0
+### v0.8.0 — Distribution & dev experience
 
-- Multi-language client generation (Python / Go / Dart / Swift)
+- Redis sessions (distributed storage)
+- WebSocket compression (per-message deflate)
+- Hot reload (`ultimo dev`)
+- `#[derive(UltimoType)]` (drop the `ts-rs` dependency papercut)
 
-### v1.0.0
+### v0.9.0 → v1.0.0 — Stabilize
 
-- Stable API
-- Complete documentation
-- Production battle-tested
+- End-to-end typed errors
+- Public-API audit + SemVer freeze
+- Documentation completeness
+- Production battle-testing
+- _(Demand-driven: MCP server, Python client generation)_
 
 ## Contributing
 

--- a/docs/superpowers/specs/2026-06-09-roadmap-revision-design.md
+++ b/docs/superpowers/specs/2026-06-09-roadmap-revision-design.md
@@ -1,0 +1,80 @@
+# Roadmap Revision — Design
+
+**Date:** 2026-06-09
+**Status:** Approved (brainstorm), pending spec review
+**Artifact:** `docs-site/docs/pages/roadmap.mdx`
+
+## Goal
+
+Revise the Ultimo roadmap to **double down on the differentiator** — type-safe
+end-to-end (Rust → typed TypeScript client) — with **1.0-focus discipline**.
+Cut dated/vague/off-core items, keep only adoption-unblockers any real app
+needs, add features that strengthen the moat, and reconcile the roadmap with
+what actually shipped through 0.5.0.
+
+## Lens / rationale
+
+Ultimo's moat is the typed RPC + automatic TS client story; many Rust frameworks
+(axum, actix) cover generic HTTP well. The roadmap should make the type-safe
+story unbeatable and stop promising generic or speculative features that dilute
+focus or that the project realistically won't build. Everything sequences toward
+a credible 1.0.
+
+## Reconciliation (roadmap is stale post-release)
+
+- `0.4.1` shipped: static files + SPA fallback, response compression.
+- `0.5.0` shipped: **client-gen** — TypeScript type derivation from Rust types
+  (`ts-rs`), `ultimo::rpc::TS`, derived `query`/`mutation` (+ `*_with_types`),
+  and `ultimo generate` now runs the project's `generate-client` bin. **This is
+  not currently reflected on the roadmap and must be added** as a shipped 0.5.0
+  entry (Feature Status row + Version Timeline section). The "(Current)" marker
+  moves from 0.4.0 to 0.5.0.
+
+## Cut (remove from roadmap)
+
+| Item | Why |
+|---|---|
+| HTTP/2 Push | Deprecated; Chrome removed support. Dead end. |
+| Long Polling | Niche; SSE (one-way) + WebSocket (bidirectional) already cover real-time. |
+| Development Dashboard | A framework shouldn't ship a metrics-UI app; large, off-core. |
+| Schema Introspection (AI) | Vague; overlaps with MCP server. |
+| Smart Suggestions (AI) | Vague marketing; no concrete scope. |
+| Go / Dart / Swift clients | Huge surface; dilutes TS-first focus. (Python kept as demand-driven, post-1.0.) |
+| Mock Server | Testing utilities already shipped; fold in or drop. |
+
+## Add (on-identity)
+
+- **Typed RPC subscriptions / typed SSE** — server-push with derived event
+  types. The standout differentiator (tRPC-style subscriptions, in Rust).
+- **End-to-end typed errors** — RPC errors surfaced as typed results in the
+  generated TS client.
+- **`#[derive(UltimoType)]` wrapper** (codegen Phase 1.5) — removes the `ts-rs`
+  direct-dependency papercut so the derive feels native.
+- **HTTP graceful shutdown** + **request timeouts** — common production gaps
+  (WebSocket graceful shutdown already exists).
+- **Explicit 1.0 stabilization track** — public-API audit, doc completeness,
+  SemVer freeze.
+
+## Keep & sequence toward 1.0
+
+- **0.6** — finish codegen: Phase 2b (scaffold `generate-client` into
+  `ultimo new` templates) + Phase 3 (TypeScript docs rewrite, `generate
+  --watch`); **deployment guides**; **advanced rate limiting**.
+- **0.7** — **SSE (typed)**, **OAuth2**, **streaming responses**, HTTP graceful
+  shutdown + request timeouts.
+- **0.8** — **Redis sessions**, WebSocket compression (per-message deflate),
+  hot reload (`ultimo dev`), `#[derive(UltimoType)]` wrapper.
+- **0.9 → 1.0** — end-to-end typed errors, 1.0 stabilization (API freeze, docs
+  completeness), **MCP server** *(if demand)*, **Python client** *(if demand)*.
+
+## Out of scope
+
+This is a documentation change to `roadmap.mdx` (plus reconciling the Feature
+Status table and Version Timeline). No code changes. Each listed feature gets
+its own brainstorm → spec → plan when picked up later.
+
+## Testing / verification
+
+- `version-sync` CI gate must stay green (roadmap edits don't touch versioned
+  surfaces, but run `scripts/check-versions.sh` to be safe).
+- Vocs docs-site build must succeed (valid MDX).


### PR DESCRIPTION
Revises the roadmap to double down on the type-safe-end-to-end differentiator with 1.0-focus discipline. Brainstorm spec: `docs/superpowers/specs/2026-06-09-roadmap-revision-design.md`.

## Highlights
- **Reconciled with reality:** adds the shipped **0.5.0** (client-gen TS derivation + real `ultimo generate`), marks it Current, fixes stale "Coming Soon".
- **Cut:** HTTP/2 Push (deprecated), Long Polling, Development Dashboard, AI cluster (Schema Introspection / Smart Suggestions), Go/Dart/Swift clients, Mock Server.
- **Added:** typed RPC subscriptions/SSE, end-to-end typed errors, `#[derive(UltimoType)]`, HTTP graceful shutdown + request timeouts, explicit 1.0 stabilization track.
- **Resequenced** 0.6 → 1.0 around the differentiator; MCP server + Python client moved to demand-driven post-1.0.

Docs-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)