### PR TITLE
fix(examples): add root route to openapi-demo + remove dead file copy

### DIFF
--- a/examples/openapi-demo/Dockerfile
+++ b/examples/openapi-demo/Dockerfile
@@ -6,8 +6,6 @@ RUN cargo build --release -p openapi-demo --bin rest-server
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/rest-server /usr/local/bin/app
-COPY examples/openapi-demo/swagger-ui.html /app/swagger-ui.html
-WORKDIR /app
 ENV PORT=3000
 EXPOSE 3000
 CMD ["app"]

--- a/examples/openapi-demo/src/rest-server.rs
+++ b/examples/openapi-demo/src/rest-server.rs
@@ -520,6 +520,16 @@ async fn main() -> ultimo::Result<()> {
         async move { ctx.json(spec).await }
     });
 
+    // Root route — redirect to Swagger UI
+    app.get("/", |ctx: Context| async move {
+        ctx.html(r#"<!doctype html><html><head><meta http-equiv="refresh" content="0;url=/docs"></head><body>
+<div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:0.5rem;padding:0.5rem 1rem;margin-bottom:1rem;font-size:0.85rem;color:#92400e;">
+⚡ <strong>Live demo</strong> — hosted on Render free tier. First request may take ~30s due to cold start.
+Powered by <a href="https://github.com/ultimo-rs/ultimo" style="color:#92400e;font-weight:600;">Ultimo</a>.
+</div>
+<p>Redirecting to <a href="/docs">/docs</a>...</p></body></html>"#).await
+    });
+
     // Serve Swagger UI at /docs
     let openapi_docs = openapi.clone();
     app.get("/docs", move |ctx: Context| {


### PR DESCRIPTION
- GET / redirects to /docs (Swagger UI) with cold-start banner
- Fixes Render health check hitting 404 at root
- Removed unnecessary swagger-ui.html copy from Dockerfile
