### PR TITLE
fix(docker): copy full workspace in Dockerfiles to resolve workspace members

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target/
+.git/
+node_modules/
+website/
+docs-site/
+docs/
+.history/
+*.md
+!README.md

--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.86-slim AS builder
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY ultimo/ ultimo/
-COPY examples/basic/ examples/basic/
+COPY . .
 RUN cargo build --release -p basic-example
 
 FROM debian:bookworm-slim

--- a/examples/jwt-auth/Dockerfile
+++ b/examples/jwt-auth/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.86-slim AS builder
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY ultimo/ ultimo/
-COPY examples/jwt-auth/ examples/jwt-auth/
+COPY . .
 RUN cargo build --release -p jwt-auth-example
 
 FROM debian:bookworm-slim

--- a/examples/openapi-demo/Dockerfile
+++ b/examples/openapi-demo/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.86-slim AS builder
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY ultimo/ ultimo/
-COPY examples/openapi-demo/ examples/openapi-demo/
+COPY . .
 RUN cargo build --release -p openapi-demo --bin rest-server
 
 FROM debian:bookworm-slim

--- a/examples/session-auth/Dockerfile
+++ b/examples/session-auth/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.86-slim AS builder
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY ultimo/ ultimo/
-COPY examples/session-auth/ examples/session-auth/
+COPY . .
 RUN cargo build --release -p session-auth-example
 
 FROM debian:bookworm-slim

--- a/examples/spa-demo/Dockerfile
+++ b/examples/spa-demo/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.86-slim AS builder
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY ultimo/ ultimo/
-COPY examples/spa-demo/ examples/spa-demo/
+COPY . .
 RUN cargo build --release -p spa-demo
 
 FROM debian:bookworm-slim

--- a/examples/websocket-chat/Dockerfile
+++ b/examples/websocket-chat/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.86-slim AS builder
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY ultimo/ ultimo/
-COPY examples/websocket-chat/ examples/websocket-chat/
+COPY . .
 RUN cargo build --release -p websocket-chat
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
Cargo needs all workspace members present to resolve the manifest.
Changed from selective COPY to COPY . . with .dockerignore to exclude
target/, .git/, node_modules/, website/, docs-site/.
