### PR TITLE
feat(website): RSS, JSON-LD, reading time, related posts, canonical URLs

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Calendar, User } from "lucide-react";
+import { ArrowLeft, Calendar, Clock, User } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -7,7 +7,7 @@ import rehypePrettyCode from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { TableOfContents } from "@/components/table-of-contents";
-import { getAllPosts, getPostBySlug } from "@/lib/blog";
+import { getAllPosts, getPostBySlug, getRelatedPosts } from "@/lib/blog";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -25,15 +25,20 @@ export async function generateMetadata({
   const post = getPostBySlug(slug);
   if (!post) return {};
 
+  const url = `https://ultimo.dev/blog/${slug}`;
+
   return {
     title: `${post.meta.title} - Ultimo Blog`,
     description: post.meta.description,
+    alternates: { canonical: url },
     openGraph: {
       title: post.meta.title,
       description: post.meta.description,
       type: "article",
+      url,
       publishedTime: post.meta.date,
       authors: [post.meta.author],
+      tags: post.meta.tags,
     },
   };
 }
@@ -48,9 +53,31 @@ export default async function BlogPostPage({ params }: PageProps) {
 
   // Strip the first H1 from content since we render it in the header
   const content = post.content.replace(/^\s*#\s+.+\n+/, "");
+  const relatedPosts = getRelatedPosts(slug, 3);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.meta.title,
+    description: post.meta.description,
+    datePublished: post.meta.date,
+    author: { "@type": "Person", name: post.meta.author },
+    publisher: {
+      "@type": "Organization",
+      name: "Ultimo",
+      url: "https://ultimo.dev",
+    },
+    url: `https://ultimo.dev/blog/${slug}`,
+    wordCount: content.split(/\s+/).length,
+    keywords: post.meta.tags.join(", "),
+  };
 
   return (
     <div className="min-h-screen selection:bg-orange-500/30">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="container mx-auto px-4 py-24 max-w-6xl">
         <Link
           href="/blog"
@@ -91,6 +118,10 @@ export default async function BlogPostPage({ params }: PageProps) {
                     })}
                   </time>
                 </span>
+                <span className="flex items-center gap-1.5">
+                  <Clock className="w-4 h-4" />
+                  {post.meta.readingTime} min read
+                </span>
               </div>
             </header>
 
@@ -110,6 +141,27 @@ export default async function BlogPostPage({ params }: PageProps) {
             </div>
 
             <footer className="mt-16 pt-8 border-t border-border/50">
+              {relatedPosts.length > 0 && (
+                <div className="mb-12">
+                  <h2 className="text-lg font-semibold mb-4">Related Posts</h2>
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {relatedPosts.map((related) => (
+                      <Link
+                        key={related.slug}
+                        href={`/blog/${related.slug}`}
+                        className="group block p-4 rounded-lg border border-border/50 hover:border-orange-500/30 transition-colors"
+                      >
+                        <h3 className="text-sm font-medium group-hover:text-orange-400 transition-colors line-clamp-2">
+                          {related.title}
+                        </h3>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {related.readingTime} min read
+                        </p>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
               <Link
                 href="/blog"
                 className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-orange-400 transition-colors"

--- a/website/app/blog/feed.xml/route.ts
+++ b/website/app/blog/feed.xml/route.ts
@@ -1,0 +1,42 @@
+import { getAllPosts } from "@/lib/blog";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const posts = getAllPosts();
+  const siteUrl = "https://ultimo.dev";
+
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title><![CDATA[${post.title}]]></title>
+      <link>${siteUrl}/blog/${post.slug}</link>
+      <guid isPermaLink="true">${siteUrl}/blog/${post.slug}</guid>
+      <description><![CDATA[${post.description}]]></description>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <author>hello@ultimo.dev (${post.author})</author>
+      ${post.tags.map((tag) => `<category>${tag}</category>`).join("\n      ")}
+    </item>`,
+    )
+    .join("\n");
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Ultimo Blog</title>
+    <link>${siteUrl}/blog</link>
+    <description>Technical articles about building modern web applications with Rust and Ultimo</description>
+    <language>en-us</language>
+    <lastBuildDate>${new Date(posts[0]?.date ?? Date.now()).toUTCString()}</lastBuildDate>
+    <atom:link href="${siteUrl}/blog/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(feed, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -29,6 +29,10 @@ export const metadata: Metadata = {
     template: "%s | Ultimo",
   },
   description,
+  alternates: {
+    canonical: siteUrl,
+    types: { "application/rss+xml": "/blog/feed.xml" },
+  },
   keywords: [
     "Rust web framework",
     "TypeScript client generation",

--- a/website/lib/blog.ts
+++ b/website/lib/blog.ts
@@ -4,6 +4,11 @@ import path from "path";
 
 const postsDirectory = path.join(process.cwd(), "content/posts");
 
+function getReadingTime(content: string): number {
+  const words = content.replace(/```[\s\S]*?```/g, "").split(/\s+/).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
 export interface PostMeta {
   slug: string;
   title: string;
@@ -12,6 +17,7 @@ export interface PostMeta {
   author: string;
   tags: string[];
   image?: string;
+  readingTime: number;
 }
 
 export function getAllPosts(): PostMeta[] {
@@ -27,7 +33,7 @@ export function getAllPosts(): PostMeta[] {
     const slug = filename.replace(/\.mdx$/, "");
     const filePath = path.join(postsDirectory, filename);
     const fileContents = fs.readFileSync(filePath, "utf8");
-    const { data } = matter(fileContents);
+    const { data, content } = matter(fileContents);
 
     return {
       slug,
@@ -37,6 +43,7 @@ export function getAllPosts(): PostMeta[] {
       author: data.author ?? "Ultimo Team",
       tags: data.tags ?? [],
       image: data.image,
+      readingTime: getReadingTime(content),
     } satisfies PostMeta;
   });
 
@@ -64,7 +71,24 @@ export function getPostBySlug(slug: string) {
       author: data.author ?? "Ultimo Team",
       tags: data.tags ?? [],
       image: data.image,
+      readingTime: getReadingTime(content),
     } satisfies PostMeta,
     content,
   };
+}
+
+export function getRelatedPosts(slug: string, limit = 3): PostMeta[] {
+  const posts = getAllPosts();
+  const current = posts.find((p) => p.slug === slug);
+  if (!current) return posts.filter((p) => p.slug !== slug).slice(0, limit);
+
+  return posts
+    .filter((p) => p.slug !== slug)
+    .map((p) => ({
+      post: p,
+      score: p.tags.filter((t) => current.tags.includes(t)).length,
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((r) => r.post);
 }

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
SEO improvements batch 2:

- **RSS feed** at `/blog/feed.xml` (RSS 2.0 + Atom self-link)
- **BlogPosting JSON-LD** per post (structured data for rich snippets)
- **Reading time** shown in post header (calculated at build time)
- **Related posts** section at bottom of each post (tag-based relevance)
- **Canonical URLs** on every blog post + RSS alternate in root layout