### PR TITLE
docs(readme): add deps.rs dependency-status security badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     <a href="https://github.com/ultimo-rs/ultimo/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License" /></a>
     <a href="https://github.com/ultimo-rs/ultimo/actions"><img src="https://img.shields.io/github/actions/workflow/status/ultimo-rs/ultimo/ci.yml?branch=main&style=flat-square" alt="Build Status" /></a>
     <a href="https://github.com/ultimo-rs/ultimo/blob/main/SECURITY.md"><img src="https://img.shields.io/badge/unsafe-forbidden-success.svg?style=flat-square" alt="Unsafe forbidden" /></a>
+    <a href="https://deps.rs/repo/github/ultimo-rs/ultimo"><img src="https://deps.rs/repo/github/ultimo-rs/ultimo/status.svg?style=flat-square" alt="Dependency status" /></a>
     <img src="https://img.shields.io/badge/MSRV-1.86-blue.svg?style=flat-square" alt="MSRV 1.86" />
   </p>
 


### PR DESCRIPTION
Adds a live **dependency status** badge ([deps.rs](https://deps.rs/repo/github/ultimo-rs/ultimo)) — an auto-updating signal that Ultimo's dependency tree is free of known security advisories.

Complements the existing `unsafe-forbidden` badge, `SECURITY.md`, and the `cargo-audit` + `cargo-deny` CI gates. Surfaces on both the GitHub README and the crates.io page.

Deliberately not adding an OpenSSF Scorecard badge for now — it needs a new workflow and publishes a numeric score that the admin self-merge pattern would drag down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)