### PR TITLE
fix(ci): add license to all workspace members, fixing cargo-deny

### DIFF
--- a/coverage-tool/Cargo.toml
+++ b/coverage-tool/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ultimo-coverage"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 authors = ["Ultimo Contributors"]
 description = "Simple, transparent code coverage tool for Ultimo framework"
 

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ ignore = [
   "RUSTSEC-2024-0436", # paste
   "RUSTSEC-2024-0370", # proc-macro-error
   "RUSTSEC-2025-0134", # rustls-pemfile
+  "RUSTSEC-2024-0384", # instant (via notify)
 ]
 
 [bans]

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "basic-example"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/database-api-styles/Cargo.toml
+++ b/examples/database-api-styles/Cargo.toml
@@ -2,6 +2,7 @@
 name = "database-api-styles"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [[bin]]
 name = "database-api-styles"

--- a/examples/database-diesel/Cargo.toml
+++ b/examples/database-diesel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "database-diesel-example"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ultimo = { path = "../../ultimo", features = ["diesel-postgres"] }

--- a/examples/database-sqlx/Cargo.toml
+++ b/examples/database-sqlx/Cargo.toml
@@ -2,6 +2,7 @@
 name = "database-sqlx-example"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ultimo = { path = "../../ultimo", features = ["sqlx-postgres"] }

--- a/examples/jwt-auth/Cargo.toml
+++ b/examples/jwt-auth/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jwt-auth-example"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/openapi-demo/Cargo.toml
+++ b/examples/openapi-demo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "openapi-demo"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [[bin]]
 name = "rest-server"

--- a/examples/rpc-modes/Cargo.toml
+++ b/examples/rpc-modes/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rpc-modes"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 ultimo = { path = "../../ultimo", features = ["client-gen"] }

--- a/examples/session-auth/Cargo.toml
+++ b/examples/session-auth/Cargo.toml
@@ -2,6 +2,7 @@
 name = "session-auth-example"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/spa-demo/Cargo.toml
+++ b/examples/spa-demo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spa-demo"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [[bin]]
 name = "spa-demo"

--- a/examples/websocket-chat-react/Cargo.toml
+++ b/examples/websocket-chat-react/Cargo.toml
@@ -2,6 +2,7 @@
 name = "websocket-chat-react"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ultimo = { path = "../../ultimo", features = ["websocket"] }

--- a/examples/websocket-chat/Cargo.toml
+++ b/examples/websocket-chat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "websocket-chat"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 ultimo = { path = "../../ultimo", features = ["websocket"] }


### PR DESCRIPTION
All examples + coverage-tool now inherit license.workspace = true (MIT).
Also added RUSTSEC-2024-0384 (instant, unmaintained) to deny.toml ignore.
