### PR TITLE
test: add integration tests for rate_limit and serve_docs

### DIFF
--- a/ultimo/tests/rate_limit.rs
+++ b/ultimo/tests/rate_limit.rs
@@ -1,0 +1,79 @@
+#![cfg(feature = "testing")]
+
+use ultimo::middleware::builtin::{rate_limiter, RateLimitKey, RateLimiter};
+use ultimo::testing::TestClient;
+use ultimo::{Context, Ultimo};
+
+#[tokio::test]
+async fn rate_limiter_allows_within_limit() {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(RateLimiter::new(5, 60).key(RateLimitKey::Global).build());
+    app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+
+    let client = TestClient::new(app);
+
+    // 5 requests should all succeed
+    for _ in 0..5 {
+        let res = client.get("/").send().await;
+        assert_eq!(res.status(), 200);
+    }
+}
+
+#[tokio::test]
+async fn rate_limiter_returns_429_when_exceeded() {
+    let mut app = Ultimo::new_without_defaults();
+    // Allow only 3 requests globally
+    app.use_middleware(RateLimiter::new(3, 60).key(RateLimitKey::Global).build());
+    app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+
+    let client = TestClient::new(app);
+
+    // First 3 should pass
+    for _ in 0..3 {
+        let res = client.get("/").send().await;
+        assert_eq!(res.status(), 200);
+    }
+
+    // 4th should be rate limited
+    let res = client.get("/").send().await;
+    assert_eq!(res.status(), 429);
+    assert!(res.header("retry-after").is_some());
+}
+
+#[tokio::test]
+async fn rate_limiter_default_convenience_function() {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(rate_limiter());
+    app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+
+    let client = TestClient::new(app);
+
+    // Default is 100 req/min — first request should succeed
+    let res = client.get("/").send().await;
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn rate_limiter_per_header_key() {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(
+        RateLimiter::new(2, 60)
+            .key(RateLimitKey::Header("X-API-Key".into()))
+            .build(),
+    );
+    app.get("/", |ctx: Context| async move { ctx.text("ok").await });
+
+    let client = TestClient::new(app);
+
+    // Client A: 2 requests OK, 3rd blocked
+    let res = client.get("/").header("X-API-Key", "client-a").send().await;
+    assert_eq!(res.status(), 200);
+    let res = client.get("/").header("X-API-Key", "client-a").send().await;
+    assert_eq!(res.status(), 200);
+    let res = client.get("/").header("X-API-Key", "client-a").send().await;
+    assert_eq!(res.status(), 429);
+
+    // Client B: still has its own quota
+    let res = client.get("/").header("X-API-Key", "client-b").send().await;
+    assert_eq!(res.status(), 200);
+}

--- a/ultimo/tests/serve_docs.rs
+++ b/ultimo/tests/serve_docs.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "testing")]
+
+use ultimo::openapi::OpenApiBuilder;
+use ultimo::testing::TestClient;
+use ultimo::Ultimo;
+
+#[tokio::test]
+async fn serve_docs_returns_swagger_ui_html() {
+    let mut app = Ultimo::new_without_defaults();
+    let spec = OpenApiBuilder::new()
+        .title("Test API")
+        .version("1.0.0")
+        .build();
+    app.serve_docs("/docs", spec);
+
+    let client = TestClient::new(app);
+    let res = client.get("/docs").send().await;
+
+    assert_eq!(res.status(), 200);
+    let body = res.text();
+    assert!(body.contains("swagger"), "Should contain Swagger UI");
+    assert!(
+        body.contains("/docs/openapi.json"),
+        "Should reference spec URL"
+    );
+}
+
+#[tokio::test]
+async fn serve_docs_returns_openapi_json() {
+    let mut app = Ultimo::new_without_defaults();
+    let spec = OpenApiBuilder::new()
+        .title("My Test API")
+        .version("2.0.0")
+        .description("A test API")
+        .build();
+    app.serve_docs("/docs", spec);
+
+    let client = TestClient::new(app);
+    let res = client.get("/docs/openapi.json").send().await;
+
+    assert_eq!(res.status(), 200);
+    let body = res.text();
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Should be valid JSON");
+    assert_eq!(json["info"]["title"], "My Test API");
+    assert_eq!(json["info"]["version"], "2.0.0");
+    assert_eq!(json["openapi"], "3.0.0");
+}
+
+#[tokio::test]
+async fn serve_docs_custom_path() {
+    let mut app = Ultimo::new_without_defaults();
+    let spec = OpenApiBuilder::new()
+        .title("Custom")
+        .version("1.0.0")
+        .build();
+    app.serve_docs("/api-docs", spec);
+
+    let client = TestClient::new(app);
+
+    let res = client.get("/api-docs").send().await;
+    assert_eq!(res.status(), 200);
+
+    let res = client.get("/api-docs/openapi.json").send().await;
+    assert_eq!(res.status(), 200);
+}


### PR DESCRIPTION
rate_limit (4 tests):
- allows within limit
- returns 429 when exceeded
- default convenience function works
- per-header key isolates clients

serve_docs (3 tests):
- returns Swagger UI HTML at /docs
- returns valid OpenAPI JSON at /docs/openapi.json
- works with custom path (/api-docs)
