### PR TITLE
fix(website): Lighthouse audit — 100 Accessibility, 100 Best Practices

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -18,9 +18,9 @@ const geistMono = Geist_Mono({
 });
 
 const siteUrl = "https://ultimo.dev";
-const title = "Ultimo - Modern Rust Web Framework";
+const title = "Ultimo - The Rust Framework for Speed, Security & Efficiency";
 const description =
-  "Performance-equivalent to Axum with automatic TypeScript client generation. The modern full-stack framework for Rust.";
+  "The Rust web framework built for speed, security, and efficiency. Type-safe APIs with automatic TypeScript client generation for trading platforms, AI backends, and latency-sensitive systems.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -75,7 +75,7 @@ export function HeroSection() {
               <div className="h-3 w-3 rounded-full bg-yellow-500/20 border border-yellow-500/50" />
               <div className="h-3 w-3 rounded-full bg-green-500/20 border border-green-500/50" />
             </div>
-            <div className="mx-auto text-xs font-mono text-zinc-500">
+            <div className="mx-auto text-xs font-mono text-zinc-400">
               server.rs
             </div>
           </div>
@@ -91,13 +91,13 @@ export function HeroSection() {
                 <span className="text-yellow-300">main</span>() {"->"}{" "}
                 <span className="text-zinc-100">ultimo::Result{"<()>"}</span>{" "}
                 {"{"}
-                {"\n"} <span className="text-zinc-500">// Initialize app</span>
+                {"\n"} <span className="text-zinc-400">// Initialize app</span>
                 {"\n"} <span className="text-blue-400">let</span>{" "}
                 <span className="text-blue-400">mut</span> app ={" "}
                 <span className="text-green-400">Ultimo</span>::
                 <span className="text-yellow-300">new</span>();
                 {"\n\n"}
-                {"\n"} <span className="text-zinc-500">// Define a route</span>
+                {"\n"} <span className="text-zinc-400">// Define a route</span>
                 {"\n"} app.<span className="text-yellow-300">get</span>(
                 <span className="text-orange-300">"/hello"</span>, |ctx|{" "}
                 <span className="text-blue-400">async move</span> {"{"}
@@ -109,7 +109,7 @@ export function HeroSection() {
                 <span className="text-blue-400">await</span>
                 {"\n"} {"}"});
                 {"\n\n"}
-                {"\n"} <span className="text-zinc-500">// Start server</span>
+                {"\n"} <span className="text-zinc-400">// Start server</span>
                 {"\n"} app.<span className="text-yellow-300">listen</span>(
                 <span className="text-orange-300">"127.0.0.1:3000"</span>).
                 <span className="text-blue-400">await</span>

--- a/website/components/site-footer.tsx
+++ b/website/components/site-footer.tsx
@@ -27,6 +27,7 @@ export function SiteFooter() {
                 href={siteConfig.links.github}
                 target="_blank"
                 className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="GitHub"
               >
                 <Github className="h-5 w-5" />
               </Link>
@@ -34,6 +35,7 @@ export function SiteFooter() {
                 href={siteConfig.links.twitter}
                 target="_blank"
                 className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Twitter"
               >
                 <Twitter className="h-5 w-5" />
               </Link>
@@ -41,6 +43,7 @@ export function SiteFooter() {
                 href={siteConfig.links.discord}
                 target="_blank"
                 className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Discord"
               >
                 <Disc className="h-5 w-5" />
               </Link>
@@ -48,7 +51,7 @@ export function SiteFooter() {
           </div>
 
           <div>
-            <h4 className="font-semibold text-foreground mb-4">Product</h4>
+            <h3 className="font-semibold text-foreground mb-4">Product</h3>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>
                 <Link
@@ -86,7 +89,7 @@ export function SiteFooter() {
           </div>
 
           <div>
-            <h4 className="font-semibold text-foreground mb-4">Resources</h4>
+            <h3 className="font-semibold text-foreground mb-4">Resources</h3>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>
                 <Link
@@ -124,7 +127,7 @@ export function SiteFooter() {
           </div>
 
           <div>
-            <h4 className="font-semibold text-foreground mb-4">Community</h4>
+            <h3 className="font-semibold text-foreground mb-4">Community</h3>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>
                 <Link

--- a/website/components/site-header.tsx
+++ b/website/components/site-header.tsx
@@ -92,6 +92,7 @@ export function SiteHeader() {
             variant="ghost"
             size="icon"
             className="md:hidden text-muted-foreground"
+            aria-label="Open menu"
           >
             <Menu className="h-6 w-6" />
           </Button>

--- a/website/components/stats-section.tsx
+++ b/website/components/stats-section.tsx
@@ -32,9 +32,9 @@ export function StatsSection() {
                   <Zap className="h-5 w-5" />
                 </div>
                 <div>
-                  <h4 className="text-lg font-semibold text-foreground">
+                  <h3 className="text-lg font-semibold text-foreground">
                     O(1) routing
-                  </h4>
+                  </h3>
                   <p className="text-muted-foreground text-sm">
                     Constant-time route lookup — 10 routes or 10,000, the same
                     cost.
@@ -47,9 +47,9 @@ export function StatsSection() {
                   <Layers className="h-5 w-5" />
                 </div>
                 <div>
-                  <h4 className="text-lg font-semibold text-foreground">
+                  <h3 className="text-lg font-semibold text-foreground">
                     Built on Hyper + Tokio
-                  </h4>
+                  </h3>
                   <p className="text-muted-foreground text-sm">
                     The proven async HTTP core of the Rust ecosystem — no
                     re-implementation.
@@ -62,9 +62,9 @@ export function StatsSection() {
                   <GitCompareArrows className="h-5 w-5" />
                 </div>
                 <div>
-                  <h4 className="text-lg font-semibold text-foreground">
+                  <h3 className="text-lg font-semibold text-foreground">
                     Regression-guarded
-                  </h4>
+                  </h3>
                   <p className="text-muted-foreground text-sm">
                     Every framework change is benchmarked in CI — we don't get
                     slower by accident.

--- a/website/components/type-safe-section.tsx
+++ b/website/components/type-safe-section.tsx
@@ -66,7 +66,7 @@ export function TypeSafeSection() {
               <span className="text-sm font-medium text-foreground">
                 frontend/src/client.ts
               </span>
-              <div className="px-2 py-0.5 rounded text-xs bg-blue-500/10 text-blue-500 border border-blue-500/20">
+              <div className="px-2 py-0.5 rounded text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20">
                 Generated
               </div>
             </div>
@@ -82,7 +82,7 @@ export function TypeSafeSection() {
                   {"    "}email: <span className="text-blue-400">string</span>;{" "}
                   {"\n"}
                   {"}"} {"\n\n"}
-                  <span className="text-zinc-500">// Fully typed!</span> {"\n"}
+                  <span className="text-zinc-400">// Fully typed!</span> {"\n"}
                   <span className="text-blue-400">const</span> user ={" "}
                   <span className="text-purple-400">await</span> client.
                   <span className="text-yellow-300">getUser</span>(1); {"\n"}


### PR DESCRIPTION
Resolves all actionable Lighthouse failures identified via Chrome DevTools MCP audit.

## Before → After
| Category | Before | After |
|----------|--------|-------|
| Accessibility | 92 | **100** |
| Best Practices | 100 | 100 |
| SEO | 92 | 92* |
| Agentic Browsing | 50 | **100** |

*SEO 92 is a false positive — meta description is present in HTML source but Lighthouse reports it missing in dev mode.

## Fixes
- **Color contrast**: `text-zinc-500` → `text-zinc-400`, `text-blue-500` → `text-blue-400` (code comments and tags)
- **Heading order**: `h4` → `h3` in footer and stats section (no h2/h3 skip)
- **Link names**: Added `aria-label` to icon-only social links (GitHub, Twitter, Discord)
- **Button name**: Added `aria-label="Open menu"` to mobile hamburger button
- **Meta description**: Updated to match new positioning (speed, security, efficiency)