### PR TITLE
feat(examples): add Render deployment with cold-start banners

### DIFF
--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.86-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY ultimo/ ultimo/
+COPY examples/basic/ examples/basic/
+RUN cargo build --release -p basic-example
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/basic-example /usr/local/bin/app
+ENV PORT=3000
+EXPOSE 3000
+CMD ["app"]

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -115,7 +115,18 @@ async fn main() -> Result<()> {
 
     // HTML response
     app.get("/html", |ctx: Context| async move {
-        ctx.html("<h1>Hello from Ultimo!</h1><p>A fast, type-safe Rust web framework</p>")
+        ctx.html(r#"<!doctype html><html><head><meta charset="utf-8"><title>Ultimo Basic Demo</title></head><body>
+<div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:0.5rem;padding:0.5rem 1rem;margin-bottom:1rem;font-size:0.85rem;color:#92400e;">
+⚡ <strong>Live demo</strong> — hosted on Render free tier. First request may take ~30s due to cold start.
+Powered by <a href="https://github.com/ultimo-rs/ultimo" style="color:#92400e;font-weight:600;">Ultimo</a>.
+</div>
+<h1>Hello from Ultimo!</h1><p>A fast, type-safe Rust web framework</p>
+<h2>Try these endpoints:</h2>
+<ul>
+<li><a href="/users/42">/users/42</a> — path params</li>
+<li><a href="/search?q=rust">/search?q=rust</a> — query params</li>
+<li><a href="/json">/json</a> — JSON response</li>
+</ul></body></html>"#)
             .await
     });
 
@@ -146,5 +157,7 @@ async fn main() -> Result<()> {
     println!("   GET  http://localhost:3000/redirect");
     println!();
 
-    app.listen("127.0.0.1:3000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/examples/jwt-auth/Dockerfile
+++ b/examples/jwt-auth/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.86-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY ultimo/ ultimo/
+COPY examples/jwt-auth/ examples/jwt-auth/
+RUN cargo build --release -p jwt-auth-example
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/jwt-auth-example /usr/local/bin/app
+ENV PORT=3000
+EXPOSE 3000
+CMD ["app"]

--- a/examples/jwt-auth/src/main.rs
+++ b/examples/jwt-auth/src/main.rs
@@ -28,6 +28,10 @@ const PAGE: &str = r#"<!doctype html>
   </style>
 </head>
 <body>
+  <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:0.5rem;padding:0.5rem 1rem;margin-bottom:1rem;font-size:0.85rem;color:#92400e;">
+    ⚡ <strong>Live demo</strong> — hosted on Render free tier. First request may take ~30s due to cold start.
+    Powered by <a href="https://github.com/ultimo-rs/ultimo" style="color:#92400e;font-weight:600;">Ultimo</a>.
+  </div>
   <h1>Ultimo JWT Auth + Guards</h1>
   <p class="hint">Log in as <code>admin</code> to get the <code>admin</code> scope; any other name gets only <code>user</code>.</p>
   <div>
@@ -139,5 +143,7 @@ async fn main() -> Result<()> {
     });
 
     println!("🔑 JWT auth + guards demo: http://127.0.0.1:3000");
-    app.listen("127.0.0.1:3000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/examples/openapi-demo/Dockerfile
+++ b/examples/openapi-demo/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.86-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY ultimo/ ultimo/
+COPY examples/openapi-demo/ examples/openapi-demo/
+RUN cargo build --release -p openapi-demo --bin rest-server
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/rest-server /usr/local/bin/app
+COPY examples/openapi-demo/swagger-ui.html /app/swagger-ui.html
+WORKDIR /app
+ENV PORT=3000
+EXPOSE 3000
+CMD ["app"]

--- a/examples/openapi-demo/src/rest-server.rs
+++ b/examples/openapi-demo/src/rest-server.rs
@@ -539,5 +539,7 @@ async fn main() -> ultimo::Result<()> {
     println!("  OpenAPI:    http://127.0.0.1:3000/openapi.json");
     println!();
 
-    app.listen("127.0.0.1:3000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/examples/openapi-demo/src/server.rs
+++ b/examples/openapi-demo/src/server.rs
@@ -207,5 +207,7 @@ async fn main() -> ultimo::Result<()> {
     println!("  OpenAPI:    http://127.0.0.1:3000/openapi.json");
     println!();
 
-    app.listen("127.0.0.1:3000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/examples/session-auth/Dockerfile
+++ b/examples/session-auth/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.86-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY ultimo/ ultimo/
+COPY examples/session-auth/ examples/session-auth/
+RUN cargo build --release -p session-auth-example
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/session-auth-example /usr/local/bin/app
+ENV PORT=3000
+EXPOSE 3000
+CMD ["app"]

--- a/examples/session-auth/src/main.rs
+++ b/examples/session-auth/src/main.rs
@@ -26,6 +26,10 @@ const PAGE: &str = r#"<!doctype html>
   </style>
 </head>
 <body>
+  <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:0.5rem;padding:0.5rem 1rem;margin-bottom:1rem;font-size:0.85rem;color:#92400e;">
+    ⚡ <strong>Live demo</strong> — hosted on Render free tier. First request may take ~30s due to cold start.
+    Powered by <a href="https://github.com/ultimo-rs/ultimo" style="color:#92400e;font-weight:600;">Ultimo</a>.
+  </div>
   <h1>Ultimo Session Auth</h1>
   <p>Log in to set a cookie-backed session, then refresh — you stay logged in.</p>
   <div>
@@ -110,5 +114,7 @@ async fn main() -> Result<()> {
     });
 
     println!("🔐 Session auth demo: http://127.0.0.1:3000");
-    app.listen("127.0.0.1:3000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/examples/spa-demo/Dockerfile
+++ b/examples/spa-demo/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.86-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY ultimo/ ultimo/
+COPY examples/spa-demo/ examples/spa-demo/
+RUN cargo build --release -p spa-demo
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/spa-demo /usr/local/bin/app
+COPY examples/spa-demo/dist/ /app/dist/
+WORKDIR /app
+ENV PORT=3000
+EXPOSE 3000
+CMD ["app"]

--- a/examples/spa-demo/src/main.rs
+++ b/examples/spa-demo/src/main.rs
@@ -36,5 +36,7 @@ async fn main() -> ultimo::Result<()> {
     app.serve_spa("./dist", "index.html");
 
     println!("→  http://127.0.0.1:3000");
-    app.listen("127.0.0.1:3000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/examples/websocket-chat/Dockerfile
+++ b/examples/websocket-chat/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.86-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY ultimo/ ultimo/
+COPY examples/websocket-chat/ examples/websocket-chat/
+RUN cargo build --release -p websocket-chat
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/websocket-chat /usr/local/bin/app
+ENV PORT=3000
+EXPOSE 3000
+CMD ["app"]

--- a/examples/websocket-chat/index.html
+++ b/examples/websocket-chat/index.html
@@ -170,6 +170,10 @@
     </style>
   </head>
   <body>
+    <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:0.5rem;padding:0.5rem 1rem;margin-bottom:1rem;font-size:0.85rem;color:#92400e;max-width:800px;margin:0.5rem auto 1rem;">
+      ⚡ <strong>Live demo</strong> — hosted on Render free tier. First request may take ~30s due to cold start.
+      Powered by <a href="https://github.com/ultimo-rs/ultimo" style="color:#92400e;font-weight:600;">Ultimo</a>.
+    </div>
     <div class="container">
       <div class="header">
         <h1>🚀 Ultimo WebSocket Chat</h1>

--- a/examples/websocket-chat/src/main.rs
+++ b/examples/websocket-chat/src/main.rs
@@ -135,5 +135,7 @@ async fn main() -> Result<()> {
     tracing::info!("  - Message fragmentation (for messages > 1MB)");
     tracing::info!("  - Backpressure handling (100 message buffer)");
 
-    app.listen("127.0.0.1:4000").await
+    let port = std::env::var("PORT").unwrap_or_else(|_| "4000".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    app.listen(&addr).await
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,66 @@
+services:
+  - type: web
+    name: ultimo-basic
+    runtime: docker
+    dockerfilePath: ./examples/basic/Dockerfile
+    rootDir: .
+    envVars:
+      - key: PORT
+        value: "3000"
+      - key: RUST_LOG
+        value: "info"
+
+  - type: web
+    name: ultimo-session-auth
+    runtime: docker
+    dockerfilePath: ./examples/session-auth/Dockerfile
+    rootDir: .
+    envVars:
+      - key: PORT
+        value: "3000"
+      - key: RUST_LOG
+        value: "info"
+
+  - type: web
+    name: ultimo-jwt-auth
+    runtime: docker
+    dockerfilePath: ./examples/jwt-auth/Dockerfile
+    rootDir: .
+    envVars:
+      - key: PORT
+        value: "3000"
+      - key: RUST_LOG
+        value: "info"
+
+  - type: web
+    name: ultimo-websocket-chat
+    runtime: docker
+    dockerfilePath: ./examples/websocket-chat/Dockerfile
+    rootDir: .
+    envVars:
+      - key: PORT
+        value: "3000"
+      - key: RUST_LOG
+        value: "info"
+
+  - type: web
+    name: ultimo-spa-demo
+    runtime: docker
+    dockerfilePath: ./examples/spa-demo/Dockerfile
+    rootDir: .
+    envVars:
+      - key: PORT
+        value: "3000"
+      - key: RUST_LOG
+        value: "info"
+
+  - type: web
+    name: ultimo-openapi-demo
+    runtime: docker
+    dockerfilePath: ./examples/openapi-demo/Dockerfile
+    rootDir: .
+    envVars:
+      - key: PORT
+        value: "3000"
+      - key: RUST_LOG
+        value: "info"


### PR DESCRIPTION
Adds live demo infrastructure for 6 Ultimo examples on Render free tier.

**Changes:**
- All deployable examples read `PORT` from env with `0.0.0.0` binding
- Per-example Dockerfiles (multi-stage, minimal runtime image)
- `render.yaml` Blueprint for one-click deployment of all demos
- Cold-start info banner (amber, inline CSS) in all HTML-serving examples

**Deployed examples:**
- basic — routing, JSON, HTML
- session-auth — cookie sessions + CSRF
- jwt-auth — JWT + authorization guards
- websocket-chat — RFC 6455 + pub/sub
- spa-demo — static files + SPA fallback
- openapi-demo — Swagger UI