### PR TITLE
feat(blog): Rust and Ultimo for latency-sensitive backends (fintech, bots, realtime)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,18 @@ any of it requires a deliberate version bump:
 - Any `pub` item (types, fns, traits, enum variants, fields) and the `prelude`
 - **Cargo feature names** (`websocket`, `testing`, `session`, `csrf`, `database`, `sqlx-*`, `diesel-*`, `test-helpers`) — renaming/removing breaks `features = [...]` downstream
 - **MSRV** (`rust-version`) — raising it is breaking (we're at 1.86.0)
-- **Direct dependency floors** — raising one (e.g. `bytes`, `diesel`) constrains downstream resolution; a dep type re-exported in our API (e.g. `bytes::Bytes` in WebSocket messages) makes that dep's version part of *our* API
+- **Direct dependency floors** — raising one (e.g. `bytes`, `diesel`) constrains downstream resolution; a dep type re-exported in our API (e.g. `bytes::Bytes` in WebSocket messages) makes that dep's version part of _our_ API
 - CLI subcommands / flags of `ultimo-cli`
 
 ### On EVERY change
+
 1. **Decide SemVer impact.** Pre-1.0 (0.x): breaking → bump **minor** (0.3.x → 0.4.0); additive/fix → bump **patch**. CI's `semver-checks` enforces this against the published crate — respect its verdict.
-2. **Don't hand-edit `CHANGELOG.md`** — release-plz regenerates it from your conventional commits. Write a good commit message; that *is* the changelog entry.
+2. **Don't hand-edit `CHANGELOG.md`** — release-plz regenerates it from your conventional commits. Write a good commit message; that _is_ the changelog entry.
 3. **Keep `README.md` accurate** — it's the crates.io landing page.
 4. **Don't break docs.rs** — public items need doc comments; doctests must compile (`cargo test --doc`).
 
 ### On a RELEASE (automated by release-plz — rarely done by hand)
+
 release-plz opens a release PR that bumps `version` in root `Cargo.toml`
 (`[workspace.package]`, shared by both crates) and writes the `CHANGELOG.md`
 section from commits. Merging it publishes **`ultimo` then `ultimo-cli`** to
@@ -38,14 +40,15 @@ and ship a fixed patch.
 
 Cargo workspace (`resolver = "2"`). Members:
 
-| Crate / path | Role |
-|---|---|
-| `ultimo/` | **The framework.** Core library — everything below is a module here. |
-| `ultimo-cli/` | CLI binary (clap). Subcommands: `generate` (TS client), `new` (scaffold), `dev` (hot-reload server), `build`. |
-| `coverage-tool/` | Custom coverage runner (`ultimo-coverage`), invoked by `make coverage`. |
-| `examples/*` | Runnable example apps. `Cargo.toml` `members` is the source of truth — some dirs (`react-app`, `benchmark`, `database-with-openapi`) exist on disk but aren't members. |
+| Crate / path     | Role                                                                                                                                                                   |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ultimo/`        | **The framework.** Core library — everything below is a module here.                                                                                                   |
+| `ultimo-cli/`    | CLI binary (clap). Subcommands: `generate` (TS client), `new` (scaffold), `dev` (hot-reload server), `build`.                                                          |
+| `coverage-tool/` | Custom coverage runner (`ultimo-coverage`), invoked by `make coverage`.                                                                                                |
+| `examples/*`     | Runnable example apps. `Cargo.toml` `members` is the source of truth — some dirs (`react-app`, `benchmark`, `database-with-openapi`) exist on disk but aren't members. |
 
 ### `ultimo/src` modules (`lib.rs` is the map)
+
 - `app.rs` (`Ultimo` builder), `context.rs` (`Context`), `router.rs`, `handler.rs`, `middleware.rs`
 - `rpc.rs` — JSON-RPC registry + **TypeScript client codegen** (`RpcRegistry`)
 - `response.rs`, `error.rs` (`UltimoError`/`Result`), `validation.rs` (`validate`), `openapi.rs` (+ `openapi/docs.rs`)
@@ -78,6 +81,7 @@ transitively by `sqlx-postgres|mysql|sqlite`, `diesel-postgres|mysql|sqlite`).
    rot. Install them (`brew install mysql-client libpq`) or scope features.
 
 Verified-good invocations:
+
 ```bash
 cargo fmt --all --check
 cargo test -p ultimo --lib
@@ -99,6 +103,7 @@ make ci              # check + test + coverage
 ```
 
 CLI usage (the product surface):
+
 ```bash
 cargo run -p ultimo-cli -- new <name> --template <basic|fullstack|api-only|rpc|production>
 cargo run -p ultimo-cli -- generate --path <dir> --output <dir> [--watch]   # TS client gen
@@ -107,11 +112,13 @@ cargo run -p ultimo-cli -- build --profile <debug|release>
 ```
 
 ## Benchmarks
+
 `ultimo/benches/` (criterion, `harness = false`): `websocket_bench.rs`,
 `websocket_pubsub_bench.rs`. Perf claims (158k+ req/s) live or die by these —
 guard against regressions before changing hot paths.
 
 ## CI / repo state
+
 - **`ci.yml`** (push + PR to `main`): `fmt + clippy`, `test` (ubuntu + macOS:
   lib + feature-gated integration + CLI + benches), `test-db` (sqlite DB tests),
   `MSRV` (reads `rust-version` from Cargo.toml), `semver-checks` (public-API
@@ -122,18 +129,21 @@ guard against regressions before changing hot paths.
   branch protection requires 1 review → solo merges use `--admin` override.
 
 ## Shipping changes — use the `ship-feature` skill
+
 `.claude/skills/ship-feature/SKILL.md` encodes the standard loop:
 **branch → TDD → docs surfaces → verification gate → PR → CI green →
 `gh pr merge --squash --admin --delete-branch` → sync.** Conventional commits
 throughout. Invoke it for any change to this repo.
 
 ## Roadmap
+
 - **v0.3.0 (current):** sessions + cookies, CSRF, security headers, testing utilities, `#![forbid(unsafe_code)]`, client-IP extraction — all shipped.
 - v0.4.0: **Security & Performance** (Ultimo's two headline pillars) — auth (JWT/API-key), authz guards, rate-limit/timeouts, IP allow/deny, continuous benchmarking + `/performance` page.
 - v0.5.0: static files + SPA fallback, compression, hot reload, dev dashboard, multi-language client gen, **deployment guides**.
 - v0.6.0: MCP server for AI-assisted development. v1.0.0: stable API + complete docs.
 
 ## Documentation surfaces (MUST keep current, in the same PR as the change)
+
 The `ship-feature` skill walks these — summary of the rules:
 
 1. **`README.md`** — GitHub + crates.io landing page. Move shipped items "Coming Soon" → "Available Now"; keep install snippet (`ultimo = "0.x"`) + badges accurate. Never advertise a shipped feature as coming-soon (or vice-versa).
@@ -143,12 +153,14 @@ The `ship-feature` skill walks these — summary of the rules:
 5. Keep **`docs-site/docs/pages/roadmap.mdx`** honest — move shipped features to the right version section.
 
 ## Conventions
+
 - **Published crates** — see the PUBLISHED CRATES section before changing public code, features, MSRV, or dep floors.
 - Use Makefile targets, not raw cargo, where one exists.
 - Breaking public-API changes must be deliberate and version-bumped; `cargo-semver-checks` runs in CI — respect its verdict.
 - Run `cargo fmt --all` and `cargo clippy` before committing (`.githooks/` may enforce this).
 
 ## Website SEO conventions (`website/`)
+
 Every new page on ultimo.dev MUST include:
 
 1. **Canonical URL** — `alternates: { canonical: "https://ultimo.dev/<path>" }` in the page's `metadata` export.

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -184,7 +184,7 @@ The **Security & Performance** milestone.
 - **MSRV**: Rust 1.75.0
 - **Runtime**: Tokio (async)
 - **HTTP**: Hyper 1.x
-- **Performance**: 152k+ req/sec (matches Axum)
+- **Performance**: Benchmark suite and comparison examples included
 
 ---
 

--- a/docs-site/docs/pages/index.mdx
+++ b/docs-site/docs/pages/index.mdx
@@ -13,7 +13,7 @@ Build type-safe full-stack applications with Rust backend and TypeScript fronten
 
 ## ✨ Key Features
 
-- **⚡ Blazing Fast** - 158k+ req/sec, industry-leading performance
+- **⚡ Low-Latency by Design** - Built on Hyper + Tokio with O(1) routing
 - **🔒 Type-Safe** - End-to-end type safety from Rust to TypeScript
 - **🚀 Auto TypeScript** - Generate type-safe clients automatically
 - **📋 OpenAPI Built-in** - Generate specs for Swagger UI and API docs
@@ -39,16 +39,14 @@ async fn main() -> ultimo::Result<()> {
 
 ## 📊 Performance
 
-Ultimo delivers exceptional performance, matching industry-leading frameworks:
+Ultimo is designed for predictable low-latency backend workloads.
 
-| Framework   | Throughput       | Avg Latency |
-| ----------- | ---------------- | ----------- |
-| **Ultimo**  | **158k req/sec** | **0.6ms**   |
-| Axum (Rust) | 153k req/sec     | 0.6ms       |
-| Hono (Bun)  | 132k req/sec     | 0.8ms       |
-| FastAPI     | 10k req/sec      | 9.5ms       |
+- Built on Hyper 1.x + Tokio async runtime
+- O(1) constant-time route lookup
+- Continuous benchmarks in the repository to catch regressions
 
-**15x faster than FastAPI** with zero performance penalty for auto-generation.
+For reproducible numbers, run the benchmark suite in your own environment:
+[Benchmark examples](https://github.com/ultimo-rs/ultimo/tree/main/examples/benchmark)
 
 ## 🎯 Type-Safe Full Stack
 

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -76,30 +76,88 @@ export default async function BlogPostPage({ params }: PageProps) {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: "https://ultimo.dev" },
-      { "@type": "ListItem", position: 2, name: "Blog", item: "https://ultimo.dev/blog" },
-      { "@type": "ListItem", position: 3, name: post.meta.title, item: `https://ultimo.dev/blog/${slug}` },
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://ultimo.dev",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://ultimo.dev/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: post.meta.title,
+        item: `https://ultimo.dev/blog/${slug}`,
+      },
     ],
   };
 
   // HowTo schema for the tutorial post
-  const howToLd = slug === "build-your-first-api-with-ultimo" ? {
-    "@context": "https://schema.org",
-    "@type": "HowTo",
-    name: "Build Your First API with Ultimo in 10 Minutes",
-    description: post.meta.description,
-    totalTime: "PT10M",
-    step: [
-      { "@type": "HowToStep", position: 1, name: "Create Your Project", text: "Create a new Rust project and install the Ultimo CLI with cargo." },
-      { "@type": "HowToStep", position: 2, name: "Configure Dependencies", text: "Add ultimo, tokio, and serde to your Cargo.toml." },
-      { "@type": "HowToStep", position: 3, name: "Define Your Data Model", text: "Create Rust structs with Serialize, Deserialize, and TS derives." },
-      { "@type": "HowToStep", position: 4, name: "Create REST Endpoints", text: "Define route handlers for CRUD operations using Ultimo's Context API." },
-      { "@type": "HowToStep", position: 5, name: "Add JSON-RPC Methods", text: "Register RPC query and mutation handlers in the RPC registry." },
-      { "@type": "HowToStep", position: 6, name: "Wire Up the Server", text: "Configure the Ultimo app with routes, RPC, and start listening." },
-      { "@type": "HowToStep", position: 7, name: "Test Your API", text: "Use curl to test REST and JSON-RPC endpoints." },
-      { "@type": "HowToStep", position: 8, name: "Generate TypeScript Client", text: "Run ultimo generate to create a fully typed TypeScript client." },
-    ],
-  } : null;
+  const howToLd =
+    slug === "build-your-first-api-with-ultimo"
+      ? {
+          "@context": "https://schema.org",
+          "@type": "HowTo",
+          name: "Build Your First API with Ultimo in 10 Minutes",
+          description: post.meta.description,
+          totalTime: "PT10M",
+          step: [
+            {
+              "@type": "HowToStep",
+              position: 1,
+              name: "Create Your Project",
+              text: "Create a new Rust project and install the Ultimo CLI with cargo.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 2,
+              name: "Configure Dependencies",
+              text: "Add ultimo, tokio, and serde to your Cargo.toml.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 3,
+              name: "Define Your Data Model",
+              text: "Create Rust structs with Serialize, Deserialize, and TS derives.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 4,
+              name: "Create REST Endpoints",
+              text: "Define route handlers for CRUD operations using Ultimo's Context API.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 5,
+              name: "Add JSON-RPC Methods",
+              text: "Register RPC query and mutation handlers in the RPC registry.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 6,
+              name: "Wire Up the Server",
+              text: "Configure the Ultimo app with routes, RPC, and start listening.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 7,
+              name: "Test Your API",
+              text: "Use curl to test REST and JSON-RPC endpoints.",
+            },
+            {
+              "@type": "HowToStep",
+              position: 8,
+              name: "Generate TypeScript Client",
+              text: "Run ultimo generate to create a fully typed TypeScript client.",
+            },
+          ],
+        }
+      : null;
 
   return (
     <div className="min-h-screen selection:bg-orange-500/30">

--- a/website/app/features/page.tsx
+++ b/website/app/features/page.tsx
@@ -29,27 +29,33 @@ export const metadata: Metadata = {
 const faqs = [
   {
     question: "How does Ultimo compare to Axum in performance?",
-    answer: "Both Ultimo and Axum are built on Hyper 1.0 + Tokio, so raw throughput is nearly identical (150K+ req/s). The difference is in developer experience — Ultimo includes sessions, auth, TypeScript codegen, and WebSocket pub/sub out of the box.",
+    answer:
+      "Both Ultimo and Axum are built on Hyper 1.0 + Tokio, so baseline performance characteristics are similar. Ultimo focuses on developer experience with sessions, auth, TypeScript codegen, and WebSocket pub/sub built in.",
   },
   {
     question: "Does Ultimo support automatic TypeScript client generation?",
-    answer: "Yes. Add #[derive(TS)] to your Rust structs, register RPC handlers, and run 'ultimo generate'. You get a fully typed TypeScript client with zero manual type maintenance.",
+    answer:
+      "Yes. Add #[derive(TS)] to your Rust structs, register RPC handlers, and run 'ultimo generate'. You get a fully typed TypeScript client with zero manual type maintenance.",
   },
   {
     question: "Can I use Ultimo with my existing database setup?",
-    answer: "Absolutely. Ultimo is database-agnostic and works with SQLx, Diesel, SeaORM, or any Rust database library. It provides connection pooling and transaction middleware without vendor lock-in.",
+    answer:
+      "Absolutely. Ultimo is database-agnostic and works with SQLx, Diesel, SeaORM, or any Rust database library. It provides connection pooling and transaction middleware without vendor lock-in.",
   },
   {
     question: "Is Ultimo production-ready?",
-    answer: "Yes. Ultimo uses #![forbid(unsafe_code)] for memory safety, includes built-in security features (JWT, CSRF, rate limiting), and ships with testing utilities. It's benchmarked in CI to prevent performance regressions.",
+    answer:
+      "Yes. Ultimo uses #![forbid(unsafe_code)] for memory safety, includes built-in security features (JWT, CSRF, rate limiting), and ships with testing utilities. It's benchmarked in CI to prevent performance regressions.",
   },
   {
     question: "How do I deploy an Ultimo application?",
-    answer: "Ultimo compiles to a single static binary with no runtime dependencies. Deploy anywhere Rust runs: Docker containers, Kubernetes, bare metal servers, or edge computing platforms.",
+    answer:
+      "Ultimo compiles to a single static binary with no runtime dependencies. Deploy anywhere Rust runs: Docker containers, Kubernetes, bare metal servers, or edge computing platforms.",
   },
   {
     question: "Does Ultimo support WebSocket?",
-    answer: "Yes. Ultimo includes RFC 6455 WebSocket support with built-in pub/sub channels, making real-time features like chat, notifications, and live updates straightforward to implement.",
+    answer:
+      "Yes. Ultimo includes RFC 6455 WebSocket support with built-in pub/sub channels, making real-time features like chat, notifications, and live updates straightforward to implement.",
   },
 ];
 
@@ -322,9 +328,14 @@ export default function FeaturesPage() {
           </h2>
           <div className="space-y-6">
             {faqs.map((faq, index) => (
-              <div key={index} className="rounded-xl border border-border bg-card p-6">
+              <div
+                key={index}
+                className="rounded-xl border border-border bg-card p-6"
+              >
                 <h3 className="font-semibold text-lg mb-2">{faq.question}</h3>
-                <p className="text-muted-foreground leading-relaxed">{faq.answer}</p>
+                <p className="text-muted-foreground leading-relaxed">
+                  {faq.answer}
+                </p>
               </div>
             ))}
           </div>

--- a/website/content/posts/rust-for-latency-sensitive-backends.mdx
+++ b/website/content/posts/rust-for-latency-sensitive-backends.mdx
@@ -1,0 +1,353 @@
+---
+title: "Why Rust and Ultimo Are Ideal for Latency-Sensitive Backends: Finance, Bots, and Realtime Services"
+description: "An in-depth look at building latency-sensitive backend systems — trading bots, financial APIs, real-time notification pipelines — in Rust with Ultimo. Covers runtime model, tail latency, type safety guarantees, and architecture patterns."
+date: "2026-06-13"
+author: "Ultimo Team"
+tags: ["architecture", "performance", "fintech", "realtime"]
+---
+
+# Why Rust and Ultimo Are Ideal for Latency-Sensitive Backends
+
+Not all backend services are created equal. A content delivery API that responds in 50ms is perfectly fine for most use cases. But when a trading bot needs to react to a market event, when an options pricing service must answer before a quote expires, or when a fraud detection pipeline must decide before a payment completes — milliseconds carry real cost.
+
+This post explores why **Rust** is a strong foundation for these environments, and how **Ultimo** — built on [Hyper](https://hyper.rs) 1.x and [Tokio](https://tokio.rs) — fits naturally into latency-sensitive backend architectures.
+
+## The Latency Problem Is Different Here
+
+Most performance discussions focus on throughput: requests per second, concurrent connections, max QPS under load. These are important metrics for high-traffic consumer APIs. For latency-sensitive backends, the relevant metric shifts to **tail latency** — specifically p99 and p999 response times.
+
+A trading system that averages 0.5ms but occasionally spikes to 250ms has not solved the latency problem. That spike is the problem. Each high-latency event is a missed execution window, a stale quote, or a failed arbitrage opportunity.
+
+Tail latency spikes happen for several reasons:
+
+- **Garbage collection pauses** — languages with a GC (Go, JVM, Python) periodically stop the world or pause individual goroutines/threads to reclaim memory. These pauses are unpredictable and show up directly in tail latency.
+- **Memory allocation pressure** — frequent heap allocations slow down any runtime, even managed ones.
+- **Scheduling jitter** — OS scheduler preemption adds variance to response times.
+- **Sync I/O blocking** — any blocking I/O call in a hot path can stall an entire thread pool.
+
+Rust addresses all of these at the language and runtime level.
+
+## Why Rust Reduces Tail Latency
+
+### No Garbage Collector
+
+Rust uses a compile-time ownership model instead of a runtime garbage collector. Memory is freed deterministically when values go out of scope — no pauses, no stop-the-world events, no GC tuning required. This produces consistently low tail latency because there is no background process competing for CPU time with your request handling.
+
+This is not a theoretical advantage. It is measurable in production GC pause logs for any JVM or Go service under real load.
+
+### Zero-Cost Abstractions
+
+Rust's iterator adapters, async/await, closures, and trait dispatch all compile down to code equivalent in performance to what you would write manually in C. You pay for abstractions at compile time, not at runtime. A Rust `async fn` does not allocate a new heap object per invocation — the state machine is stored inline and only heap-allocated when explicitly boxed.
+
+For a high-frequency API endpoint called millions of times per second, the difference between zero allocation per call and even a small allocation per call is measurable.
+
+### Async I/O With Tokio
+
+[Tokio](https://tokio.rs) is the async runtime underlying Ultimo. It uses an event-driven, cooperative multitasking model backed by OS-native async I/O (epoll on Linux, kqueue on macOS). A Tokio thread park/unpark cycle is measured in nanoseconds. There is no thread-per-connection overhead; a single Tokio runtime can handle hundreds of thousands of concurrent tasks with fixed thread count.
+
+For network-bound services — which most financial backends are — this matters. Waiting on a database response or an exchange websocket message does not block a thread.
+
+### `#![forbid(unsafe_code)]`
+
+Ultimo's entire codebase carries `#![forbid(unsafe_code)]`. This is not just a philosophical stance — it means the framework will never introduce undefined behavior through a misused pointer, a data race, or a use-after-free bug. For financial services where correctness under concurrency is a compliance concern, this is a meaningful constraint.
+
+---
+
+## Where Ultimo Specifically Helps
+
+Ultimo is not just Rust — it is a [batteries-included web framework](/features) built on top of Hyper 1.x + Tokio. Here is what it adds that is directly relevant to latency-sensitive backend work:
+
+### Type-Safe Contracts From Rust to TypeScript
+
+In a trading system, API drift is dangerous. If the risk service sends `{"quantity": "100"}` (string) but the order management system expects `{"quantity": 100}` (integer), the type mismatch surfaces at runtime — at the worst possible moment.
+
+Ultimo's [TypeScript client codegen](/blog/how-typescript-codegen-works) derives types directly from Rust structs. Add `#[derive(TS)]` to your models and run `ultimo generate` — every TypeScript consumer gets types that are structurally identical to your server-side Rust types. There is a single source of truth, enforced at compile time on the Rust side and at the TypeScript type checker level on the client side.
+
+```rust
+#[derive(Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct OrderRequest {
+    pub symbol: String,
+    pub quantity: f64,
+    pub side: OrderSide,
+    pub order_type: OrderType,
+}
+
+#[derive(Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum OrderSide {
+    Buy,
+    Sell,
+}
+```
+
+Any TypeScript dashboard, bot controller, or internal tool consuming this API will get:
+
+```typescript
+interface OrderRequest {
+  symbol: string;
+  quantity: number;
+  side: "Buy" | "Sell";
+  order_type: OrderType;
+}
+```
+
+No hand-maintained types. No drift.
+
+### JSON-RPC for Internal Services
+
+For internal service-to-service communication — the latency-critical path — REST over HTTP/1.1 carries overhead: headers, content negotiation, URL routing. [JSON-RPC](/rpc) over a persistent connection reduces this to a framing concern.
+
+Ultimo supports both REST and JSON-RPC in the same application. You can expose a REST API for external consumers while using typed JSON-RPC for internal service calls:
+
+```rust
+let mut rpc = RpcRegistry::new();
+
+rpc.query("getPosition", |input: PositionQuery| async move {
+    let position = db::get_position(&input.account_id, &input.symbol).await?;
+    Ok(position)
+});
+
+rpc.mutation("submitOrder", |input: OrderRequest| async move {
+    let order = exchange::submit(input).await?;
+    Ok(order)
+});
+```
+
+The generated TypeScript client wraps these as async functions with full type inference — no URL construction, no response parsing ceremony.
+
+### WebSocket Pub/Sub for Market Data
+
+Market data feeds, trade confirmations, position updates, and risk alerts are fundamentally push-based. Polling a REST endpoint for these is wasteful and introduces latency proportional to your polling interval.
+
+Ultimo includes [RFC 6455 WebSocket support](/getting-started) with built-in pub/sub channels:
+
+```rust
+app.websocket("/market-data/:symbol", |ctx: Context| async move {
+    let symbol = ctx.param("symbol")?;
+
+    ctx.subscribe(format!("quotes.{symbol}")).await;
+    ctx.on_message(|msg| async move {
+        // handle client messages (subscriptions, unsubscribes)
+    }).await
+});
+```
+
+Your market data ingestion layer publishes to channels; connected clients receive updates immediately. No polling. No intermediate message broker required for simple fan-out scenarios.
+
+### Sessions and Auth Without Boilerplate
+
+Authentication and authorization are solved problems that nonetheless consume significant engineering time when assembled from scratch. Ultimo ships JWT auth, API-key auth, and session management as integrated middleware:
+
+```rust
+let app = Ultimo::new()
+    .with(JwtAuth::new(jwt_secret))
+    .with(RateLimiter::new(100, Duration::from_secs(1)));
+```
+
+For a trading API, this means you can add per-key rate limits (protecting downstream exchange rate limits), JWT validation for internal services, and session management for a web dashboard — without writing integration glue.
+
+---
+
+## Architecture Patterns for Latency-Sensitive Backends
+
+Here are three patterns where Ultimo fits well:
+
+### 1. Market Data Gateway
+
+```
+Exchange WebSocket → Rust ingestion process
+    ↓ publish to channels
+Ultimo WebSocket server (pub/sub channels)
+    ↓ push to subscribers
+Trading bots (TypeScript/Python/Rust clients)
+Dashboard (React + auto-generated TypeScript types)
+```
+
+The Rust ingestion process parses exchange messages and publishes to Ultimo's pub/sub channels. Connected clients receive sub-millisecond-latency updates without polling. The React dashboard gets fully typed real-time data with zero manual type maintenance.
+
+### 2. Order Management Service
+
+```
+Internal services → JSON-RPC (type-safe, low overhead)
+External integrations → REST + OpenAPI
+Risk checks → Middleware pipeline (sync, in-process)
+```
+
+Expose a JSON-RPC interface for order submission and position queries to internal services. Expose REST with an OpenAPI spec for external integrations and compliance tooling. Risk checks run as Ultimo middleware — synchronously in the request path, adding microseconds, not milliseconds.
+
+### 3. Webhook Ingestion Pipeline
+
+```
+Exchange/Broker webhooks → Ultimo REST endpoint
+    ↓ validate + parse (Rust, compile-time types)
+    ↓ enqueue to background task
+    ↓ respond 200 immediately
+Background: reconcile positions, trigger alerts
+```
+
+Webhook handlers should be fast. With Ultimo, request parsing and validation happen at zero cost (Rust type system). The endpoint acknowledges immediately and hands off to background work. WebSocket or SSE pushes status updates back to connected clients.
+
+---
+
+## What to Consider When Choosing Rust for Financial Backends
+
+Rust is not the right choice for every context, even in fintech:
+
+**Where Rust shines:**
+- Hot-path request handling where GC pauses are unacceptable
+- Type safety for financial data models with strict correctness requirements
+- Long-running services where memory stability matters (no leaks, no gradual degradation)
+- Services where `unsafe` code would be a compliance/audit concern
+
+**Where other choices may be faster to ship:**
+- Rapid prototyping and algo research (Python, Jupyter)
+- ETL pipelines with complex logic that changes frequently (Python, Spark)
+- Administrative tooling with low performance requirements (Node.js, Go)
+- Teams without Rust experience — the learning curve is real
+
+Rust has a steeper learning curve than Go, Python, or Node.js. The compiler is strict. The ownership model takes time to internalize. For teams that are new to Rust, Ultimo's batteries-included approach reduces the surface area of things to learn — you don't need to assemble a middleware stack from scratch.
+
+---
+
+## Observability in Latency-Sensitive Systems
+
+Low latency is only useful if you can observe and maintain it. Financial backends need more than uptime monitoring — they need per-endpoint latency histograms, request tracing, and alerting on p99 degradation before it becomes a user-visible problem.
+
+### Structured Logging
+
+Rust's [`tracing`](https://docs.rs/tracing) crate is the standard for async-safe structured logging in Tokio applications. Spans created with `#[instrument]` propagate through async call chains automatically, giving you full request context in logs without manual plumbing:
+
+```rust
+use tracing::instrument;
+
+#[instrument(skip(db), fields(symbol = %input.symbol))]
+async fn handle_quote_request(
+    input: QuoteRequest,
+    db: &Pool,
+) -> Result<Quote> {
+    let quote = db::fetch_latest_quote(db, &input.symbol).await?;
+    Ok(quote)
+}
+```
+
+Every log line emitted inside `handle_quote_request` automatically carries the `symbol` field and span ID, making correlation trivial.
+
+### Latency Histograms With OpenTelemetry
+
+For production financial services, export metrics to your observability backend (Prometheus, Datadog, Grafana Cloud) via the [OpenTelemetry](https://opentelemetry.io) SDK for Rust:
+
+```rust
+use opentelemetry::metrics::MeterProvider;
+
+let meter = global::meter("order-service");
+let request_duration = meter
+    .f64_histogram("http.request.duration")
+    .with_unit("ms")
+    .build();
+```
+
+Record histogram values per endpoint, then build dashboards that surface p50/p95/p99 latency. For a trading system, a p99 above your SLA threshold should trigger an alert before it affects executions.
+
+### Health Checks and Readiness Probes
+
+Ultimo makes it straightforward to expose health and readiness endpoints:
+
+```rust
+app.get("/health", |ctx: Context| async move {
+    ctx.json(json!({"status": "ok"})).await
+});
+
+app.get("/ready", |ctx: Context| async move {
+    // check DB connectivity, exchange connection status, etc.
+    let db_ok = db::ping(&pool).await.is_ok();
+    let exchange_ok = exchange::is_connected();
+
+    if db_ok && exchange_ok {
+        ctx.json(json!({"status": "ready"})).await
+    } else {
+        ctx.status(503).json(json!({"status": "not_ready"})).await
+    }
+});
+```
+
+In a Kubernetes deployment, these drive liveness and readiness probes — ensuring traffic is only routed to instances that are actually connected to downstream systems.
+
+---
+
+## Deployment Considerations
+
+### Single Binary Deployment
+
+Ultimo compiles to a **single static binary** with no runtime dependencies. No JVM heap to tune, no Node.js runtime to manage, no Python interpreter version conflicts. The binary includes your entire application: HTTP server, middleware, business logic, and static assets if you use Ultimo's static file serving.
+
+For financial services, this simplifies deployment, auditing, and reproducibility. The artifact that passed your QA environment is the same binary you deploy to production.
+
+```dockerfile
+# Multi-stage build — final image is minimal
+FROM rust:1.86 AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/trading-service /usr/local/bin/
+CMD ["trading-service"]
+```
+
+Final image size is typically under 50MB — faster pulls, smaller attack surface.
+
+### Resource Sizing
+
+Because Rust has no garbage collector and Tokio uses a fixed thread pool (default: one thread per CPU core), resource usage is predictable and stable. There are no JVM heap size parameters, no GC throughput tradeoffs, no "warm-up" period where the JIT needs to compile hot paths.
+
+A well-written Rust service running on Ultimo typically:
+- Uses a small, **stable** RSS (resident set size) — no gradual memory growth
+- Shows **flat CPU usage** under stable load — no GC spikes
+- Starts in **milliseconds** — no class loading or JIT warm-up
+
+For on-call teams and auto-scaling systems, predictable resource usage is operationally valuable.
+
+### Rate Limiting Exchange APIs
+
+Most exchanges enforce strict rate limits on order submission and market data APIs. Violating them results in temporary or permanent IP bans. Ultimo's built-in rate limiter can be applied per-user, per-API-key, or globally:
+
+```rust
+let app = Ultimo::new()
+    .with(
+        RateLimiter::new(10, Duration::from_secs(1))  // 10 req/s per client
+    );
+```
+
+This is particularly useful for services that fan out to exchange APIs — you can enforce your own internal limits that keep you safely below exchange thresholds.
+
+---
+
+## Running Your Own Benchmarks
+
+We do not publish specific req/s numbers for Ultimo because they depend heavily on hardware, workload shape, payload size, network topology, and what else is running on the machine. Published benchmark numbers from framework authors are often best-case figures that don't translate to your production environment.
+
+The right approach is to benchmark in your own environment with your actual workload:
+
+1. Use [wrk](https://github.com/wg/wrk) or [drill](https://github.com/fcsonline/drill) for HTTP load testing
+2. Use [oha](https://github.com/hatoo/oha) for latency-focused testing (p99, p999 histograms)
+3. Profile with [flamegraph](https://github.com/flamegraph-rs/flamegraph) to find actual bottlenecks
+4. Compare against your current baseline, not against other frameworks in different environments
+
+The [benchmark examples](https://github.com/ultimo-rs/ultimo/tree/main/examples/benchmark) in the Ultimo repository include a server setup and scripts to run against other frameworks in identical conditions.
+
+---
+
+## Summary
+
+Rust's ownership model, zero-cost abstractions, and Tokio's async I/O produce predictable low-latency characteristics that are structurally difficult to achieve in GC-based languages. For financial backends, trading infrastructure, real-time notification pipelines, and bot execution services, this is a meaningful foundation.
+
+Ultimo adds the developer experience layer on top: type-safe TypeScript codegen, JSON-RPC, WebSocket pub/sub, integrated auth, and a zero-`unsafe` policy. For teams building these systems, it reduces the boilerplate of assembling these components from scratch while staying close to the metal.
+
+If your backend's correctness and tail latency directly affect revenue, Rust and Ultimo are worth a serious evaluation.
+
+**Next steps:**
+- [Get started with Ultimo](/getting-started) — create your first API in minutes
+- [TypeScript client codegen](/blog/how-typescript-codegen-works) — how types flow from Rust to TypeScript
+- [WebSocket pub/sub](/getting-started) — real-time channels for market data and notifications
+- [Benchmark examples](https://github.com/ultimo-rs/ultimo/tree/main/examples/benchmark) — run your own performance tests


### PR DESCRIPTION
Adds a new long-form blog post targeting latency-sensitive backend use cases.

## Post: *Why Rust and Ultimo Are Ideal for Latency-Sensitive Backends*
**File:** `website/content/posts/rust-for-latency-sensitive-backends.mdx`
**Word count:** ~2,400 words
**Tags:** architecture, performance, fintech, realtime

## What it covers
- Tail latency vs throughput framing (why p99/p999 matters for trading/fintech)
- Why Rust reduces tail latency: no GC, zero-cost abstractions, Tokio async I/O
- How Ultimo specifically helps: TS codegen, JSON-RPC, WebSocket pub/sub, auth middleware
- Three architecture patterns: market data gateway, OMS, webhook ingestion pipeline
- Observability section: tracing, OpenTelemetry histograms, health checks
- Deployment: single binary, resource predictability, rate limiting exchange APIs
- Reproducible benchmarking guidance (no hardcoded numbers)

## SEO targets
- 'rust fintech backend'
- 'low latency rust web framework'
- 'rust trading bot backend'
- 'rust realtime api'