### PR TITLE
fix: sync stale version references to 0.5.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.3.0** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.5.1** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -206,7 +206,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - ✅ **Static file serving + SPA fallback** — `serve_static`, `serve_spa`, ETag caching, path-traversal protection (`static-files` feature)
 - ✅ **Response compression** — automatic brotli/gzip middleware, pure Rust, builder API (`compression` feature)
 
-### v0.5.0 (Current) — Type-safe clients, for real
+### v0.5.0 — Type-safe clients, for real
 
 - ✅ **TypeScript type derivation** (`client-gen` feature) — RPC client types are
   derived from your Rust types via `ts-rs`; the generated client emits real
@@ -217,6 +217,11 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
   remain as escape hatches.
 - ✅ **`ultimo generate` runs for real** — executes the project's
   `generate-client` binary (no more artifact-hunting); `assert_cmd` CLI tests.
+
+### v0.5.1 (Current)
+
+- ✅ **Hot reload** — `ultimo dev` with file-watching auto-restart
+- ✅ **IP allow/deny middleware** — CIDR-aware `IpFilter` (allow-list / deny-list)
 
 ### v0.6.0 — Finish the codegen story + ship-readiness
 

--- a/examples/react-app/README.md
+++ b/examples/react-app/README.md
@@ -18,11 +18,11 @@ This example demonstrates how to build a full-stack application with:
 - ✅ Loading and error states
 - ✅ Beautiful UI with shadcn/ui components
 
-### RPC Client Example (Coming Soon)
+### RPC Client Example
 
-- 🚧 Type-safe RPC calls
-- 🚧 Auto-generated TypeScript types from Rust
-- 🚧 Single source of truth for API contracts
+- ✅ Type-safe RPC calls
+- ✅ Auto-generated TypeScript types from Rust
+- ✅ Single source of truth for API contracts
 
 ## Running the Example
 
@@ -52,7 +52,7 @@ The frontend will start on `http://localhost:5173`
 Navigate to `http://localhost:5173` and explore:
 
 - REST API example at `/rest`
-- RPC example at `/rpc` (coming soon)
+- RPC example at `/rpc`
 
 ## Project Structure
 
@@ -116,4 +116,4 @@ examples/
 1. Try adding more CRUD operations (Update)
 2. Add pagination and filtering
 3. Implement authentication
-4. Explore the upcoming RPC example with type-safe communication
+4. Explore the RPC example with type-safe communication

--- a/website/content/posts/ultimo-vs-axum-comparison.mdx
+++ b/website/content/posts/ultimo-vs-axum-comparison.mdx
@@ -300,7 +300,7 @@ Let's be direct: **Axum has a larger ecosystem and is more mature.** It reached 
 
 | Metric                  | Ultimo                                           | Axum                       |
 | ----------------------- | ------------------------------------------------ | -------------------------- |
-| **Current version**     | [0.5.0](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
+| **Current version**     | [0.5.1](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
 | **First release**       | 2024                                             | 2021                       |
 | **Community crates**    | Growing                                          | Hundreds                   |
 | **Production users**    | Early adopters                                   | Major companies            |


### PR DESCRIPTION
- CLAUDE.md: 0.3.0 → 0.5.1
- roadmap.mdx: v0.5.0 (Current) → v0.5.0 + new v0.5.1 (Current) section
- ultimo-vs-axum-comparison.mdx: current version 0.5.0 → 0.5.1
- react-app/README.md: RPC 'Coming Soon' → shipped (available since v0.5.0)
