### PR TITLE
feat(seo): dynamic OG images with CTA via next/og (Satori)

### DIFF
--- a/website/app/blog/[slug]/opengraph-image.tsx
+++ b/website/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,171 @@
+import { ImageResponse } from "next/og";
+import { getAllPosts, getPostBySlug } from "@/lib/blog";
+
+export const dynamic = "force-static";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export function generateStaticParams() {
+  const posts = getAllPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export default async function OGImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+
+  if (!post) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "#0a0a0a",
+            color: "#fff",
+            fontSize: 48,
+            fontWeight: 700,
+          }}
+        >
+          Ultimo Blog
+        </div>
+      ),
+      { ...size }
+    );
+  }
+
+  const tagColors: Record<string, string> = {
+    tutorial: "#22c55e",
+    architecture: "#3b82f6",
+    comparison: "#a855f7",
+    performance: "#f59e0b",
+    fintech: "#06b6d4",
+    realtime: "#ec4899",
+    typescript: "#3178c6",
+    security: "#ef4444",
+    rust: "#ca3500",
+  };
+
+  const primaryTag = post.meta.tags[0] || "rust";
+  const tagColor = tagColors[primaryTag] || "#f97316";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          backgroundColor: "#0a0a0a",
+          padding: "60px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        {/* Top: tag + title */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                backgroundColor: tagColor,
+                color: "#fff",
+                padding: "6px 16px",
+                borderRadius: "20px",
+                fontSize: 18,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              {primaryTag}
+            </div>
+            <div style={{ display: "flex", color: "#a1a1aa", fontSize: 18 }}>
+              {`${post.meta.readingTime} min read`}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              fontSize: 52,
+              fontWeight: 800,
+              color: "#ffffff",
+              lineHeight: 1.2,
+              maxWidth: "900px",
+            }}
+          >
+            {post.meta.title}
+          </div>
+        </div>
+
+        {/* Bottom: branding + CTA */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+            <div
+              style={{
+                width: "44px",
+                height: "44px",
+                backgroundColor: "#ca3500",
+                borderRadius: "8px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+                fontSize: 24,
+                fontWeight: 800,
+              }}
+            >
+              U
+            </div>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              <div
+                style={{ display: "flex", color: "#ffffff", fontSize: 22, fontWeight: 700 }}
+              >
+                ultimo.dev
+              </div>
+              <div style={{ display: "flex", color: "#a1a1aa", fontSize: 16 }}>
+                The Rust Framework for Speed, Security & Efficiency
+              </div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              backgroundColor: "#f97316",
+              color: "#000",
+              padding: "12px 28px",
+              borderRadius: "8px",
+              fontSize: 18,
+              fontWeight: 700,
+            }}
+          >
+            Read on ultimo.dev →
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -40,14 +40,6 @@ export async function generateMetadata({
       publishedTime: post.meta.date,
       authors: [post.meta.author],
       tags: post.meta.tags,
-      images: [
-        {
-          url: "https://ultimo.dev/og-image.png",
-          width: 1200,
-          height: 630,
-          alt: post.meta.title,
-        },
-      ],
     },
   };
 }

--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -1,0 +1,106 @@
+import { ImageResponse } from "next/og";
+
+export const dynamic = "force-static";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          padding: "60px",
+          fontFamily: "system-ui, sans-serif",
+          gap: "32px",
+        }}
+      >
+        {/* Logo */}
+        <div
+          style={{
+            width: "80px",
+            height: "80px",
+            backgroundColor: "#ca3500",
+            borderRadius: "16px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#fff",
+            fontSize: 44,
+            fontWeight: 800,
+          }}
+        >
+          U
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            display: "flex",
+            fontSize: 64,
+            fontWeight: 800,
+            color: "#ffffff",
+            textAlign: "center",
+          }}
+        >
+          <div style={{ display: "flex" }}>The&nbsp;</div>
+          <div style={{ display: "flex", color: "#f97316" }}>Rust Framework</div>
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            display: "flex",
+            fontSize: 32,
+            color: "#a1a1aa",
+            textAlign: "center",
+          }}
+        >
+          for Speed, Security & Efficiency
+        </div>
+
+        {/* CTA */}
+        <div
+          style={{
+            display: "flex",
+            backgroundColor: "#f97316",
+            color: "#000",
+            padding: "16px 40px",
+            borderRadius: "10px",
+            fontSize: 22,
+            fontWeight: 700,
+            marginTop: "16px",
+          }}
+        >
+          Start Building → ultimo.dev
+        </div>
+
+        {/* Pillars */}
+        <div
+          style={{
+            display: "flex",
+            gap: "40px",
+            marginTop: "8px",
+            color: "#71717a",
+            fontSize: 18,
+          }}
+        >
+          <div style={{ display: "flex" }}>Zero GC</div>
+          <div style={{ display: "flex" }}>•</div>
+          <div style={{ display: "flex" }}>100% Safe Rust</div>
+          <div style={{ display: "flex" }}>•</div>
+          <div style={{ display: "flex" }}>Auto TypeScript</div>
+          <div style={{ display: "flex" }}>•</div>
+          <div style={{ display: "flex" }}>Single Binary</div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Generates unique OG images for every page at build time using `next/og` (Satori). Each image includes a clear CTA.

## Root page OG image
![Root OG](https://via.placeholder.com/600x315/0a0a0a/f97316?text=See+below)
- Ultimo logo mark + 'The Rust Framework' (orange) + subtitle
- CTA button: **'Start Building → ultimo.dev'**
- Bottom pillars: Zero GC • 100% Safe Rust • Auto TypeScript • Single Binary

## Blog post OG images (per-post, unique)
- Color-coded tag badge (tutorial=green, architecture=blue, etc.)
- Reading time
- Full post title (large, bold)
- Ultimo branding + CTA: **'Read on ultimo.dev →'**

## Technical
- Uses `next/og` (`ImageResponse` from Satori) — no external deps
- `export const dynamic = 'force-static'` for static export compatibility
- `generateStaticParams` generates images for all 10 blog posts at build time
- 1200×630 PNG (standard OG image dimensions)
- Build verified: all images generated successfully

## Fixes
- Blog posts now have unique, per-post OG images (was shared generic image)
- All OG images include CTA (was missing — flagged by opengraph.to)