### PR TITLE
docs: add live demo links to README and getting-started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,25 @@ WebSockets, database integration, testing, and [performance](https://docs.ultimo
 
 ## Examples
 
-Runnable examples live in [`examples/`](https://github.com/ultimo-rs/ultimo/tree/main/examples)
-— including `session-auth` and `jwt-auth` full-stack demos. Run one with:
+Runnable examples live in [`examples/`](https://github.com/ultimo-rs/ultimo/tree/main/examples).
+Run one locally with:
 
 ```bash
 cargo run -p jwt-auth-example
 ```
+
+### Live demos
+
+Try them without cloning (hosted on Render free tier — first request may take ~30s):
+
+| Demo                                                           | What it shows                     |
+| -------------------------------------------------------------- | --------------------------------- |
+| [basic-example](https://basic-example-v4wi.onrender.com/)      | Routing, JSON, query params, HTML |
+| [session-auth](https://session-auth-example.onrender.com/)     | Cookie sessions + CSRF protection |
+| [jwt-auth](https://jwt-auth-example-16kq.onrender.com/)        | JWT authentication + scope guards |
+| [websocket-chat](https://websocket-chat-example.onrender.com/) | WebSocket pub/sub chat room       |
+| [spa-demo](https://spa-demo-example.onrender.com/)             | Static files + SPA fallback       |
+| [openapi-demo](https://openapi-demo-example.onrender.com/)     | Swagger UI + OpenAPI spec         |
 
 ## Contributing
 

--- a/docs-site/docs/pages/getting-started.mdx
+++ b/docs-site/docs/pages/getting-started.mdx
@@ -87,3 +87,14 @@ my-app/
         └── lib/
             └── client.ts # Auto-generated TypeScript client
 ```
+
+## Live Demos
+
+Try Ultimo without installing anything (hosted on Render — first request may take ~30s):
+
+- [Basic example](https://basic-example-v4wi.onrender.com/) — routing, JSON, params
+- [Session auth](https://session-auth-example.onrender.com/) — cookie sessions + CSRF
+- [JWT auth](https://jwt-auth-example-16kq.onrender.com/) — JWT + scope guards
+- [WebSocket chat](https://websocket-chat-example.onrender.com/) — real-time pub/sub
+- [SPA demo](https://spa-demo-example.onrender.com/) — static files + SPA fallback
+- [OpenAPI / Swagger](https://openapi-demo-example.onrender.com/) — interactive API docs


### PR DESCRIPTION
6 Ultimo examples deployed on Render free tier with clickable links:
basic, session-auth, jwt-auth, websocket-chat, spa-demo, openapi-demo
