### PR TITLE
fix(ci): add clippy lint for workspace examples + fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       - name: clippy (ultimo-cli)
         run: cargo clippy -p ultimo-cli --all-targets -- -D warnings
 
+      # Lint all workspace examples (catches broken code before it ships)
+      - name: clippy (examples)
+        run: cargo clippy --workspace --exclude ultimo --exclude ultimo-cli --exclude ultimo-coverage -- -D warnings
+
       # --all-targets here lints lib, integration tests and benches together,
       # all of which compile once websocket+test-helpers are enabled.
       # Database features are linted in the `test-db` job (needs system libs).

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -74,7 +74,7 @@ a{color:#4f46e5}code{background:#f4f4f5;padding:0.15rem 0.4rem;border-radius:0.2
 
     // Query parameters
     app.get("/search", |ctx: Context| async move {
-        let query = ctx.req.query("q").unwrap_or_else(|| "".to_string());
+        let query = ctx.req.query("q").unwrap_or_default();
         ctx.json(json!({
             "query": query,
             "results": []

--- a/examples/websocket-chat/src/main.rs
+++ b/examples/websocket-chat/src/main.rs
@@ -59,10 +59,8 @@ impl WebSocketHandler for ChatHandler {
                 tracing::info!("Received binary data: {} bytes", data.len());
                 ws.send_binary(data).await.ok();
             }
-            Message::Close(frame) => {
-                if let Some(cf) = frame {
-                    tracing::info!("Client closing: {} - {}", cf.code, cf.reason);
-                }
+            Message::Close(Some(cf)) => {
+                tracing::info!("Client closing: {} - {}", cf.code, cf.reason);
             }
             _ => {}
         }
@@ -96,16 +94,14 @@ async fn main() -> Result<()> {
 
     // Serve static HTML page
     app.get("/", |_ctx: Context| async move {
-        Ok(ultimo::response::helpers::html(include_str!(
-            "../index.html"
-        ))?)
+        ultimo::response::helpers::html(include_str!("../index.html"))
     });
 
     // WebSocket endpoint with custom configuration (Phase 2 features)
     let config = WebSocketConfig {
         // Limit message sizes for chat
         max_message_size: 10 * 1024 * 1024, // 10 MB
-        max_frame_size: 1 * 1024 * 1024,    // 1 MB (enables automatic fragmentation)
+        max_frame_size: 1024 * 1024,        // 1 MB (enables automatic fragmentation)
 
         // Disable ping/pong for the demo (browser pong handling varies)
         ping_interval: None,


### PR DESCRIPTION
CI now runs clippy on all workspace examples (catches broken code).

Fixed clippy warnings:
- basic: unwrap_or_else → unwrap_or_default
- websocket-chat: collapsed if-let, removed redundant Ok(?), 1*1024 → 1024
