### PR TITLE
fix(examples): commit spa-demo/dist so Docker build can copy it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ venv/
 .next/
 
 *.swp
+!examples/spa-demo/dist/

--- a/examples/spa-demo/dist/app.js
+++ b/examples/spa-demo/dist/app.js
@@ -1,0 +1,10 @@
+// Minimal SPA: fetch /api/hello and display the result.
+// In a real app this would be a compiled bundle (Vite, webpack, etc.).
+fetch("/api/hello")
+  .then((r) => r.json())
+  .then((data) => {
+    document.getElementById("app").textContent = data.message;
+  })
+  .catch((err) => {
+    document.getElementById("app").textContent = "Error: " + err.message;
+  });

--- a/examples/spa-demo/dist/index.html
+++ b/examples/spa-demo/dist/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Ultimo SPA Demo</title>
+</head>
+<body>
+  <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:0.5rem;padding:0.5rem 1rem;margin-bottom:1rem;font-size:0.85rem;color:#92400e;">
+    ⚡ <strong>Live demo</strong> — hosted on Render free tier. First request may take ~30s due to cold start.
+    Powered by <a href="https://github.com/ultimo-rs/ultimo" style="color:#92400e;font-weight:600;">Ultimo</a>.
+  </div>
+  <div id="app">Loading…</div>
+  <script src="/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Root .gitignore excludes 'dist'. Added exception for examples/spa-demo/dist/
which contains the static SPA files needed at runtime.
