### PR TITLE
docs: remove unverified numeric throughput claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,18 @@ any of it requires a deliberate version bump:
 - Any `pub` item (types, fns, traits, enum variants, fields) and the `prelude`
 - **Cargo feature names** (`websocket`, `testing`, `session`, `csrf`, `database`, `sqlx-*`, `diesel-*`, `test-helpers`) — renaming/removing breaks `features = [...]` downstream
 - **MSRV** (`rust-version`) — raising it is breaking (we're at 1.86.0)
-- **Direct dependency floors** — raising one (e.g. `bytes`, `diesel`) constrains downstream resolution; a dep type re-exported in our API (e.g. `bytes::Bytes` in WebSocket messages) makes that dep's version part of *our* API
+- **Direct dependency floors** — raising one (e.g. `bytes`, `diesel`) constrains downstream resolution; a dep type re-exported in our API (e.g. `bytes::Bytes` in WebSocket messages) makes that dep's version part of _our_ API
 - CLI subcommands / flags of `ultimo-cli`
 
 ### On EVERY change
+
 1. **Decide SemVer impact.** Pre-1.0 (0.x): breaking → bump **minor** (0.3.x → 0.4.0); additive/fix → bump **patch**. CI's `semver-checks` enforces this against the published crate — respect its verdict.
-2. **Don't hand-edit `CHANGELOG.md`** — release-plz regenerates it from your conventional commits. Write a good commit message; that *is* the changelog entry.
+2. **Don't hand-edit `CHANGELOG.md`** — release-plz regenerates it from your conventional commits. Write a good commit message; that _is_ the changelog entry.
 3. **Keep `README.md` accurate** — it's the crates.io landing page.
 4. **Don't break docs.rs** — public items need doc comments; doctests must compile (`cargo test --doc`).
 
 ### On a RELEASE (automated by release-plz — rarely done by hand)
+
 release-plz opens a release PR that bumps `version` in root `Cargo.toml`
 (`[workspace.package]`, shared by both crates) and writes the `CHANGELOG.md`
 section from commits. Merging it publishes **`ultimo` then `ultimo-cli`** to
@@ -38,14 +40,15 @@ and ship a fixed patch.
 
 Cargo workspace (`resolver = "2"`). Members:
 
-| Crate / path | Role |
-|---|---|
-| `ultimo/` | **The framework.** Core library — everything below is a module here. |
-| `ultimo-cli/` | CLI binary (clap). Subcommands: `generate` (TS client), `new` (scaffold), `dev` (hot-reload server), `build`. |
-| `coverage-tool/` | Custom coverage runner (`ultimo-coverage`), invoked by `make coverage`. |
-| `examples/*` | Runnable example apps. `Cargo.toml` `members` is the source of truth — some dirs (`react-app`, `benchmark`, `database-with-openapi`) exist on disk but aren't members. |
+| Crate / path     | Role                                                                                                                                                                   |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ultimo/`        | **The framework.** Core library — everything below is a module here.                                                                                                   |
+| `ultimo-cli/`    | CLI binary (clap). Subcommands: `generate` (TS client), `new` (scaffold), `dev` (hot-reload server), `build`.                                                          |
+| `coverage-tool/` | Custom coverage runner (`ultimo-coverage`), invoked by `make coverage`.                                                                                                |
+| `examples/*`     | Runnable example apps. `Cargo.toml` `members` is the source of truth — some dirs (`react-app`, `benchmark`, `database-with-openapi`) exist on disk but aren't members. |
 
 ### `ultimo/src` modules (`lib.rs` is the map)
+
 - `app.rs` (`Ultimo` builder), `context.rs` (`Context`), `router.rs`, `handler.rs`, `middleware.rs`
 - `rpc.rs` — JSON-RPC registry + **TypeScript client codegen** (`RpcRegistry`)
 - `response.rs`, `error.rs` (`UltimoError`/`Result`), `validation.rs` (`validate`), `openapi.rs` (+ `openapi/docs.rs`)
@@ -78,6 +81,7 @@ transitively by `sqlx-postgres|mysql|sqlite`, `diesel-postgres|mysql|sqlite`).
    rot. Install them (`brew install mysql-client libpq`) or scope features.
 
 Verified-good invocations:
+
 ```bash
 cargo fmt --all --check
 cargo test -p ultimo --lib
@@ -99,6 +103,7 @@ make ci              # check + test + coverage
 ```
 
 CLI usage (the product surface):
+
 ```bash
 cargo run -p ultimo-cli -- new <name> --template <basic|fullstack|api-only|rpc|production>
 cargo run -p ultimo-cli -- generate --path <dir> --output <dir> [--watch]   # TS client gen
@@ -107,11 +112,13 @@ cargo run -p ultimo-cli -- build --profile <debug|release>
 ```
 
 ## Benchmarks
+
 `ultimo/benches/` (criterion, `harness = false`): `websocket_bench.rs`,
 `websocket_pubsub_bench.rs`. Perf claims (158k+ req/s) live or die by these —
 guard against regressions before changing hot paths.
 
 ## CI / repo state
+
 - **`ci.yml`** (push + PR to `main`): `fmt + clippy`, `test` (ubuntu + macOS:
   lib + feature-gated integration + CLI + benches), `test-db` (sqlite DB tests),
   `MSRV` (reads `rust-version` from Cargo.toml), `semver-checks` (public-API
@@ -122,18 +129,21 @@ guard against regressions before changing hot paths.
   branch protection requires 1 review → solo merges use `--admin` override.
 
 ## Shipping changes — use the `ship-feature` skill
+
 `.claude/skills/ship-feature/SKILL.md` encodes the standard loop:
 **branch → TDD → docs surfaces → verification gate → PR → CI green →
 `gh pr merge --squash --admin --delete-branch` → sync.** Conventional commits
 throughout. Invoke it for any change to this repo.
 
 ## Roadmap
+
 - **v0.3.0 (current):** sessions + cookies, CSRF, security headers, testing utilities, `#![forbid(unsafe_code)]`, client-IP extraction — all shipped.
 - v0.4.0: **Security & Performance** (Ultimo's two headline pillars) — auth (JWT/API-key), authz guards, rate-limit/timeouts, IP allow/deny, continuous benchmarking + `/performance` page.
 - v0.5.0: static files + SPA fallback, compression, hot reload, dev dashboard, multi-language client gen, **deployment guides**.
 - v0.6.0: MCP server for AI-assisted development. v1.0.0: stable API + complete docs.
 
 ## Documentation surfaces (MUST keep current, in the same PR as the change)
+
 The `ship-feature` skill walks these — summary of the rules:
 
 1. **`README.md`** — GitHub + crates.io landing page. Move shipped items "Coming Soon" → "Available Now"; keep install snippet (`ultimo = "0.x"`) + badges accurate. Never advertise a shipped feature as coming-soon (or vice-versa).
@@ -143,12 +153,14 @@ The `ship-feature` skill walks these — summary of the rules:
 5. Keep **`docs-site/docs/pages/roadmap.mdx`** honest — move shipped features to the right version section.
 
 ## Conventions
+
 - **Published crates** — see the PUBLISHED CRATES section before changing public code, features, MSRV, or dep floors.
 - Use Makefile targets, not raw cargo, where one exists.
 - Breaking public-API changes must be deliberate and version-bumped; `cargo-semver-checks` runs in CI — respect its verdict.
 - Run `cargo fmt --all` and `cargo clippy` before committing (`.githooks/` may enforce this).
 
 ## Website SEO conventions (`website/`)
+
 Every new page on ultimo.dev MUST include:
 
 1. **Canonical URL** — `alternates: { canonical: "https://ultimo.dev/<path>" }` in the page's `metadata` export.

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -184,7 +184,7 @@ The **Security & Performance** milestone.
 - **MSRV**: Rust 1.75.0
 - **Runtime**: Tokio (async)
 - **HTTP**: Hyper 1.x
-- **Performance**: 152k+ req/sec (matches Axum)
+- **Performance**: Benchmark suite and comparison examples included
 
 ---
 

--- a/docs-site/docs/pages/index.mdx
+++ b/docs-site/docs/pages/index.mdx
@@ -13,7 +13,7 @@ Build type-safe full-stack applications with Rust backend and TypeScript fronten
 
 ## ✨ Key Features
 
-- **⚡ Blazing Fast** - 158k+ req/sec, industry-leading performance
+- **⚡ Low-Latency by Design** - Built on Hyper + Tokio with O(1) routing
 - **🔒 Type-Safe** - End-to-end type safety from Rust to TypeScript
 - **🚀 Auto TypeScript** - Generate type-safe clients automatically
 - **📋 OpenAPI Built-in** - Generate specs for Swagger UI and API docs
@@ -39,16 +39,14 @@ async fn main() -> ultimo::Result<()> {
 
 ## 📊 Performance
 
-Ultimo delivers exceptional performance, matching industry-leading frameworks:
+Ultimo is designed for predictable low-latency backend workloads.
 
-| Framework   | Throughput       | Avg Latency |
-| ----------- | ---------------- | ----------- |
-| **Ultimo**  | **158k req/sec** | **0.6ms**   |
-| Axum (Rust) | 153k req/sec     | 0.6ms       |
-| Hono (Bun)  | 132k req/sec     | 0.8ms       |
-| FastAPI     | 10k req/sec      | 9.5ms       |
+- Built on Hyper 1.x + Tokio async runtime
+- O(1) constant-time route lookup
+- Continuous benchmarks in the repository to catch regressions
 
-**15x faster than FastAPI** with zero performance penalty for auto-generation.
+For reproducible numbers, run the benchmark suite in your own environment:
+[Benchmark examples](https://github.com/ultimo-rs/ultimo/tree/main/examples/benchmark)
 
 ## 🎯 Type-Safe Full Stack
 

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -76,30 +76,88 @@ export default async function BlogPostPage({ params }: PageProps) {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: "https://ultimo.dev" },
-      { "@type": "ListItem", position: 2, name: "Blog", item: "https://ultimo.dev/blog" },
-      { "@type": "ListItem", position: 3, name: post.meta.title, item: `https://ultimo.dev/blog/${slug}` },
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://ultimo.dev",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://ultimo.dev/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: post.meta.title,
+        item: `https://ultimo.dev/blog/${slug}`,
+      },
     ],
   };
 
   // HowTo schema for the tutorial post
-  const howToLd = slug === "build-your-first-api-with-ultimo" ? {
-    "@context": "https://schema.org",
-    "@type": "HowTo",
-    name: "Build Your First API with Ultimo in 10 Minutes",
-    description: post.meta.description,
-    totalTime: "PT10M",
-    step: [
-      { "@type": "HowToStep", position: 1, name: "Create Your Project", text: "Create a new Rust project and install the Ultimo CLI with cargo." },
-      { "@type": "HowToStep", position: 2, name: "Configure Dependencies", text: "Add ultimo, tokio, and serde to your Cargo.toml." },
-      { "@type": "HowToStep", position: 3, name: "Define Your Data Model", text: "Create Rust structs with Serialize, Deserialize, and TS derives." },
-      { "@type": "HowToStep", position: 4, name: "Create REST Endpoints", text: "Define route handlers for CRUD operations using Ultimo's Context API." },
-      { "@type": "HowToStep", position: 5, name: "Add JSON-RPC Methods", text: "Register RPC query and mutation handlers in the RPC registry." },
-      { "@type": "HowToStep", position: 6, name: "Wire Up the Server", text: "Configure the Ultimo app with routes, RPC, and start listening." },
-      { "@type": "HowToStep", position: 7, name: "Test Your API", text: "Use curl to test REST and JSON-RPC endpoints." },
-      { "@type": "HowToStep", position: 8, name: "Generate TypeScript Client", text: "Run ultimo generate to create a fully typed TypeScript client." },
-    ],
-  } : null;
+  const howToLd =
+    slug === "build-your-first-api-with-ultimo"
+      ? {
+          "@context": "https://schema.org",
+          "@type": "HowTo",
+          name: "Build Your First API with Ultimo in 10 Minutes",
+          description: post.meta.description,
+          totalTime: "PT10M",
+          step: [
+            {
+              "@type": "HowToStep",
+              position: 1,
+              name: "Create Your Project",
+              text: "Create a new Rust project and install the Ultimo CLI with cargo.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 2,
+              name: "Configure Dependencies",
+              text: "Add ultimo, tokio, and serde to your Cargo.toml.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 3,
+              name: "Define Your Data Model",
+              text: "Create Rust structs with Serialize, Deserialize, and TS derives.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 4,
+              name: "Create REST Endpoints",
+              text: "Define route handlers for CRUD operations using Ultimo's Context API.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 5,
+              name: "Add JSON-RPC Methods",
+              text: "Register RPC query and mutation handlers in the RPC registry.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 6,
+              name: "Wire Up the Server",
+              text: "Configure the Ultimo app with routes, RPC, and start listening.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 7,
+              name: "Test Your API",
+              text: "Use curl to test REST and JSON-RPC endpoints.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 8,
+              name: "Generate TypeScript Client",
+              text: "Run ultimo generate to create a fully typed TypeScript client.",
+            },
+          ],
+        }
+      : null;
 
   return (
     <div className="min-h-screen selection:bg-orange-500/30">

--- a/website/app/features/page.tsx
+++ b/website/app/features/page.tsx
@@ -29,27 +29,33 @@ export const metadata: Metadata = {
 const faqs = [
   {
     question: "How does Ultimo compare to Axum in performance?",
-    answer: "Both Ultimo and Axum are built on Hyper 1.0 + Tokio, so raw throughput is nearly identical (150K+ req/s). The difference is in developer experience — Ultimo includes sessions, auth, TypeScript codegen, and WebSocket pub/sub out of the box.",
+    answer:
+      "Both Ultimo and Axum are built on Hyper 1.0 + Tokio, so baseline performance characteristics are similar. Ultimo focuses on developer experience with sessions, auth, TypeScript codegen, and WebSocket pub/sub built in.",
   },
   {
     question: "Does Ultimo support automatic TypeScript client generation?",
-    answer: "Yes. Add #[derive(TS)] to your Rust structs, register RPC handlers, and run 'ultimo generate'. You get a fully typed TypeScript client with zero manual type maintenance.",
+    answer:
+      "Yes. Add #[derive(TS)] to your Rust structs, register RPC handlers, and run 'ultimo generate'. You get a fully typed TypeScript client with zero manual type maintenance.",
   },
   {
     question: "Can I use Ultimo with my existing database setup?",
-    answer: "Absolutely. Ultimo is database-agnostic and works with SQLx, Diesel, SeaORM, or any Rust database library. It provides connection pooling and transaction middleware without vendor lock-in.",
+    answer:
+      "Absolutely. Ultimo is database-agnostic and works with SQLx, Diesel, SeaORM, or any Rust database library. It provides connection pooling and transaction middleware without vendor lock-in.",
   },
   {
     question: "Is Ultimo production-ready?",
-    answer: "Yes. Ultimo uses #![forbid(unsafe_code)] for memory safety, includes built-in security features (JWT, CSRF, rate limiting), and ships with testing utilities. It's benchmarked in CI to prevent performance regressions.",
+    answer:
+      "Yes. Ultimo uses #![forbid(unsafe_code)] for memory safety, includes built-in security features (JWT, CSRF, rate limiting), and ships with testing utilities. It's benchmarked in CI to prevent performance regressions.",
   },
   {
     question: "How do I deploy an Ultimo application?",
-    answer: "Ultimo compiles to a single static binary with no runtime dependencies. Deploy anywhere Rust runs: Docker containers, Kubernetes, bare metal servers, or edge computing platforms.",
+    answer:
+      "Ultimo compiles to a single static binary with no runtime dependencies. Deploy anywhere Rust runs: Docker containers, Kubernetes, bare metal servers, or edge computing platforms.",
   },
   {
     question: "Does Ultimo support WebSocket?",
-    answer: "Yes. Ultimo includes RFC 6455 WebSocket support with built-in pub/sub channels, making real-time features like chat, notifications, and live updates straightforward to implement.",
+    answer:
+      "Yes. Ultimo includes RFC 6455 WebSocket support with built-in pub/sub channels, making real-time features like chat, notifications, and live updates straightforward to implement.",
   },
 ];
 
@@ -322,9 +328,14 @@ export default function FeaturesPage() {
           </h2>
           <div className="space-y-6">
             {faqs.map((faq, index) => (
-              <div key={index} className="rounded-xl border border-border bg-card p-6">
+              <div
+                key={index}
+                className="rounded-xl border border-border bg-card p-6"
+              >
                 <h3 className="font-semibold text-lg mb-2">{faq.question}</h3>
-                <p className="text-muted-foreground leading-relaxed">{faq.answer}</p>
+                <p className="text-muted-foreground leading-relaxed">
+                  {faq.answer}
+                </p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Removes all fabricated 158k/152k req/sec numbers and comparison tables from user-facing pages.

## Changes
- `docs-site/docs/pages/index.mdx` — replaced numeric benchmark table with O(1) routing + Hyper/Tokio description + link to reproducible benchmark examples
- `docs-site/docs/pages/changelog.mdx` — removed '152k+ req/sec (matches Axum)'  
- `website/app/features/page.tsx` — removed '150K+ req/s' from FAQ performance answer

## Why
These numbers were fabricated marketing copy with no reproducible evidence. They undermine trust and could mislead users. The honest claim is: Ultimo is built on Hyper + Tokio (same foundation as Axum/actix) with O(1) routing — users should run benchmarks in their own environment.