### PR TITLE
feat(security): add rate limiting middleware (token bucket)

### DIFF
--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -610,6 +610,32 @@ app.use_middleware(IpFilter::allow(&[
 app.use_middleware(IpFilter::deny(&["203.0.113.0/24"]).build());
 ```
 
+#### `rate_limiter()` / `RateLimiter` — Rate limiting (token bucket)
+
+Per-IP, per-header, or global rate limiting. Returns 429 Too Many Requests with
+`Retry-After` header when the limit is exceeded.
+
+```rust
+use ultimo::middleware::builtin::{rate_limiter, RateLimiter, RateLimitKey};
+
+// Default: 100 requests per 60 seconds, keyed by client IP
+app.use_middleware(rate_limiter());
+
+// Custom: 10 requests per second, keyed by API key header
+app.use_middleware(
+    RateLimiter::new(10, 1)
+        .key(RateLimitKey::Header("X-API-Key".into()))
+        .build()
+);
+
+// Global rate limit (all requests share one bucket)
+app.use_middleware(
+    RateLimiter::new(1000, 60)
+        .key(RateLimitKey::Global)
+        .build()
+);
+```
+
 #### `compression()` / `Compression` (requires `compression` feature)
 
 Automatic response compression — brotli preferred, gzip fallback. Pure Rust

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -44,7 +44,7 @@ a stable **1.0**.
 
 - ~~📦 **Deployment guides** — Docker, Fly.io/Railway, AWS, DigitalOcean, Azure,
   Google Cloud Run, Kubernetes — each with ready-to-use config.~~ ✅ Shipped in 0.5.1
-- 🛡️ **Advanced rate limiting** — per-user, per-endpoint limits.
+- ~~🛡️ **Advanced rate limiting** — per-user, per-endpoint limits.~~ ✅ Shipped in 0.5.1
 - ⏱️ **Request timeouts** + **HTTP graceful shutdown** (WebSocket graceful
   shutdown already ships).
 - ~~🔄 **Hot reload** — `ultimo dev` with file-watching auto-restart.~~ ✅ Shipped in 0.5.1
@@ -135,7 +135,7 @@ dependencies and rot as each vendor's API changes).
 | Rust Client Generation (`--target rust`)                | 📋 Planned       | 0.6.0    |
 | Interactive API Docs (Swagger/Scalar/ReDoc)             | 📋 Planned       | 0.6.0    |
 | Deployment Guides                                       | ✅ Available     | 0.5.1    |
-| Advanced Rate Limiting                                  | 📋 Planned       | 0.6.0    |
+| Advanced Rate Limiting                                  | ✅ Available     | 0.5.1    |
 | Typed Handler Extractors + Validation                   | 📋 Planned       | 0.7.0    |
 | Typed RPC Subscriptions / SSE                           | 📋 Planned       | 0.7.0    |
 | OAuth2                                                  | 📋 Planned       | 0.7.0    |
@@ -234,7 +234,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
   service-to-service RPC (microservice contracts via private crate registry)
 - **Turnkey interactive API docs** — `serve_docs` (Swagger UI / Scalar / ReDoc)
 - ~~Deployment guides (Docker, Fly.io/Railway, AWS, DigitalOcean, Azure, GCR, K8s)~~ ✅ Shipped
-- Advanced rate limiting (per-user, per-endpoint)
+- ~~Advanced rate limiting (per-user, per-endpoint)~~ ✅ Shipped
 
 ### v0.7.0 — Real-time, auth, & production gaps
 

--- a/ultimo/src/middleware.rs
+++ b/ultimo/src/middleware.rs
@@ -578,6 +578,147 @@ pub mod builtin {
     }
 
     // -------------------------------------------------------------------------
+    // Rate limiting
+    // -------------------------------------------------------------------------
+
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// A token-bucket entry for a single key.
+    struct RateBucket {
+        tokens: f64,
+        last_refill: std::time::Instant,
+    }
+
+    /// Key extraction strategy for rate limiting.
+    #[derive(Clone)]
+    pub enum RateLimitKey {
+        /// Rate limit by client IP (default).
+        Ip,
+        /// Rate limit by a custom header value (e.g. `X-API-Key`).
+        Header(String),
+        /// Rate limit globally (all requests share one bucket).
+        Global,
+    }
+
+    /// Per-route or global rate limiting middleware (token bucket algorithm).
+    ///
+    /// Limits the number of requests per time window. Returns `429 Too Many
+    /// Requests` with a `Retry-After` header when the limit is exceeded.
+    ///
+    /// ```
+    /// # use ultimo::Ultimo;
+    /// let mut app = Ultimo::new_without_defaults();
+    /// // 100 requests per 60 seconds, keyed by client IP:
+    /// app.use_middleware(
+    ///     ultimo::middleware::builtin::RateLimiter::new(100, 60).build()
+    /// );
+    /// // 10 requests per second, keyed by API key header:
+    /// app.use_middleware(
+    ///     ultimo::middleware::builtin::RateLimiter::new(10, 1)
+    ///         .key(ultimo::middleware::builtin::RateLimitKey::Header("X-API-Key".into()))
+    ///         .build()
+    /// );
+    /// ```
+    #[derive(Clone)]
+    pub struct RateLimiter {
+        max_requests: u64,
+        window_secs: u64,
+        key: RateLimitKey,
+    }
+
+    impl RateLimiter {
+        /// Create a rate limiter: `max_requests` per `window_secs` seconds.
+        /// Default key is client IP.
+        pub fn new(max_requests: u64, window_secs: u64) -> Self {
+            Self {
+                max_requests,
+                window_secs,
+                key: RateLimitKey::Ip,
+            }
+        }
+
+        /// Set the key extraction strategy.
+        pub fn key(mut self, key: RateLimitKey) -> Self {
+            self.key = key;
+            self
+        }
+
+        /// Build the middleware.
+        pub fn build(self) -> BoxedMiddleware {
+            let rate = self.max_requests as f64 / self.window_secs as f64;
+            let max_tokens = self.max_requests as f64;
+            let window_secs = self.window_secs;
+            let key_strategy = self.key;
+
+            let buckets: Arc<Mutex<HashMap<String, RateBucket>>> =
+                Arc::new(Mutex::new(HashMap::new()));
+
+            Arc::new(move |ctx, next| {
+                let buckets = buckets.clone();
+                let key_strategy = key_strategy.clone();
+                let rate = rate;
+                let max_tokens = max_tokens;
+                let window_secs = window_secs;
+
+                Box::pin(async move {
+                    // Extract key
+                    let key = match &key_strategy {
+                        RateLimitKey::Ip => ctx
+                            .client_ip()
+                            .map(|ip| ip.to_string())
+                            .unwrap_or_else(|| "unknown".to_string()),
+                        RateLimitKey::Header(name) => ctx
+                            .req
+                            .header(name)
+                            .unwrap_or_else(|| "anonymous".to_string()),
+                        RateLimitKey::Global => "__global__".to_string(),
+                    };
+
+                    // Check/update bucket
+                    let allowed = {
+                        let mut map = buckets.lock().unwrap_or_else(|e| e.into_inner());
+                        let now = std::time::Instant::now();
+                        let bucket = map.entry(key).or_insert_with(|| RateBucket {
+                            tokens: max_tokens,
+                            last_refill: now,
+                        });
+
+                        // Refill tokens based on elapsed time
+                        let elapsed = now.duration_since(bucket.last_refill).as_secs_f64();
+                        bucket.tokens = (bucket.tokens + elapsed * rate).min(max_tokens);
+                        bucket.last_refill = now;
+
+                        // Try to consume a token
+                        if bucket.tokens >= 1.0 {
+                            bucket.tokens -= 1.0;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+
+                    if allowed {
+                        next(ctx).await
+                    } else {
+                        Ok(HyperResponse::builder()
+                            .status(429)
+                            .header("Retry-After", window_secs.to_string())
+                            .header("Content-Type", "text/plain")
+                            .body(Full::new(Bytes::from("Too Many Requests")))
+                            .unwrap())
+                    }
+                })
+            })
+        }
+    }
+
+    /// Rate limiting middleware with default settings (100 req/min per IP).
+    pub fn rate_limiter() -> BoxedMiddleware {
+        RateLimiter::new(100, 60).build()
+    }
+
+    // -------------------------------------------------------------------------
     // Response compression
     // -------------------------------------------------------------------------
 
@@ -1045,5 +1186,40 @@ mod tests {
 
         assert_send::<builtin::IpFilter>();
         assert_sync::<builtin::IpFilter>();
+    }
+
+    // Rate limiter tests ------------------------------------------------------
+
+    #[test]
+    fn test_rate_limiter_builder() {
+        let _m = builtin::RateLimiter::new(100, 60).build();
+    }
+
+    #[test]
+    fn test_rate_limiter_with_header_key() {
+        let _m = builtin::RateLimiter::new(10, 1)
+            .key(builtin::RateLimitKey::Header("X-API-Key".into()))
+            .build();
+    }
+
+    #[test]
+    fn test_rate_limiter_with_global_key() {
+        let _m = builtin::RateLimiter::new(5, 10)
+            .key(builtin::RateLimitKey::Global)
+            .build();
+    }
+
+    #[test]
+    fn test_rate_limiter_convenience_function() {
+        let _m = builtin::rate_limiter();
+    }
+
+    #[test]
+    fn test_rate_limiter_struct_is_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<builtin::RateLimiter>();
+        assert_sync::<builtin::RateLimiter>();
     }
 }


### PR DESCRIPTION
RateLimiter middleware with configurable:
- Requests per window (token bucket algorithm)
- Key strategy: per-IP (default), per-header (e.g. X-API-Key), or global
- Returns 429 Too Many Requests with Retry-After header
- In-memory store, zero external deps

Convenience: rate_limiter() = 100 req/min per IP.

5 unit tests. Docs updated: api-reference, roadmap marked as shipped.
