### PR TITLE
docs: add deployment guides (Docker, Fly.io, Railway, AWS, GCP, Azure, DO, K8s)

### DIFF
--- a/docs-site/docs/pages/deployment.mdx
+++ b/docs-site/docs/pages/deployment.mdx
@@ -1,0 +1,411 @@
+# Deployment
+
+How to deploy an Ultimo application to production. Every guide starts from a
+working app (e.g. `ultimo new my-app --template basic`).
+
+## Build for release
+
+```bash
+cargo build --release
+```
+
+The optimized binary is at `target/release/<your-app>`. It's a **single static
+binary** — no runtime, no interpreter, no `node_modules`. Copy it to the server
+and run it.
+
+## Docker
+
+### Dockerfile (multi-stage)
+
+```dockerfile
+# ── Build stage ──────────────────────────────────────────────────────
+FROM rust:1.86-slim AS builder
+
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+# ── Runtime stage ────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/my-app /usr/local/bin/app
+
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["app"]
+```
+
+Replace `my-app` with your binary name (the `[[bin]]` name in `Cargo.toml`, or
+the package name by default).
+
+### .dockerignore
+
+```
+target/
+.git/
+```
+
+### Build and run locally
+
+```bash
+docker build -t my-app .
+docker run -p 3000:3000 my-app
+```
+
+### Docker Compose
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+      - RUST_LOG=info
+    restart: unless-stopped
+```
+
+```bash
+docker compose up -d
+```
+
+---
+
+## Fly.io
+
+[Fly.io](https://fly.io) runs Docker containers on edge servers worldwide.
+
+### 1. Install the Fly CLI and sign up
+
+```bash
+curl -L https://fly.io/install.sh | sh
+fly auth login
+```
+
+### 2. Launch
+
+From your project root (with the `Dockerfile` above):
+
+```bash
+fly launch
+```
+
+Fly detects the Dockerfile, picks a region, and generates `fly.toml`. Accept the
+defaults or customize.
+
+### 3. Deploy
+
+```bash
+fly deploy
+```
+
+### fly.toml (reference)
+
+```toml
+app = "my-app"
+primary_region = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 500
+    soft_limit = 250
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1
+```
+
+### Custom domain
+
+```bash
+fly certs add your-domain.com
+```
+
+---
+
+## Railway
+
+[Railway](https://railway.app) detects Rust projects and builds them automatically.
+
+### 1. Push to GitHub
+
+Railway deploys from your Git repo.
+
+### 2. Create a project
+
+Go to [railway.app/new](https://railway.app/new) → **Deploy from GitHub repo** →
+select your repository.
+
+### 3. Configure
+
+Railway auto-detects Rust and runs `cargo build --release`. Set environment
+variables in the dashboard:
+
+| Variable    | Value  |
+| ----------- | ------ |
+| `PORT`      | `$PORT` (Railway injects this) |
+| `RUST_LOG`  | `info` |
+
+### 4. Expose the service
+
+In your Railway service settings → **Networking** → **Generate Domain** (or add a
+custom domain).
+
+:::tip
+Railway's Rust builds can be slow on the free tier. Add a `Dockerfile` (the one
+above) for faster, cached builds.
+:::
+
+---
+
+## AWS (ECS + Fargate)
+
+Run your container on AWS without managing servers.
+
+### 1. Push image to ECR
+
+```bash
+# Authenticate Docker to ECR
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin <account-id>.dkr.ecr.us-east-1.amazonaws.com
+
+# Create repository (once)
+aws ecr create-repository --repository-name my-app
+
+# Build, tag, push
+docker build -t my-app .
+docker tag my-app:latest <account-id>.dkr.ecr.us-east-1.amazonaws.com/my-app:latest
+docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/my-app:latest
+```
+
+### 2. Create ECS service
+
+```bash
+# Create cluster
+aws ecs create-cluster --cluster-name my-cluster
+
+# Register task definition (see below) then create service
+aws ecs create-service \
+  --cluster my-cluster \
+  --service-name my-app \
+  --task-definition my-app \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxx],securityGroups=[sg-xxx],assignPublicIp=ENABLED}"
+```
+
+### Task definition (reference)
+
+```json
+{
+  "family": "my-app",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "<account-id>.dkr.ecr.us-east-1.amazonaws.com/my-app:latest",
+      "portMappings": [{ "containerPort": 3000 }],
+      "environment": [
+        { "name": "PORT", "value": "3000" },
+        { "name": "RUST_LOG", "value": "info" }
+      ]
+    }
+  ]
+}
+```
+
+:::tip
+For production, add an **Application Load Balancer** in front of the ECS service
+for HTTPS termination and health checks.
+:::
+
+---
+
+## Google Cloud Run
+
+[Cloud Run](https://cloud.google.com/run) runs containers with automatic scaling
+(including scale-to-zero).
+
+### 1. Build and push to Artifact Registry
+
+```bash
+# Enable APIs (once)
+gcloud services enable run.googleapis.com artifactregistry.googleapis.com
+
+# Create repository (once)
+gcloud artifacts repositories create my-repo \
+  --repository-format=docker --location=us-central1
+
+# Build and push
+gcloud builds submit --tag us-central1-docker.pkg.dev/<project-id>/my-repo/my-app
+```
+
+### 2. Deploy
+
+```bash
+gcloud run deploy my-app \
+  --image us-central1-docker.pkg.dev/<project-id>/my-repo/my-app \
+  --port 3000 \
+  --region us-central1 \
+  --allow-unauthenticated
+```
+
+Cloud Run provides an HTTPS URL automatically. Add a custom domain in the
+console under **Manage custom domains**.
+
+---
+
+## Azure Container Apps
+
+```bash
+# Create resource group and environment (once)
+az group create --name my-rg --location eastus
+az containerapp env create --name my-env --resource-group my-rg --location eastus
+
+# Deploy (builds from Dockerfile)
+az containerapp up \
+  --name my-app \
+  --resource-group my-rg \
+  --environment my-env \
+  --source . \
+  --target-port 3000 \
+  --ingress external
+```
+
+---
+
+## DigitalOcean App Platform
+
+### Via the dashboard
+
+1. Go to [cloud.digitalocean.com/apps](https://cloud.digitalocean.com/apps) → **Create App**
+2. Connect your GitHub repo
+3. DigitalOcean detects the `Dockerfile` and builds automatically
+4. Set the HTTP port to `3000`
+5. Deploy
+
+### Via doctl
+
+```bash
+doctl apps create --spec .do/app.yaml
+```
+
+```yaml
+# .do/app.yaml
+name: my-app
+services:
+  - name: app
+    dockerfile_path: Dockerfile
+    http_port: 3000
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    source_dir: /
+    github:
+      repo: your-org/your-repo
+      branch: main
+      deploy_on_push: true
+```
+
+---
+
+## Kubernetes
+
+### Manifests
+
+```yaml
+# k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: app
+          image: my-registry/my-app:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+            - name: RUST_LOG
+              value: "info"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+spec:
+  selector:
+    app: my-app
+  ports:
+    - port: 80
+      targetPort: 3000
+  type: ClusterIP
+```
+
+```bash
+kubectl apply -f k8s/
+```
+
+Add an **Ingress** (nginx-ingress, Traefik, or cloud LB) for HTTPS.
+
+---
+
+## Production checklist
+
+Before going live:
+
+- [ ] **Environment variables** — don't hardcode secrets; use env vars or a
+  secret manager
+- [ ] **Health check endpoint** — add a `GET /health` route returning 200 for
+  load balancer probes
+- [ ] **Logging** — set `RUST_LOG=info` (or `RUST_LOG=ultimo=info`) for
+  structured output
+- [ ] **HTTPS** — terminate TLS at the load balancer/proxy or use a reverse
+  proxy (nginx, Caddy)
+- [ ] **Security headers** — enable
+  `ultimo::middleware::builtin::security_headers()` in your app
+- [ ] **Trust proxy** — if behind a load balancer, call `app.trust_proxy(true)`
+  so `client_ip()` reads `X-Forwarded-For`
+- [ ] **Graceful shutdown** — Ultimo handles `SIGTERM` automatically for HTTP;
+  WebSocket connections get a close frame via `broadcast_all()`
+- [ ] **Resource limits** — Ultimo binaries are small (~10 MB); 64–128 MB RAM is
+  typically enough for most workloads

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -36,8 +36,8 @@ a stable **1.0**.
 
 ### Production-readiness
 
-- 📦 **Deployment guides** — Docker, Fly.io/Railway, AWS, DigitalOcean, Azure,
-  Google Cloud Run, Kubernetes — each with ready-to-use config.
+- ~~📦 **Deployment guides** — Docker, Fly.io/Railway, AWS, DigitalOcean, Azure,
+  Google Cloud Run, Kubernetes — each with ready-to-use config.~~ ✅ Shipped in 0.5.1
 - 🛡️ **Advanced rate limiting** — per-user, per-endpoint limits.
 - ⏱️ **Request timeouts** + **HTTP graceful shutdown** (WebSocket graceful
   shutdown already ships).
@@ -127,7 +127,7 @@ dependencies and rot as each vendor's API changes).
 | IP Allow/Deny (CIDR)     | ✅ Available     | 0.5.1   |
 | Codegen: `ultimo new` scaffold + `--watch` | 📋 Planned | 0.6.0 |
 | Interactive API Docs (Swagger/Scalar/ReDoc) | 📋 Planned | 0.6.0 |
-| Deployment Guides         | 📋 Planned       | 0.6.0   |
+| Deployment Guides         | ✅ Available     | 0.5.1   |
 | Advanced Rate Limiting    | 📋 Planned       | 0.6.0   |
 | Typed Handler Extractors + Validation | 📋 Planned | 0.7.0 |
 | Typed RPC Subscriptions / SSE | 📋 Planned   | 0.7.0   |
@@ -224,7 +224,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - Codegen: scaffold `generate-client` into `ultimo new` templates; TypeScript
   docs rewrite; `ultimo generate --watch`
 - **Turnkey interactive API docs** — `serve_docs` (Swagger UI / Scalar / ReDoc)
-- Deployment guides (Docker, Fly.io/Railway, AWS, DigitalOcean, Azure, GCR, K8s)
+- ~~Deployment guides (Docker, Fly.io/Railway, AWS, DigitalOcean, Azure, GCR, K8s)~~ ✅ Shipped
 - Advanced rate limiting (per-user, per-endpoint)
 
 ### v0.7.0 — Real-time, auth, & production gaps

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -130,6 +130,15 @@ export default defineConfig({
         },
       ],
     },
+    {
+      text: "Operations",
+      items: [
+        {
+          text: "Deployment",
+          link: "/deployment",
+        },
+      ],
+    },
   ],
   socials: [
     {


### PR DESCRIPTION
Comprehensive deployment page covering:
- Multi-stage Dockerfile + Docker Compose
- Fly.io, Railway
- AWS ECS/Fargate, Google Cloud Run, Azure Container Apps
- DigitalOcean App Platform
- Kubernetes manifests
- Production checklist

Adds sidebar entry under new 'Operations' section.
