### PR TITLE
fix(examples): update rpc-modes to use JSON-RPC 2.0 handle_request()

### DIFF
--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -517,10 +517,17 @@ pub enum RpcMode {
 Full JSON-RPC 2.0 dispatch. Parses the body, validates, dispatches (concurrently for batch), and returns spec-compliant responses.
 
 ```rust
+let body = ctx.req.bytes().await?;
 let output = registry.handle_request(&body).await;
 match output.into_body() {
-    Some(bytes) => ctx.json_bytes(bytes).await,
-    None => ctx.status(204).send().await, // notification
+    Some(bytes) => {
+        let value: serde_json::Value = serde_json::from_slice(&bytes)?;
+        ctx.json(value).await
+    }
+    None => {
+        ctx.status(204).await;
+        ctx.text("").await
+    }
 }
 ```
 

--- a/docs-site/docs/pages/rpc.mdx
+++ b/docs-site/docs/pages/rpc.mdx
@@ -549,11 +549,17 @@ async fn main() -> Result<()> {
     app.post("/rpc", move |ctx: Context| {
         let rpc = rpc.clone();
         async move {
-            let body = ctx.req.body_bytes().await?;
+            let body = ctx.req.bytes().await?;
             let output = rpc.handle_request(&body).await;
             match output.into_body() {
-                Some(bytes) => ctx.json_bytes(bytes).await,
-                None => ctx.status(204).send().await,
+                Some(bytes) => {
+                    let value: serde_json::Value = serde_json::from_slice(&bytes)?;
+                    ctx.json(value).await
+                }
+                None => {
+                    ctx.status(204).await;
+                    ctx.text("").await
+                }
             }
         }
     });

--- a/examples/rpc-modes/src/main.rs
+++ b/examples/rpc-modes/src/main.rs
@@ -201,18 +201,34 @@ async fn main() -> ultimo::Result<()> {
     println!("   - POST /rpc (all methods)");
     println!();
 
-    // Mount JSON-RPC endpoint
+    // Mount JSON-RPC 2.0 endpoint (supports single, batch, and notifications)
     let rpc_handler = jsonrpc_rpc.clone();
     jsonrpc_app.post("/rpc", move |ctx: Context| {
         let rpc = rpc_handler.clone();
         async move {
-            let req: RpcRequest = ctx.req.json().await?;
-            let result = rpc.call(&req.method, req.params).await?;
-            ctx.json(result).await
+            let body = ctx.req.bytes().await?;
+            let output = rpc.handle_request(&body).await;
+            match output.into_body() {
+                Some(bytes) => {
+                    let value: serde_json::Value = serde_json::from_slice(&bytes)
+                        .map_err(|e| ultimo::UltimoError::Internal(e.to_string()))?;
+                    ctx.json(value).await
+                }
+                None => {
+                    ctx.status(204).await;
+                    ctx.text("").await
+                }
+            }
         }
     });
 
     println!("JSON-RPC Mode: Would listen on http://localhost:3000");
+    println!();
+    println!("  Supports:");
+    println!("  - Single: {{\"jsonrpc\":\"2.0\",\"method\":\"getUser\",\"params\":{{\"id\":1}},\"id\":1}}");
+    println!("  - Batch:  [{{...}}, {{...}}] — executed concurrently");
+    println!("  - Notify: {{\"jsonrpc\":\"2.0\",\"method\":\"...\",\"params\":{{}}}} (no id = no response)");
+    println!("  - Legacy: {{\"method\":\"getUser\",\"params\":{{\"id\":1}}}} (backward compatible)");
     println!();
 
     // ============================================
@@ -226,10 +242,12 @@ async fn main() -> ultimo::Result<()> {
     println!("  ✅ RESTful conventions");
     println!("  ⚠️  More complex routing");
     println!();
-    println!("JSON-RPC Mode:");
+    println!("JSON-RPC 2.0 Mode:");
     println!("  ✅ Simple routing (one endpoint)");
-    println!("  ✅ Easy batching");
-    println!("  ✅ Single middleware point");
+    println!("  ✅ Batch multiple calls in one request");
+    println!("  ✅ Notifications (fire-and-forget)");
+    println!("  ✅ Standard error codes");
+    println!("  ✅ Backward compatible with legacy format");
     println!("  ⚠️  All requests look same in Network tab");
     println!();
     println!("Choose based on your needs! 🎯");


### PR DESCRIPTION
Updates the rpc-modes example and docs code snippets to use the new `handle_request()` API with correct Context methods.

## Changes
- `examples/rpc-modes/src/main.rs`: Uses `handle_request()` instead of manual `RpcRequest` + `call()`
- `docs-site/docs/pages/rpc.mdx`: Fixed code example to use `ctx.req.bytes()` / `ctx.json()`
- `docs-site/docs/pages/api-reference.mdx`: Same fix

Example now demonstrates batch, notifications, and backward compatibility.