### PR TITLE
fix(seo): meta description length, og:image and og:site_name for blog posts

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -36,9 +36,18 @@ export async function generateMetadata({
       description: post.meta.description,
       type: "article",
       url,
+      siteName: "Ultimo",
       publishedTime: post.meta.date,
       authors: [post.meta.author],
       tags: post.meta.tags,
+      images: [
+        {
+          url: "https://ultimo.dev/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: post.meta.title,
+        },
+      ],
     },
   };
 }

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -20,7 +20,7 @@ const geistMono = Geist_Mono({
 const siteUrl = "https://ultimo.dev";
 const title = "Ultimo - The Rust Framework for Speed, Security & Efficiency";
 const description =
-  "The Rust web framework built for speed, security, and efficiency. Type-safe APIs with automatic TypeScript client generation for trading platforms, AI backends, and latency-sensitive systems.";
+  "The Rust web framework for speed, security, and efficiency. Type-safe APIs with automatic TypeScript generation for latency-sensitive systems.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),


### PR DESCRIPTION
Fixes SEO issues found via opengraph.to validation.

## Fixes
1. **Meta description too long** (191 → 142 chars, under 160 limit)
2. **Blog posts missing og:image** — now all posts include the shared OG image
3. **Blog posts missing og:site_name** — added `siteName: 'Ultimo'` to blog metadata

## Verified via Chrome DevTools MCP
- All pages have: og:title, og:description, og:image, og:site_name, og:type
- robots.txt ✓ (allows all, points to sitemap)
- sitemap.xml ✓ (all 10 blog posts + static pages included)
- Meta description under 160 chars on all pages

## Regarding og:image CTA
The OG image currently shows the Ultimo logo + brand name. Adding a text CTA ('Start Building' or similar) to the image itself would require regenerating the PNG — can be done as a follow-up.