### PR TITLE
feat(cli): implement `ultimo dev` hot-reload dev server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-15
+
+### Added
+
+- `ultimo dev` — hot-reload development server with file watching
+
 ## [0.5.0] - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +934,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1562,6 +1581,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.12.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1694,26 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "ultimo",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.12.1",
+ "libc",
 ]
 
 [[package]]
@@ -1778,6 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1842,6 +1922,73 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.12.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify 0.10.2",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types 1.0.1",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.12.1",
+ "fsevent-sys",
+ "inotify 0.11.2",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types 2.1.0",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa5a66d07ed97dce782be94dcf5ab4d1b457f4243f7566c7557f15cabc8c799"
+dependencies = [
+ "log",
+ "notify 7.0.0",
+ "notify-types 1.0.1",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.12.1",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3697,6 +3844,8 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "notify 8.2.0",
+ "notify-debouncer-mini",
  "predicates",
  "serde",
  "serde_json",
@@ -4177,6 +4326,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4208,11 +4366,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4228,6 +4403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,6 +4419,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4252,10 +4439,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4270,6 +4469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,6 +4485,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4294,6 +4505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,6 +4521,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"

--- a/README.md
+++ b/README.md
@@ -132,8 +132,12 @@ ultimo new my-app --template fullstack                 # scaffold a new project
 ultimo generate --project ./backend --output ./client  # generate the TypeScript client
 ```
 
-> `ultimo dev` and `ultimo build` are **not implemented yet** — use `cargo run` and
-> `cargo build --release` for now. See the [roadmap](https://docs.ultimo.dev/roadmap).
+```bash
+ultimo dev --port 3000   # hot-reload dev server (watches src/, restarts on change)
+```
+
+> `ultimo build` is **not implemented yet** — use `cargo build --release` for now.
+> See the [roadmap](https://docs.ultimo.dev/roadmap).
 
 ## Documentation
 

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-15
+
+### Added
+
+- `ultimo dev` — hot-reload development server with file watching (#15)
+
 ## [0.5.0] - 2026-06-09
 
 ### Added

--- a/docs-site/docs/pages/cli.mdx
+++ b/docs-site/docs/pages/cli.mdx
@@ -226,15 +226,29 @@ ultimo new my-app --template fullstack
 
 Available templates: `basic`, `fullstack`, `api-only`, `rpc`, `production`.
 
+## Development Server
+
+Start a hot-reload development server that watches for file changes and
+automatically recompiles and restarts:
+
+```bash
+ultimo dev                       # default: 127.0.0.1:3000
+ultimo dev --port 8080           # custom port
+ultimo dev --host 0.0.0.0        # bind to all interfaces
+```
+
+The dev server watches `src/**/*.rs` and `Cargo.toml`. On any change it kills
+the running server, rebuilds with `cargo build`, and restarts. Compilation
+errors are printed inline — the watcher stays active so the server restarts
+automatically once you fix the error.
+
 ## Future Commands
 
 > ⚠️ **Not implemented yet.** These commands exist as placeholders and currently
-> print a notice. The flags below are tentative sketches, not a stable interface.
-> Until they land, use the cargo equivalents.
+> print a notice. Until they land, use the cargo equivalents.
 
 | Command | Status | Use instead |
 | --- | --- | --- |
-| `ultimo dev` | Planned (0.7.0) — file-watching dev server | `cargo run` |
 | `ultimo build` | Planned — production build wrapper | `cargo build --release` |
 | `ultimo test` | Not planned yet | `cargo test` |
 | `ultimo fmt` / `ultimo lint` | Not planned yet | `cargo fmt` / `cargo clippy` |

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -44,7 +44,7 @@ a stable **1.0**.
 - 🛡️ **Advanced rate limiting** — per-user, per-endpoint limits.
 - ⏱️ **Request timeouts** + **HTTP graceful shutdown** (WebSocket graceful
   shutdown already ships).
-- 🔄 **Hot reload** — `ultimo dev` with file-watching auto-restart.
+- ~~🔄 **Hot reload** — `ultimo dev` with file-watching auto-restart.~~ ✅ Shipped in 0.5.1
 
 ### Developer experience
 
@@ -141,7 +141,7 @@ dependencies and rot as each vendor's API changes).
 | Request Timeouts + HTTP Graceful Shutdown | 📋 Planned | 0.7.0 |
 | Redis (sessions · cache · rate-limit) | 📋 Planned | 0.8.0 |
 | WebSocket Compression     | 📋 Planned       | 0.8.0   |
-| Hot Reload (`ultimo dev`) | 📋 Planned       | 0.8.0   |
+| Hot Reload (`ultimo dev`) | ✅ Available     | 0.5.1   |
 | `#[derive(UltimoType)]`   | 📋 Planned       | 0.8.0   |
 | Built-in Middleware Pack (request-id, cache-control, …) | 📋 Planned | 0.8.0 |
 | End-to-end Typed Errors   | 📋 Planned       | 0.9.0   |
@@ -241,7 +241,6 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 - **Redis integration** — sessions, cache, and rate-limit store (one dependency)
 - WebSocket compression (per-message deflate)
-- Hot reload (`ultimo dev`)
 - `#[derive(UltimoType)]` (drop the `ts-rs` dependency papercut)
 - Built-in middleware pack (request-id, cache-control/ETag, server-timing, basic-auth)
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/examples/rpc-modes/src/main.rs
+++ b/examples/rpc-modes/src/main.rs
@@ -228,7 +228,9 @@ async fn main() -> ultimo::Result<()> {
     println!("  - Single: {{\"jsonrpc\":\"2.0\",\"method\":\"getUser\",\"params\":{{\"id\":1}},\"id\":1}}");
     println!("  - Batch:  [{{...}}, {{...}}] — executed concurrently");
     println!("  - Notify: {{\"jsonrpc\":\"2.0\",\"method\":\"...\",\"params\":{{}}}} (no id = no response)");
-    println!("  - Legacy: {{\"method\":\"getUser\",\"params\":{{\"id\":1}}}} (backward compatible)");
+    println!(
+        "  - Legacy: {{\"method\":\"getUser\",\"params\":{{\"id\":1}}}} (backward compatible)"
+    );
     println!();
 
     // ============================================

--- a/ultimo-cli/Cargo.toml
+++ b/ultimo-cli/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"
 colored = "2.1"
+notify = "8"
+notify-debouncer-mini = "0.5"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/ultimo-cli/src/dev.rs
+++ b/ultimo-cli/src/dev.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use colored::Colorize;
+use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode};
+use std::path::Path;
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::signal;
+use tokio::sync::mpsc as tokio_mpsc;
+
+/// Run the development server with hot reload.
+///
+/// Watches `.rs` files and `Cargo.toml` for changes, then recompiles and
+/// restarts the server automatically.
+pub async fn run(port: u16, host: String) -> Result<()> {
+    println!(
+        "{}",
+        format!("🔥 Starting dev server on {}:{}", host, port)
+            .bold()
+            .green()
+    );
+    println!(
+        "{}",
+        "   Watching for file changes (src/**/*.rs, Cargo.toml)...".dimmed()
+    );
+    println!();
+
+    let (tx, mut rx) = tokio_mpsc::channel::<()>(1);
+
+    let _debouncer = {
+        let tx = tx.clone();
+        let (std_tx, std_rx) = std::sync::mpsc::channel();
+
+        let mut debouncer = new_debouncer(Duration::from_millis(500), std_tx)?;
+
+        // Watch src/ directory
+        let src_path = Path::new("src");
+        if src_path.exists() {
+            debouncer
+                .watcher()
+                .watch(src_path, RecursiveMode::Recursive)?;
+        }
+
+        // Watch Cargo.toml
+        let cargo_toml = Path::new("Cargo.toml");
+        if cargo_toml.exists() {
+            debouncer
+                .watcher()
+                .watch(cargo_toml, RecursiveMode::NonRecursive)?;
+        }
+
+        // Bridge std channel to tokio channel in a background thread
+        std::thread::spawn(move || {
+            while std_rx.recv().is_ok() {
+                let _ = tx.blocking_send(());
+            }
+        });
+
+        debouncer
+    };
+
+    // Initial build and run
+    let mut child = spawn_server(port, &host).await?;
+
+    loop {
+        tokio::select! {
+            _ = signal::ctrl_c() => {
+                println!("\n{}", "⏹  Shutting down dev server...".yellow());
+                kill_child(&mut child).await;
+                break;
+            }
+            _ = rx.recv() => {
+                println!();
+                println!("{}", "♻  Change detected, restarting...".cyan());
+                kill_child(&mut child).await;
+                child = spawn_server(port, &host).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn spawn_server(port: u16, host: &str) -> Result<tokio::process::Child> {
+    println!("{}", "   Compiling...".dimmed());
+
+    // Build first so we can show compilation errors clearly
+    let build_status = Command::new("cargo").args(["build"]).status().await?;
+
+    if !build_status.success() {
+        println!(
+            "{}",
+            "❌ Build failed. Waiting for file changes...".red().bold()
+        );
+        // Return a dummy process that just sleeps (will be killed on next change)
+        let child = Command::new("sleep").arg("86400").spawn()?;
+        return Ok(child);
+    }
+
+    println!(
+        "{}",
+        format!("✅ Running on http://{}:{}", host, port).green()
+    );
+    println!();
+
+    let child = Command::new("cargo")
+        .args(["run"])
+        .env("PORT", port.to_string())
+        .env("HOST", host)
+        .spawn()?;
+
+    Ok(child)
+}
+
+async fn kill_child(child: &mut tokio::process::Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}

--- a/ultimo-cli/src/main.rs
+++ b/ultimo-cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use colored::Colorize;
 use std::path::PathBuf;
 
+mod dev;
 mod generate;
 mod new;
 
@@ -41,11 +42,15 @@ enum Commands {
         template: String,
     },
 
-    /// [not implemented yet] Development server with hot reload (planned for 0.7.0)
+    /// Development server with hot reload
     Dev {
         /// Port to run on
         #[arg(short, long, default_value = "3000")]
         port: u16,
+
+        /// Host to bind to
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
     },
 
     /// [not implemented yet] Production build — use `cargo build --release` for now
@@ -74,12 +79,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::New { name, template } => {
             new::run(name, template).await?;
         }
-        Commands::Dev { port: _ } => {
-            println!(
-                "{}",
-                "`ultimo dev` is not implemented yet (planned for 0.7.0).".yellow()
-            );
-            println!("Run your app directly for now:  {}", "cargo run".cyan());
+        Commands::Dev { port, host } => {
+            dev::run(port, host).await?;
         }
         Commands::Build { profile: _ } => {
             println!("{}", "`ultimo build` is not implemented yet.".yellow());

--- a/ultimo-cli/tests/cli.rs
+++ b/ultimo-cli/tests/cli.rs
@@ -32,12 +32,16 @@ fn version_flag_prints_version() {
 }
 
 #[test]
-fn dev_and_build_report_not_implemented() {
+fn dev_shows_help() {
     ultimo()
-        .arg("dev")
+        .args(["dev", "--help"])
         .assert()
         .success()
-        .stdout(contains("not implemented"));
+        .stdout(contains("hot reload"));
+}
+
+#[test]
+fn build_reports_not_implemented() {
     ultimo()
         .arg("build")
         .assert()

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -66,8 +66,10 @@ pub(crate) mod static_files;
 pub use app::Ultimo;
 pub use context::Context;
 pub use error::{Result, UltimoError};
+pub use rpc::{
+    error_code, JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, JsonRpcRequest, JsonRpcResponse,
+};
 pub use rpc::{RpcRegistry, RpcRequest, RpcResponse};
-pub use rpc::{JsonRpcRequest, JsonRpcResponse, JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, error_code};
 pub use validation::validate;
 
 /// Prelude module for convenient imports
@@ -76,8 +78,10 @@ pub mod prelude {
     pub use crate::context::Context;
     pub use crate::error::{Result, UltimoError};
     pub use crate::middleware;
+    pub use crate::rpc::{
+        JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, JsonRpcRequest, JsonRpcResponse,
+    };
     pub use crate::rpc::{RpcRegistry, RpcRequest, RpcResponse};
-    pub use crate::rpc::{JsonRpcRequest, JsonRpcResponse, JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput};
     pub use crate::validation::validate;
     pub use serde::{Deserialize, Serialize};
     pub use serde_json::json;

--- a/ultimo/src/rpc.rs
+++ b/ultimo/src/rpc.rs
@@ -967,15 +967,18 @@ impl RpcRegistry {
         let value: serde_json::Value = match serde_json::from_slice(body) {
             Ok(v) => v,
             Err(_) => {
-                return JsonRpcOutput::Single(serde_json::to_value(JsonRpcErrorResponse {
-                    jsonrpc: "2.0",
-                    error: JsonRpcError {
-                        code: error_code::PARSE_ERROR,
-                        message: "Parse error".to_string(),
-                        data: None,
-                    },
-                    id: serde_json::Value::Null,
-                }).unwrap());
+                return JsonRpcOutput::Single(
+                    serde_json::to_value(JsonRpcErrorResponse {
+                        jsonrpc: "2.0",
+                        error: JsonRpcError {
+                            code: error_code::PARSE_ERROR,
+                            message: "Parse error".to_string(),
+                            data: None,
+                        },
+                        id: serde_json::Value::Null,
+                    })
+                    .unwrap(),
+                );
             }
         };
 
@@ -983,15 +986,18 @@ impl RpcRegistry {
             serde_json::Value::Array(requests) => {
                 // Batch request
                 if requests.is_empty() {
-                    return JsonRpcOutput::Single(serde_json::to_value(JsonRpcErrorResponse {
-                        jsonrpc: "2.0",
-                        error: JsonRpcError {
-                            code: error_code::INVALID_REQUEST,
-                            message: "Invalid Request: empty batch".to_string(),
-                            data: None,
-                        },
-                        id: serde_json::Value::Null,
-                    }).unwrap());
+                    return JsonRpcOutput::Single(
+                        serde_json::to_value(JsonRpcErrorResponse {
+                            jsonrpc: "2.0",
+                            error: JsonRpcError {
+                                code: error_code::INVALID_REQUEST,
+                                message: "Invalid Request: empty batch".to_string(),
+                                data: None,
+                            },
+                            id: serde_json::Value::Null,
+                        })
+                        .unwrap(),
+                    );
                 }
 
                 let futures: Vec<_> = requests
@@ -1002,10 +1008,7 @@ impl RpcRegistry {
                 let results = futures_util::future::join_all(futures).await;
 
                 // Filter out None responses (notifications)
-                let responses: Vec<serde_json::Value> = results
-                    .into_iter()
-                    .flatten()
-                    .collect();
+                let responses: Vec<serde_json::Value> = results.into_iter().flatten().collect();
 
                 if responses.is_empty() {
                     JsonRpcOutput::None
@@ -1020,8 +1023,8 @@ impl RpcRegistry {
                     None => JsonRpcOutput::None, // notification
                 }
             }
-            _ => {
-                JsonRpcOutput::Single(serde_json::to_value(JsonRpcErrorResponse {
+            _ => JsonRpcOutput::Single(
+                serde_json::to_value(JsonRpcErrorResponse {
                     jsonrpc: "2.0",
                     error: JsonRpcError {
                         code: error_code::INVALID_REQUEST,
@@ -1029,8 +1032,9 @@ impl RpcRegistry {
                         data: None,
                     },
                     id: serde_json::Value::Null,
-                }).unwrap())
-            }
+                })
+                .unwrap(),
+            ),
         }
     }
 
@@ -1058,30 +1062,39 @@ impl RpcRegistry {
                 if is_notification {
                     return None;
                 }
-                return Some(serde_json::to_value(JsonRpcErrorResponse {
-                    jsonrpc: "2.0",
-                    error: JsonRpcError {
-                        code: error_code::INVALID_REQUEST,
-                        message: "Invalid Request: missing 'method' field".to_string(),
-                        data: None,
-                    },
-                    id: id.unwrap_or(serde_json::Value::Null),
-                }).unwrap());
+                return Some(
+                    serde_json::to_value(JsonRpcErrorResponse {
+                        jsonrpc: "2.0",
+                        error: JsonRpcError {
+                            code: error_code::INVALID_REQUEST,
+                            message: "Invalid Request: missing 'method' field".to_string(),
+                            data: None,
+                        },
+                        id: id.unwrap_or(serde_json::Value::Null),
+                    })
+                    .unwrap(),
+                );
             }
         };
 
-        let params = value.get("params").cloned().unwrap_or(serde_json::Value::Null);
+        let params = value
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
 
         match self.call(&method, params).await {
             Ok(result) => {
                 if is_notification {
                     None
                 } else {
-                    Some(serde_json::to_value(JsonRpcResponse {
-                        jsonrpc: "2.0",
-                        result,
-                        id: id.unwrap(),
-                    }).unwrap())
+                    Some(
+                        serde_json::to_value(JsonRpcResponse {
+                            jsonrpc: "2.0",
+                            result,
+                            id: id.unwrap(),
+                        })
+                        .unwrap(),
+                    )
                 }
             }
             Err(e) => {
@@ -1089,15 +1102,18 @@ impl RpcRegistry {
                     None
                 } else {
                     let (code, message) = Self::error_to_jsonrpc_code(&e);
-                    Some(serde_json::to_value(JsonRpcErrorResponse {
-                        jsonrpc: "2.0",
-                        error: JsonRpcError {
-                            code,
-                            message,
-                            data: None,
-                        },
-                        id: id.unwrap_or(serde_json::Value::Null),
-                    }).unwrap())
+                    Some(
+                        serde_json::to_value(JsonRpcErrorResponse {
+                            jsonrpc: "2.0",
+                            error: JsonRpcError {
+                                code,
+                                message,
+                                data: None,
+                            },
+                            id: id.unwrap_or(serde_json::Value::Null),
+                        })
+                        .unwrap(),
+                    )
                 }
             }
         }
@@ -1108,23 +1124,30 @@ impl RpcRegistry {
         let method = match value.get("method").and_then(|v| v.as_str()) {
             Some(m) => m.to_string(),
             None => {
-                return Some(serde_json::to_value(RpcErrorResponse {
-                    error: "Missing 'method' field".to_string(),
-                    code: -1,
-                }).unwrap());
+                return Some(
+                    serde_json::to_value(RpcErrorResponse {
+                        error: "Missing 'method' field".to_string(),
+                        code: -1,
+                    })
+                    .unwrap(),
+                );
             }
         };
 
-        let params = value.get("params").cloned().unwrap_or(serde_json::Value::Null);
+        let params = value
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
 
         match self.call(&method, params).await {
             Ok(result) => Some(serde_json::to_value(RpcResponse { result }).unwrap()),
-            Err(e) => {
-                Some(serde_json::to_value(RpcErrorResponse {
+            Err(e) => Some(
+                serde_json::to_value(RpcErrorResponse {
                     error: e.to_string(),
                     code: -1,
-                }).unwrap())
-            }
+                })
+                .unwrap(),
+            ),
         }
     }
 
@@ -1490,11 +1513,11 @@ mod jsonrpc2_tests {
             let b = input.get("b").and_then(|v| v.as_i64()).unwrap_or(0);
             Ok(serde_json::to_value(a + b).unwrap())
         });
-        registry.register("echo", |input: serde_json::Value| async move {
-            Ok(input)
-        });
+        registry.register("echo", |input: serde_json::Value| async move { Ok(input) });
         registry.register("fail", |_input: serde_json::Value| async move {
-            Err::<serde_json::Value, _>(crate::UltimoError::BadRequest("intentional error".to_string()))
+            Err::<serde_json::Value, _>(crate::UltimoError::BadRequest(
+                "intentional error".to_string(),
+            ))
         });
         registry
     }
@@ -1507,7 +1530,8 @@ mod jsonrpc2_tests {
             "method": "add",
             "params": {"a": 3, "b": 4},
             "id": 1
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         let response_body = output.into_body().unwrap();
@@ -1526,7 +1550,8 @@ mod jsonrpc2_tests {
             "jsonrpc": "2.0",
             "method": "echo",
             "params": {"hello": "world"}
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         assert!(output.is_none());
@@ -1539,7 +1564,8 @@ mod jsonrpc2_tests {
             {"jsonrpc": "2.0", "method": "add", "params": {"a": 1, "b": 2}, "id": 1},
             {"jsonrpc": "2.0", "method": "add", "params": {"a": 10, "b": 20}, "id": 2},
             {"jsonrpc": "2.0", "method": "echo", "params": {"x": 99}, "id": 3}
-        ])).unwrap();
+        ]))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         let response_body = output.into_body().unwrap();
@@ -1558,7 +1584,8 @@ mod jsonrpc2_tests {
             {"jsonrpc": "2.0", "method": "add", "params": {"a": 5, "b": 5}, "id": 1},
             {"jsonrpc": "2.0", "method": "echo", "params": {"fire": "forget"}},
             {"jsonrpc": "2.0", "method": "add", "params": {"a": 7, "b": 3}, "id": 2}
-        ])).unwrap();
+        ]))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         let response_body = output.into_body().unwrap();
@@ -1574,7 +1601,8 @@ mod jsonrpc2_tests {
         let body = serde_json::to_vec(&json!([
             {"jsonrpc": "2.0", "method": "echo", "params": {}},
             {"jsonrpc": "2.0", "method": "echo", "params": {}}
-        ])).unwrap();
+        ]))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         assert!(output.is_none());
@@ -1614,7 +1642,8 @@ mod jsonrpc2_tests {
             "method": "nonexistent",
             "params": {},
             "id": 42
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(body.as_slice()).await;
         let response_body = output.into_body().unwrap();
@@ -1632,7 +1661,8 @@ mod jsonrpc2_tests {
             "method": "fail",
             "params": {},
             "id": 7
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(body.as_slice()).await;
         let response_body = output.into_body().unwrap();
@@ -1649,7 +1679,8 @@ mod jsonrpc2_tests {
         let body = serde_json::to_vec(&json!({
             "method": "add",
             "params": {"a": 10, "b": 5}
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         let response_body = output.into_body().unwrap();
@@ -1681,7 +1712,8 @@ mod jsonrpc2_tests {
             "method": "echo",
             "params": {"val": 1},
             "id": "abc-123"
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         let response_body = output.into_body().unwrap();
@@ -1700,7 +1732,8 @@ mod jsonrpc2_tests {
             "method": "add",
             "params": {"a": 1, "b": 1},
             "id": null
-        })).unwrap();
+        }))
+        .unwrap();
 
         let output = registry.handle_request(&body).await;
         let response_body = output.into_body().unwrap();

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.5.0 Now Available
+          v0.5.1 Now Available
         </div>
 
         <h1 className="font-bold tracking-tight mb-6 max-w-4xl text-center">

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Adds a file-watching development server that automatically recompiles and
restarts on source changes. Uses notify + debouncing (500ms) to watch
src/**/*.rs and Cargo.toml.

Features:
- --port (default 3000) and --host (default 127.0.0.1)
- Colored status output (compiling, restarting, errors)
- Graceful shutdown on Ctrl+C
- Build errors shown inline; watcher stays active for auto-retry

Closes #15
