### PR TITLE
fix(website): blog table rendering, link hover, duplicate title

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import rehypePrettyCode from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
+import remarkGfm from "remark-gfm";
 import { TableOfContents } from "@/components/table-of-contents";
 import { getAllPosts, getPostBySlug } from "@/lib/blog";
 
@@ -93,11 +94,12 @@ export default async function BlogPostPage({ params }: PageProps) {
               </div>
             </header>
 
-            <div className="prose prose-invert prose-orange max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-orange-400 prose-a:no-underline hover:prose-a:underline prose-code:text-orange-300 prose-pre:bg-[#0d1117] prose-pre:border prose-pre:border-border/50 prose-img:rounded-lg">
+            <div className="prose prose-invert prose-orange max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-orange-400 prose-a:no-underline prose-a:hover:underline prose-code:text-orange-300 prose-pre:bg-[#0d1117] prose-pre:border prose-pre:border-border/50 prose-img:rounded-lg">
               <MDXRemote
                 source={content}
                 options={{
                   mdxOptions: {
+                    remarkPlugins: [remarkGfm],
                     rehypePlugins: [
                       rehypeSlug,
                       [rehypePrettyCode, { theme: "github-dark-dimmed" }],

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -5,8 +5,8 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import rehypePrettyCode from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
-import { getAllPosts, getPostBySlug } from "@/lib/blog";
 import { TableOfContents } from "@/components/table-of-contents";
+import { getAllPosts, getPostBySlug } from "@/lib/blog";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -46,7 +46,7 @@ export default async function BlogPostPage({ params }: PageProps) {
   }
 
   // Strip the first H1 from content since we render it in the header
-  const content = post.content.replace(/^#\s+.+\n+/, "");
+  const content = post.content.replace(/^\s*#\s+.+\n+/, "");
 
   return (
     <div className="min-h-screen selection:bg-orange-500/30">

--- a/website/components/table-of-contents.tsx
+++ b/website/components/table-of-contents.tsx
@@ -75,7 +75,7 @@ function extractHeadings(markdown: string): TocItem[] {
     const match = line.match(/^(#{2,4})\s+(.+)$/);
     if (match) {
       const level = match[1].length;
-      const text = match[2].replace(/[`*_~\[\]]/g, "").trim();
+      const text = match[2].replace(/[`*_~[\]]/g, "").trim();
       const id = text
         .toLowerCase()
         .replace(/[^\w\s-]/g, "")

--- a/website/content/posts/build-your-first-api-with-ultimo.mdx
+++ b/website/content/posts/build-your-first-api-with-ultimo.mdx
@@ -690,4 +690,4 @@ Check out the [full documentation](https://docs.ultimo.dev) and the [examples di
 
 ---
 
-*Have questions? Open an issue on [GitHub](https://github.com/ultimo-rs/ultimo) or join the discussion in the repository's Discussions tab.*
+_Have questions? Open an issue on [GitHub](https://github.com/ultimo-rs/ultimo) or join the discussion in the repository's Discussions tab._

--- a/website/content/posts/how-typescript-codegen-works.mdx
+++ b/website/content/posts/how-typescript-codegen-works.mdx
@@ -145,6 +145,7 @@ Running `ultimo generate --path ./src --output ./client` triggers a multi-phase 
 **Phase 4: Deduplication.** Multiple methods might share types (e.g., several endpoints return `User`). The generator deduplicates by type name, ensuring each interface appears exactly once in the output.
 
 **Phase 5: Code Emission.** The generator writes a self-contained TypeScript module with:
+
 - All interface/type definitions (topologically sorted so dependencies appear before dependents)
 - A typed function for each RPC method
 - A configurable base client with error handling
@@ -238,7 +239,7 @@ export class RpcError extends Error {
   constructor(
     public code: number,
     message: string,
-    public data?: unknown
+    public data?: unknown,
   ) {
     super(message);
     this.name = "RpcError";
@@ -359,28 +360,28 @@ export interface PaginatedUser {
 
 Here is the complete mapping from Rust types to TypeScript types:
 
-| Rust Type | TypeScript Type |
-|-----------|----------------|
-| `String`, `&str` | `string` |
-| `u8`, `u16`, `u32`, `i8`, `i16`, `i32` | `number` |
-| `u64`, `i64`, `u128`, `i128` | `number` |
-| `f32`, `f64` | `number` |
-| `bool` | `boolean` |
-| `()` | `null` |
-| `Vec<T>` | `T[]` |
-| `Option<T>` | `T \| null` |
-| `HashMap<K, V>` | `Record<K, V>` |
-| `BTreeMap<K, V>` | `Record<K, V>` |
-| `HashSet<T>` | `T[]` |
-| `(A, B, C)` | `[A, B, C]` |
-| `Box<T>`, `Arc<T>`, `Rc<T>` | `T` (transparent) |
-| `Uuid` | `string` |
-| `DateTime<Utc>` (chrono) | `string` |
-| `NaiveDate` | `string` |
-| Unit enum variants | String literal union |
-| Tagged enum | Discriminated union |
-| Untagged enum | Union type |
-| Struct | Interface |
+| Rust Type                              | TypeScript Type      |
+| -------------------------------------- | -------------------- |
+| `String`, `&str`                       | `string`             |
+| `u8`, `u16`, `u32`, `i8`, `i16`, `i32` | `number`             |
+| `u64`, `i64`, `u128`, `i128`           | `number`             |
+| `f32`, `f64`                           | `number`             |
+| `bool`                                 | `boolean`            |
+| `()`                                   | `null`               |
+| `Vec<T>`                               | `T[]`                |
+| `Option<T>`                            | `T \| null`          |
+| `HashMap<K, V>`                        | `Record<K, V>`       |
+| `BTreeMap<K, V>`                       | `Record<K, V>`       |
+| `HashSet<T>`                           | `T[]`                |
+| `(A, B, C)`                            | `[A, B, C]`          |
+| `Box<T>`, `Arc<T>`, `Rc<T>`            | `T` (transparent)    |
+| `Uuid`                                 | `string`             |
+| `DateTime<Utc>` (chrono)               | `string`             |
+| `NaiveDate`                            | `string`             |
+| Unit enum variants                     | String literal union |
+| Tagged enum                            | Discriminated union  |
+| Untagged enum                          | Union type           |
+| Struct                                 | Interface            |
 
 Smart pointer types (`Box`, `Arc`, `Rc`) are transparent — the generated TypeScript sees only the inner type. This matches how serde serializes them.
 

--- a/website/content/posts/introducing-ultimo-v0-5.mdx
+++ b/website/content/posts/introducing-ultimo-v0-5.mdx
@@ -118,23 +118,23 @@ This pulls in [`ts-rs`](https://github.com/Aleph-Alpha/ts-rs) as a dependency an
 
 When you derive `TS`, each Rust type maps to a TypeScript equivalent. Here's the complete mapping table for common types:
 
-| Rust Type | TypeScript Type | Notes |
-|-----------|----------------|-------|
-| `bool` | `boolean` | |
-| `u8`, `u16`, `u32`, `i8`, `i16`, `i32` | `number` | |
-| `u64`, `i64`, `u128`, `i128` | `number` | Consider `bigint` for large values |
-| `f32`, `f64` | `number` | |
-| `String`, `&str` | `string` | |
-| `Option<T>` | `T \| null` | |
-| `Vec<T>` | `T[]` | |
-| `HashMap<K, V>` | `Record<K, V>` | K must be string-like |
-| `HashSet<T>` | `T[]` | |
-| `(A, B)` | `[A, B]` | Tuple types preserved |
-| `chrono::NaiveDateTime` | `string` | With `ts-rs` chrono feature |
-| `uuid::Uuid` | `string` | With `ts-rs` uuid feature |
-| Enums (unit variants) | `"A" \| "B" \| "C"` | String literal union |
-| Enums (data variants) | Tagged union | `{ type: "A", data: ... }` |
-| `serde_json::Value` | `any` | Escape hatch |
+| Rust Type                              | TypeScript Type     | Notes                              |
+| -------------------------------------- | ------------------- | ---------------------------------- |
+| `bool`                                 | `boolean`           |                                    |
+| `u8`, `u16`, `u32`, `i8`, `i16`, `i32` | `number`            |                                    |
+| `u64`, `i64`, `u128`, `i128`           | `number`            | Consider `bigint` for large values |
+| `f32`, `f64`                           | `number`            |                                    |
+| `String`, `&str`                       | `string`            |                                    |
+| `Option<T>`                            | `T \| null`         |                                    |
+| `Vec<T>`                               | `T[]`               |                                    |
+| `HashMap<K, V>`                        | `Record<K, V>`      | K must be string-like              |
+| `HashSet<T>`                           | `T[]`               |                                    |
+| `(A, B)`                               | `[A, B]`            | Tuple types preserved              |
+| `chrono::NaiveDateTime`                | `string`            | With `ts-rs` chrono feature        |
+| `uuid::Uuid`                           | `string`            | With `ts-rs` uuid feature          |
+| Enums (unit variants)                  | `"A" \| "B" \| "C"` | String literal union               |
+| Enums (data variants)                  | Tagged union        | `{ type: "A", data: ... }`         |
+| `serde_json::Value`                    | `any`               | Escape hatch                       |
 
 Nested structs are resolved transitively — if `UserOutput` contains a `Vec<Role>` and `Role` derives `TS`, the generated client emits the `Role` type declaration automatically.
 

--- a/website/content/posts/migrating-from-axum-to-ultimo.mdx
+++ b/website/content/posts/migrating-from-axum-to-ultimo.mdx
@@ -18,22 +18,22 @@ This guide walks you through migrating an Axum application to Ultimo, concept by
 
 Before diving into code, here's how Axum concepts translate to Ultimo:
 
-| Axum | Ultimo | Notes |
-|------|--------|-------|
-| `Router::new()` | `Ultimo::new()` | App builder and router combined |
-| `.route("/path", get(handler))` | `.get("/path", handler)` | Methods directly on the builder |
-| `async fn handler(...)` with extractors | `async fn handler(ctx: Context) -> Result<impl Into<Response>>` | Single `Context` parameter |
-| `State(pool): State<DbPool>` | `ctx.state::<DbPool>()` | Method call instead of extractor |
-| `Path(id): Path<u64>` | `ctx.param("id")` | String-based, parse yourself |
-| `Query(params): Query<T>` | `ctx.query::<T>()` | Deserializes from query string |
-| `Json(body): Json<T>` | `ctx.json_body::<T>().await` | Async because it reads the body |
-| `impl IntoResponse` | `Result<impl Into<Response>>` | Error handling built into return type |
-| `(StatusCode, Json(val))` | `ctx.status(201).json(&val)` | Chainable response builder |
-| `Router::with_state(state)` | `.state(my_state)` | Method on the app builder |
-| Tower layers / `middleware::from_fn` | `.middleware(fn)` | Simple async function |
-| `axum::serve(listener, app)` | `app.listen("0.0.0.0:3000").await` | One-liner |
-| No equivalent | `RpcRegistry` + `.rpc("/rpc", registry)` | JSON-RPC with TS codegen |
-| No equivalent | Automatic TypeScript client generation | Zero-config from Rust types |
+| Axum                                    | Ultimo                                                          | Notes                                 |
+| --------------------------------------- | --------------------------------------------------------------- | ------------------------------------- |
+| `Router::new()`                         | `Ultimo::new()`                                                 | App builder and router combined       |
+| `.route("/path", get(handler))`         | `.get("/path", handler)`                                        | Methods directly on the builder       |
+| `async fn handler(...)` with extractors | `async fn handler(ctx: Context) -> Result<impl Into<Response>>` | Single `Context` parameter            |
+| `State(pool): State<DbPool>`            | `ctx.state::<DbPool>()`                                         | Method call instead of extractor      |
+| `Path(id): Path<u64>`                   | `ctx.param("id")`                                               | String-based, parse yourself          |
+| `Query(params): Query<T>`               | `ctx.query::<T>()`                                              | Deserializes from query string        |
+| `Json(body): Json<T>`                   | `ctx.json_body::<T>().await`                                    | Async because it reads the body       |
+| `impl IntoResponse`                     | `Result<impl Into<Response>>`                                   | Error handling built into return type |
+| `(StatusCode, Json(val))`               | `ctx.status(201).json(&val)`                                    | Chainable response builder            |
+| `Router::with_state(state)`             | `.state(my_state)`                                              | Method on the app builder             |
+| Tower layers / `middleware::from_fn`    | `.middleware(fn)`                                               | Simple async function                 |
+| `axum::serve(listener, app)`            | `app.listen("0.0.0.0:3000").await`                              | One-liner                             |
+| No equivalent                           | `RpcRegistry` + `.rpc("/rpc", registry)`                        | JSON-RPC with TS codegen              |
+| No equivalent                           | Automatic TypeScript client generation                          | Zero-config from Rust types           |
 
 ## Basic Route Migration
 

--- a/website/content/posts/ultimo-vs-axum-comparison.mdx
+++ b/website/content/posts/ultimo-vs-axum-comparison.mdx
@@ -10,7 +10,7 @@ tags: ["comparison", "axum", "rust"]
 
 If you're building a web service in [Rust](https://www.rust-lang.org) in 2026, you've likely narrowed your choices to a handful of frameworks. Two that frequently appear side-by-side are **[Axum](https://github.com/tokio-rs/axum)** and **Ultimo**. Both are built on **[Hyper](https://hyper.rs) 1.0 + [Tokio](https://tokio.rs)**, both prioritize type safety, and both produce extremely fast HTTP services. But they take fundamentally different approaches to developer experience, abstraction, and what belongs "in the box."
 
-This post is an honest, feature-by-feature comparison. We build Ultimo, so we obviously believe in its approach — but we also genuinely respect Axum and use it ourselves in certain contexts. Our goal isn't to declare a winner; it's to help you choose the right tool for *your* project.
+This post is an honest, feature-by-feature comparison. We build Ultimo, so we obviously believe in its approach — but we also genuinely respect Axum and use it ourselves in certain contexts. Our goal isn't to declare a winner; it's to help you choose the right tool for _your_ project.
 
 ## Architecture: Same Engine, Different Chassis
 
@@ -20,7 +20,7 @@ Under the hood, Ultimo and Axum share the same async runtime stack:
 - **[Hyper](https://hyper.rs) 1.0** for the HTTP/1.1 and HTTP/2 implementation
 - **[Tower](https://docs.rs/tower)** (Axum) or function-based middleware (Ultimo) for the middleware layer
 
-Because the performance-critical layer — connection handling, request parsing, response serialization — is identical between the two, raw throughput differences are negligible. The frameworks diverge in what they build *on top* of that shared core.
+Because the performance-critical layer — connection handling, request parsing, response serialization — is identical between the two, raw throughput differences are negligible. The frameworks diverge in what they build _on top_ of that shared core.
 
 **Axum** follows a composition-first philosophy. It provides minimal built-in functionality and relies on the Tower ecosystem for middleware, the broader crate ecosystem for sessions/auth/CSRF, and extractors for type-safe request parsing. This makes Axum extremely flexible — you can swap almost any component.
 
@@ -141,14 +141,14 @@ async fn create_user(
 
 ### Tradeoffs
 
-| Aspect | Ultimo (Context) | Axum (Extractors) |
-|--------|-----------------|-------------------|
-| **Compile-time checking** | Runtime access | Compile-time type checking via generics |
-| **Discoverability** | IDE autocomplete on `ctx.` | Must know available extractors |
-| **Flexibility** | Access anything, anywhere | Order-dependent extraction |
-| **Refactoring** | Add features without changing signature | Adding data requires signature changes |
-| **Learning curve** | One concept to learn | Multiple extractor types to learn |
-| **Error messages** | Clear runtime errors | Sometimes cryptic trait bound errors |
+| Aspect                    | Ultimo (Context)                        | Axum (Extractors)                       |
+| ------------------------- | --------------------------------------- | --------------------------------------- |
+| **Compile-time checking** | Runtime access                          | Compile-time type checking via generics |
+| **Discoverability**       | IDE autocomplete on `ctx.`              | Must know available extractors          |
+| **Flexibility**           | Access anything, anywhere               | Order-dependent extraction              |
+| **Refactoring**           | Add features without changing signature | Adding data requires signature changes  |
+| **Learning curve**        | One concept to learn                    | Multiple extractor types to learn       |
+| **Error messages**        | Clear runtime errors                    | Sometimes cryptic trait bound errors    |
 
 Axum's extractors provide stronger compile-time guarantees — if your handler compiles, the extraction will succeed (barring runtime data issues). This is a genuine advantage for large teams. Ultimo's Context trades some compile-time safety for a flatter learning curve and less ceremony when prototyping.
 
@@ -172,6 +172,7 @@ ultimo generate --path ./src --output ./frontend/src/api
 The generated client includes full TypeScript types matching your Rust structs, proper error handling, and method signatures. Your frontend developers get autocomplete, type checking, and zero manual API client maintenance.
 
 **With Axum**, you'd typically:
+
 1. Manually write OpenAPI specs (or use `utoipa` to derive them)
 2. Run a separate code generator like `openapi-typescript-codegen`
 3. Maintain synchronization between your Rust types and the generated client
@@ -297,48 +298,48 @@ Ultimo's middleware is simpler to write (it's just an async function), but the e
 
 Let's be direct: **Axum has a larger ecosystem and is more mature.** It reached [version 0.8.x](https://docs.rs/axum) with a post-1.0 stability promise, has hundreds of community crates, extensive documentation, and is used in production by major companies.
 
-| Metric | Ultimo | Axum |
-|--------|--------|------|
-| **Current version** | [0.5.0](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
-| **First release** | 2024 | 2021 |
-| **Community crates** | Growing | Hundreds |
-| **Production users** | Early adopters | Major companies |
-| **Documentation** | [Complete](https://docs.ultimo.dev), improving | Extensive |
-| **Breaking changes** | Possible (pre-1.0) | Rare, well-managed |
-| **Tower compatibility** | No (own middleware) | Full |
-| **GitHub stars** | Growing | 20,000+ |
+| Metric                  | Ultimo                                           | Axum                       |
+| ----------------------- | ------------------------------------------------ | -------------------------- |
+| **Current version**     | [0.5.0](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
+| **First release**       | 2024                                             | 2021                       |
+| **Community crates**    | Growing                                          | Hundreds                   |
+| **Production users**    | Early adopters                                   | Major companies            |
+| **Documentation**       | [Complete](https://docs.ultimo.dev), improving   | Extensive                  |
+| **Breaking changes**    | Possible (pre-1.0)                               | Rare, well-managed         |
+| **Tower compatibility** | No (own middleware)                              | Full                       |
+| **GitHub stars**        | Growing                                          | 20,000+                    |
 
 If stability and ecosystem breadth are your top priorities, Axum is the safer choice today. If integrated features and developer velocity matter more, Ultimo offers a compelling alternative.
 
 ## Comprehensive Feature Comparison
 
-| Feature | Ultimo | Axum |
-|---------|--------|------|
-| HTTP/1.1 + HTTP/2 | ✅ | ✅ |
-| Async (Tokio) | ✅ | ✅ |
-| JSON serialization | ✅ (built-in) | ✅ (via serde) |
-| Path parameters | ✅ | ✅ |
-| Query parameters | ✅ | ✅ |
-| Request body parsing | ✅ | ✅ |
-| Static file serving | ✅ (built-in) | Via `tower-http` |
-| Response compression | ✅ (built-in) | Via `tower-http` |
-| WebSocket | ✅ (with pub/sub) | ✅ (raw) |
-| JSON-RPC | ✅ (first-class) | ❌ |
-| TypeScript client gen | ✅ (automatic) | ❌ |
-| OpenAPI generation | ✅ (built-in) | Via `utoipa` |
-| Sessions | ✅ (built-in) | Via `tower-sessions` |
-| CSRF protection | ✅ (built-in) | Manual |
-| JWT auth | ✅ (built-in) | Via ecosystem |
-| API-key auth | ✅ (built-in) | Manual |
-| Authorization guards | ✅ (built-in) | Manual / `axum-extra` |
-| Rate limiting | ✅ (built-in) | Via `tower-governor` |
-| Nested routers | Basic | ✅ (advanced) |
-| Tower middleware | ❌ | ✅ |
-| Compile-time extraction | ❌ (runtime Context) | ✅ |
-| `#![forbid(unsafe_code)]` | ✅ | ❌ (some unsafe) |
-| Routing complexity | O(1) hash | O(log n) trie |
-| Hot reload (dev) | ✅ (CLI) | Via `cargo-watch` |
-| Project scaffolding | ✅ (CLI templates) | Manual |
+| Feature                   | Ultimo               | Axum                  |
+| ------------------------- | -------------------- | --------------------- |
+| HTTP/1.1 + HTTP/2         | ✅                   | ✅                    |
+| Async (Tokio)             | ✅                   | ✅                    |
+| JSON serialization        | ✅ (built-in)        | ✅ (via serde)        |
+| Path parameters           | ✅                   | ✅                    |
+| Query parameters          | ✅                   | ✅                    |
+| Request body parsing      | ✅                   | ✅                    |
+| Static file serving       | ✅ (built-in)        | Via `tower-http`      |
+| Response compression      | ✅ (built-in)        | Via `tower-http`      |
+| WebSocket                 | ✅ (with pub/sub)    | ✅ (raw)              |
+| JSON-RPC                  | ✅ (first-class)     | ❌                    |
+| TypeScript client gen     | ✅ (automatic)       | ❌                    |
+| OpenAPI generation        | ✅ (built-in)        | Via `utoipa`          |
+| Sessions                  | ✅ (built-in)        | Via `tower-sessions`  |
+| CSRF protection           | ✅ (built-in)        | Manual                |
+| JWT auth                  | ✅ (built-in)        | Via ecosystem         |
+| API-key auth              | ✅ (built-in)        | Manual                |
+| Authorization guards      | ✅ (built-in)        | Manual / `axum-extra` |
+| Rate limiting             | ✅ (built-in)        | Via `tower-governor`  |
+| Nested routers            | Basic                | ✅ (advanced)         |
+| Tower middleware          | ❌                   | ✅                    |
+| Compile-time extraction   | ❌ (runtime Context) | ✅                    |
+| `#![forbid(unsafe_code)]` | ✅                   | ❌ (some unsafe)      |
+| Routing complexity        | O(1) hash            | O(log n) trie         |
+| Hot reload (dev)          | ✅ (CLI)             | Via `cargo-watch`     |
+| Project scaffolding       | ✅ (CLI templates)   | Manual                |
 
 ## When to Choose Ultimo
 
@@ -385,4 +386,4 @@ The Rust web ecosystem is richer for having both.
 
 ---
 
-*Ready to try Ultimo? Check out our [getting started guide](/blog/build-your-first-api-with-ultimo) or explore the [examples repository](https://github.com/ultimo-rs/ultimo/tree/main/examples).*
+_Ready to try Ultimo? Check out our [getting started guide](/blog/build-your-first-api-with-ultimo) or explore the [examples repository](https://github.com/ultimo-rs/ultimo/tree/main/examples)._

--- a/website/lib/blog.ts
+++ b/website/lib/blog.ts
@@ -5,21 +5,21 @@ import path from "path";
 const postsDirectory = path.join(process.cwd(), "content/posts");
 
 export interface PostMeta {
-	slug: string;
-	title: string;
-	description: string;
-	date: string;
-	author: string;
-	tags: string[];
-	image?: string;
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  tags: string[];
+  image?: string;
 }
 
 export function getAllPosts(): PostMeta[] {
-	if (!fs.existsSync(postsDirectory)) {
-		return [];
-	}
+  if (!fs.existsSync(postsDirectory)) {
+    return [];
+  }
 
-	const files = fs
+  const files = fs
     .readdirSync(postsDirectory)
     .filter((f) => f.endsWith(".mdx"));
 
@@ -46,25 +46,25 @@ export function getAllPosts(): PostMeta[] {
 }
 
 export function getPostBySlug(slug: string) {
-	const filePath = path.join(postsDirectory, `${slug}.mdx`);
+  const filePath = path.join(postsDirectory, `${slug}.mdx`);
 
-	if (!fs.existsSync(filePath)) {
-		return null;
-	}
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
 
-	const fileContents = fs.readFileSync(filePath, "utf8");
-	const { data, content } = matter(fileContents);
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  const { data, content } = matter(fileContents);
 
-	return {
-		meta: {
-			slug,
-			title: data.title ?? slug,
-			description: data.description ?? "",
-			date: data.date ?? "",
-			author: data.author ?? "Ultimo Team",
-			tags: data.tags ?? [],
-			image: data.image,
-		} satisfies PostMeta,
-		content,
-	};
+  return {
+    meta: {
+      slug,
+      title: data.title ?? slug,
+      description: data.description ?? "",
+      date: data.date ?? "",
+      author: data.author ?? "Ultimo Team",
+      tags: data.tags ?? [],
+      image: data.image,
+    } satisfies PostMeta,
+    content,
+  };
 }

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/website/package.json
+++ b/website/package.json
@@ -60,6 +60,7 @@
     "recharts": "2.15.4",
     "rehype-pretty-code": "^0.14.3",
     "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "shiki": "^4.2.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.5.5",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       shiki:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1475,6 +1478,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -1679,8 +1686,32 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1708,6 +1739,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -2012,6 +2064,9 @@ packages:
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
@@ -2020,6 +2075,9 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3526,6 +3584,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   esprima@4.0.1: {}
 
   estree-util-attach-comments@3.0.0:
@@ -3785,6 +3845,15 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3799,6 +3868,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3901,6 +4027,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -4360,6 +4544,17 @@ snapshots:
       hast-util-to-string: 3.0.1
       unist-util-visit: 5.1.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-mdx@3.1.1:
     dependencies:
       mdast-util-mdx: 3.0.0
@@ -4383,6 +4578,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   scheduler@0.27.0: {}
 


### PR DESCRIPTION
- Add remark-gfm for proper GFM table rendering in MDX blog posts
- Fix link hover (prose-a:hover:underline instead of hover:prose-a:underline)
- Strip duplicate H1 from MDX content (already rendered in page header)