### PR TITLE
chore: commit agent onboarding (AGENTS.md, .agents/skills) + version-sync it

### DIFF
--- a/.agents/skills/ship-feature/SKILL.md
+++ b/.agents/skills/ship-feature/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: ship-feature
+description: >-
+  The end-to-end workflow for shipping a change to the Ultimo framework — branch,
+  TDD, update every documentation surface (api-reference, docs-site + sidebar,
+  README, examples), run the verification gate, open a PR, watch CI go green, and
+  admin-squash-merge. Use this whenever you're adding, changing, or removing
+  anything in the Ultimo repo (a feature, a public API, a middleware, a Cargo
+  feature, a bug fix) — even small changes — so nothing in the release checklist
+  or the four doc-surface rules gets skipped. Trigger on "implement", "add",
+  "ship", "fix", "let's build", "work on issue #N", or any request that ends in a
+  PR to ultimo-rs/ultimo.
+---
+
+# Shipping a feature to Ultimo
+
+This skill exists so feature work is **cheap, consistent, and never drops a doc
+surface or a release-hygiene step.** Ultimo publishes two crates real users depend
+on (`ultimo`, `ultimo-cli`), so every change is a potential breaking change and
+every user-facing change must land its docs *in the same PR*. The cost of
+forgetting is a follow-up PR, a stale docs site, or a broken downstream build —
+all more expensive than doing it inline. Follow the steps in order.
+
+> Read `AGENTS.md` at the repo root for the authoritative rules — this skill is the
+> operational loop *over* those rules, not a replacement. When the two disagree,
+> AGENTS.md wins.
+
+## TodoWrite first
+
+Create one todo per phase below (Branch → TDD → Docs → Gate → PR → Merge →
+Cleanup). It keeps the doc surfaces from being forgotten once the code compiles —
+the most common failure mode is stopping at "tests pass" and shipping without docs.
+
+## 1. Branch
+
+`main` is protected. Never commit to it directly.
+
+```bash
+git switch -c <type>/<short-slug>   # e.g. feat/security-headers, fix/router-precedence
+```
+
+Use the conventional-commit type as the prefix (`feat`, `fix`, `docs`, `chore`,
+`refactor`, `perf`, `test`). This matters downstream: **release-plz derives the
+next version and the CHANGELOG from your commit messages**, so the type you pick
+here becomes the released changelog entry.
+
+## 2. Implement with TDD
+
+Invoke the TDD skill if you have it — write the failing test first, then the code.
+Ultimo's whole value proposition is reliability; tests are the guardrail that lets
+us move fast on a published crate.
+
+Ultimo-specific implementation rules:
+
+- **Gate new code behind a Cargo feature** when it's optional (`#[cfg(feature = "…")]`),
+  and wire the feature in `ultimo/Cargo.toml`. Everything is `default = []` / opt-in.
+- **Treat the public API as a contract.** Any new/renamed/removed `pub` item, feature
+  name, MSRV, or dependency floor is a SemVer event. Pre-1.0 rule: breaking → bump
+  **minor**, additive/fix → **patch**. CI's `semver-checks` job enforces this against
+  the published crate — respect its verdict, don't override it.
+- **Public items need doc comments**, and doctests must compile (`cargo test --doc`).
+  docs.rs builds the public API; a missing doc or broken doctest breaks the build.
+- **100% safe Rust** — the crate is `#![forbid(unsafe_code)]`. Don't reach for `unsafe`.
+- **Integration tests need feature flags.** A bare `cargo test` won't compile the
+  feature-gated `tests/*.rs` — that's expected, not a regression. Enable the combo
+  (see the gate below).
+
+## 3. Update every documentation surface (in this PR)
+
+This is the step most likely to be skipped and the reason this skill exists. Walk
+the four surfaces explicitly — skip one only after consciously deciding it doesn't
+apply, not by forgetting:
+
+1. **`docs-site/docs/pages/api-reference.mdx`** — update whenever the public surface
+   changes: a new/renamed/removed `pub` method or type, a new middleware, new
+   `Context`/`Ultimo`/`Request` methods, or a new/changed Cargo feature. This is the
+   canonical API list; don't let it drift behind the code.
+2. **`docs-site/docs/pages/<feature>.mdx` + `docs-site/vocs.config.ts` sidebar** — any
+   *user-facing* feature needs a docs-site page (Vocs, deploys to docs.ultimo.dev on
+   merge) **and** a sidebar entry. The top-level `docs/` dir is internal notes only —
+   writing there does NOT surface a feature to users.
+3. **`README.md`** — it's both the GitHub landing page and the crates.io front page.
+   Move shipped items from "Coming Soon" → "Available Now", keep the install snippet
+   (`ultimo = "0.x"`) and badges accurate. Never advertise a shipped feature as
+   "coming soon" or vice-versa.
+4. **`examples/`** — if the feature is usable from a frontend (routes/RPC, cookies,
+   sessions, WebSocket, auth, SSE, file upload…), create or update a runnable example
+   that demonstrates it from a client, and add it to the workspace `members` so CI
+   builds it. Pattern to copy: `examples/session-auth` (a Rust backend serving an
+   HTML+JS page, `cargo run -p <example>`). Update it in *this* PR, don't defer.
+
+Also keep the **roadmap** (`docs-site/docs/pages/roadmap.mdx`) honest — move the
+feature from Planned to the shipped version section if it was listed.
+
+**Do not hand-edit `CHANGELOG.md`.** release-plz regenerates it from your
+conventional commits on release. Get the changelog right by writing good commit
+messages, not by editing the file. (AGENTS.md's "update CHANGELOG" rule predates
+release-plz automation — the commit *is* the changelog entry now.)
+
+## 4. Run the verification gate
+
+Run all of these and get them green before opening the PR. This mirrors what CI
+runs, so a clean gate locally means a green PR.
+
+```bash
+cd /Users/ruslanelishaev/Desktop/projects/ultimo
+
+# Formatting
+cargo fmt --all --check
+
+# Clippy across the feature surface, warnings = errors
+cargo clippy -p ultimo --features "websocket,test-helpers,testing,session,csrf" \
+  --all-targets -- -D warnings
+
+# Library unit tests
+cargo test -p ultimo --lib
+
+# Feature-gated integration tests (won't compile without the features — expected)
+cargo test -p ultimo --features "websocket,test-helpers,testing,session,csrf"
+
+# Doctests (public API examples)
+cargo test -p ultimo --doc --features "websocket,testing,session,csrf"
+```
+
+If you touched DB code, also run the sqlite-backed tests:
+`cargo test -p ultimo --features "testing,sqlx-sqlite,diesel-sqlite"`.
+(`--all-features` needs `libpq`/`libmysqlclient` system libs — scope features to
+what you changed instead.)
+
+If you touched a hot path, run the benches (`ultimo/benches/`) — perf claims are
+guarded there.
+
+## 5. Commit and open the PR
+
+```bash
+git add -A
+git commit -m "feat(scope): concise summary"   # conventional commits — drives release-plz
+git push --no-verify -u origin <branch>          # --no-verify: the gate already ran
+gh pr create --fill
+```
+
+Write the commit body to explain the *why*. End the PR body with the Codex
+generated-with line. Multiple commits are fine — they get squashed on merge, so the
+**PR title** must be a clean conventional-commit line (that's what release-plz reads).
+
+## 6. Watch CI to green
+
+```bash
+gh pr checks --watch
+```
+
+Don't merge on red. Fix forward (new commit on the same branch) and re-watch. The
+jobs that gate the merge: `fmt + clippy`, `test` (ubuntu + macOS), `test-db`, `MSRV`,
+`semver-checks`, `cargo-audit`, `cargo-deny`, `version-sync`.
+
+## 7. Merge (admin override)
+
+`main` requires 1 review and a solo dev can't approve their own PR, so use the admin
+squash-merge:
+
+```bash
+gh pr merge --squash --admin --delete-branch
+```
+
+Squash keeps one clean conventional commit on `main` per feature — exactly what
+release-plz needs to compute the next version and changelog.
+
+## 8. Sync and clean up
+
+```bash
+git switch main && git pull
+git branch -D <branch> 2>/dev/null || true
+```
+
+## Releasing is separate — and automated
+
+You do **not** cut a release as part of shipping a feature. After merges land on
+`main`, **release-plz** opens (or updates) a release PR that bumps the version and
+writes the CHANGELOG from the accumulated conventional commits. Merging *that* PR
+publishes `ultimo` then `ultimo-cli` to crates.io and tags a GitHub release. Your
+job per feature ends at step 8; just make sure your commit messages are accurate
+because they become the release notes.
+
+## Quick recap
+
+branch → TDD → **docs (api-reference · docs-site+sidebar · README · examples)** →
+gate → PR → CI green → `gh pr merge --squash --admin` → sync. Conventional commits
+throughout; never hand-edit CHANGELOG; release-plz handles the release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,177 @@
+# Ultimo — Developer Reference (for Codex / coding agents)
+
+Ultimo is a modern Rust web framework: REST + JSON-RPC in one app, automatic
+**TypeScript client generation** from Rust API definitions, and RFC 6455
+WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
+
+- Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
+- Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
+- Current version: **0.6.0** · Edition 2021 · MSRV **1.86.0** · License MIT
+
+## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
+
+Ultimo ships two crates to crates.io that real users depend on: **`ultimo`**
+(the library) and **`ultimo-cli`** (the binary; depends on `ultimo`). Every
+change is a potential breaking change. **The public API contract** — changing
+any of it requires a deliberate version bump:
+
+- Any `pub` item (types, fns, traits, enum variants, fields) and the `prelude`
+- **Cargo feature names** (`websocket`, `testing`, `session`, `csrf`, `database`, `sqlx-*`, `diesel-*`, `test-helpers`) — renaming/removing breaks `features = [...]` downstream
+- **MSRV** (`rust-version`) — raising it is breaking (we're at 1.86.0)
+- **Direct dependency floors** — raising one (e.g. `bytes`, `diesel`) constrains downstream resolution; a dep type re-exported in our API (e.g. `bytes::Bytes` in WebSocket messages) makes that dep's version part of _our_ API
+- CLI subcommands / flags of `ultimo-cli`
+
+### On EVERY change
+
+1. **Decide SemVer impact.** Pre-1.0 (0.x): breaking → bump **minor** (0.3.x → 0.4.0); additive/fix → bump **patch**. CI's `semver-checks` enforces this against the published crate — respect its verdict.
+2. **Don't hand-edit `CHANGELOG.md`** — release-plz regenerates it from your conventional commits. Write a good commit message; that _is_ the changelog entry.
+3. **Keep `README.md` accurate** — it's the crates.io landing page.
+4. **Don't break docs.rs** — public items need doc comments; doctests must compile (`cargo test --doc`).
+
+### On a RELEASE (automated by release-plz — rarely done by hand)
+
+release-plz opens a release PR that bumps `version` in root `Cargo.toml`
+(`[workspace.package]`, shared by both crates) and writes the `CHANGELOG.md`
+section from commits. Merging it publishes **`ultimo` then `ultimo-cli`** to
+crates.io and tags a release. A published vuln/serious bug → **`cargo yank`** it
+and ship a fixed patch.
+
+## Workspace layout
+
+Cargo workspace (`resolver = "2"`). Members:
+
+| Crate / path     | Role                                                                                                                                                                   |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ultimo/`        | **The framework.** Core library — everything below is a module here.                                                                                                   |
+| `ultimo-cli/`    | CLI binary (clap). Subcommands: `generate` (TS client), `new` (scaffold), `dev` (hot-reload server), `build`.                                                          |
+| `coverage-tool/` | Custom coverage runner (`ultimo-coverage`), invoked by `make coverage`.                                                                                                |
+| `examples/*`     | Runnable example apps. `Cargo.toml` `members` is the source of truth — some dirs (`react-app`, `benchmark`, `database-with-openapi`) exist on disk but aren't members. |
+
+### `ultimo/src` modules (`lib.rs` is the map)
+
+- `app.rs` (`Ultimo` builder), `context.rs` (`Context`), `router.rs`, `handler.rs`, `middleware.rs`
+- `rpc.rs` — JSON-RPC registry + **TypeScript client codegen** (`RpcRegistry`)
+- `response.rs`, `error.rs` (`UltimoError`/`Result`), `validation.rs` (`validate`), `openapi.rs` (+ `openapi/docs.rs`)
+- `cookie.rs` (core), `session/` (`session`), `csrf.rs` (`csrf`), `testing/` (`testing`)
+- `database/` = `sqlx.rs` + `diesel.rs` (behind `database`); `websocket/` (behind `websocket`)
+
+Public API surface (keep stable): `Ultimo`, `Context`, `Result`, `UltimoError`,
+`RpcRegistry`, `RpcRequest`, `RpcResponse`, `validate`, plus `ultimo::prelude::*`.
+The crate is `#![forbid(unsafe_code)]` — 100% safe Rust, no `unsafe`.
+
+## Cargo features (`ultimo/Cargo.toml`)
+
+`default = []` — **everything is opt-in.** When adding code under a feature, gate
+it with `#[cfg(feature = "...")]`. Features: `websocket`, `testing`
+(TestClient/assertions/fixtures), `session`, `csrf`, `test-helpers` (exposes
+`websocket::test_helpers` for integration tests), `database` (enabled
+transitively by `sqlx-postgres|mysql|sqlite`, `diesel-postgres|mysql|sqlite`).
+
+## ⚠️ Test invocation gotchas (READ BEFORE TOUCHING TESTS)
+
+1. **Integration tests need feature flags.** The `tests/*.rs` files use
+   feature-gated modules, so a bare `cargo test` (no features) **fails to
+   compile** them — that's expected, not a regression. Enable the combo:
+   ```bash
+   cargo test -p ultimo --features "websocket,test-helpers,testing,session,csrf"
+   ```
+2. **`--all-features` needs system libs.** `diesel-mysql`/`sqlx-mysql` link
+   `libmysqlclient`; postgres backends need `libpq`. Without them
+   `--all-features` / `make check` **fails at the linker** — an env gap, not code
+   rot. Install them (`brew install mysql-client libpq`) or scope features.
+
+Verified-good invocations:
+
+```bash
+cargo fmt --all --check
+cargo test -p ultimo --lib
+cargo test -p ultimo --features "websocket,test-helpers,testing,session,csrf"
+cargo test -p ultimo --features "testing,sqlx-sqlite,diesel-sqlite"   # DB-backed tests
+```
+
+## Commands (Makefile is the canonical entry point)
+
+```bash
+make help            # list targets
+make build           # cargo build --release
+make test            # cargo test --lib --no-fail-fast   (UNIT ONLY — see gotchas)
+make check           # clippy --all-targets --all-features + fmt --check (needs system libs)
+make fmt             # cargo fmt --all
+make coverage        # cargo run --release -p ultimo-coverage  → target/coverage/html
+make doc             # cargo doc --no-deps --open
+make ci              # check + test + coverage
+```
+
+CLI usage (the product surface):
+
+```bash
+cargo run -p ultimo-cli -- new <name> --template <basic|fullstack|api-only|rpc|production>
+cargo run -p ultimo-cli -- generate --path <dir> --output <dir> [--watch]   # TS client gen
+cargo run -p ultimo-cli -- dev --port <n>
+cargo run -p ultimo-cli -- build --profile <debug|release>
+```
+
+## Benchmarks
+
+`ultimo/benches/` (criterion, `harness = false`): `websocket_bench.rs`,
+`websocket_pubsub_bench.rs`. Perf claims (158k+ req/s) live or die by these —
+guard against regressions before changing hot paths.
+
+## CI / repo state
+
+- **`ci.yml`** (push + PR to `main`): `fmt + clippy`, `test` (ubuntu + macOS:
+  lib + feature-gated integration + CLI + benches), `test-db` (sqlite DB tests),
+  `MSRV` (reads `rust-version` from Cargo.toml), `semver-checks` (public-API
+  breakage vs published crate), `cargo-audit` (RUSTSEC), `cargo-deny`
+  (advisories/bans/sources), `version-sync`.
+- **`release-plz.yml`** automates releases (opt-in per crate); CodeQL + Vercel
+  (docs-site + website) run as checks. **`Cargo.lock` is committed.** `main`
+  branch protection requires 1 review → solo merges use `--admin` override.
+
+## Shipping changes — use the `ship-feature` skill
+
+`.Codex/skills/ship-feature/SKILL.md` encodes the standard loop:
+**branch → TDD → docs surfaces → verification gate → PR → CI green →
+`gh pr merge --squash --admin --delete-branch` → sync.** Conventional commits
+throughout. Invoke it for any change to this repo.
+
+## Roadmap
+
+- **v0.3.0 (current):** sessions + cookies, CSRF, security headers, testing utilities, `#![forbid(unsafe_code)]`, client-IP extraction — all shipped.
+- v0.4.0: **Security & Performance** (Ultimo's two headline pillars) — auth (JWT/API-key), authz guards, rate-limit/timeouts, IP allow/deny, continuous benchmarking + `/performance` page.
+- v0.5.0: static files + SPA fallback, compression, hot reload, dev dashboard, multi-language client gen, **deployment guides**.
+- v0.6.0: MCP server for AI-assisted development. v1.0.0: stable API + complete docs.
+
+## Documentation surfaces (MUST keep current, in the same PR as the change)
+
+The `ship-feature` skill walks these — summary of the rules:
+
+1. **`README.md`** — GitHub + crates.io landing page. Move shipped items "Coming Soon" → "Available Now"; keep install snippet (`ultimo = "0.x"`) + badges accurate. Never advertise a shipped feature as coming-soon (or vice-versa).
+2. **`docs-site/docs/pages/api-reference.mdx`** — canonical public-API list. Update on any new/renamed/removed `pub` method/type, new middleware, new `Context`/`Ultimo`/`Request` method, or changed Cargo feature.
+3. **`docs-site/docs/pages/<feature>.mdx` + `docs-site/vocs.config.ts` sidebar** — any user-facing feature needs a docs-site page (Vocs → docs.ultimo.dev, auto-deploys on merge) AND a sidebar entry. Top-level `docs/` is internal notes only; writing there does NOT surface a feature to users.
+4. **`examples/`** — if usable from a frontend (routes/RPC, cookies, sessions, WebSocket, auth, SSE, file upload…), create/update a runnable example demonstrating it from a client and add it to workspace `members` so CI builds it. Pattern: `examples/session-auth` (Rust backend serving HTML+JS, `cargo run -p <example>`). Same PR — don't defer.
+5. Keep **`docs-site/docs/pages/roadmap.mdx`** honest — move shipped features to the right version section.
+
+## Conventions
+
+- **Published crates** — see the PUBLISHED CRATES section before changing public code, features, MSRV, or dep floors.
+- Use Makefile targets, not raw cargo, where one exists.
+- Breaking public-API changes must be deliberate and version-bumped; `cargo-semver-checks` runs in CI — respect its verdict.
+- Run `cargo fmt --all` and `cargo clippy` before committing (`.githooks/` may enforce this).
+
+## Website SEO conventions (`website/`)
+
+Every new page on ultimo.dev MUST include:
+
+1. **Canonical URL** — `alternates: { canonical: "https://ultimo.dev/<path>" }` in the page's `metadata` export.
+2. **Structured data (JSON-LD)** — pick the appropriate schema:
+   - Blog post → `BlogPosting` + `BreadcrumbList` (already automatic via `app/blog/[slug]/page.tsx`)
+   - Tutorial/guide → add `HowTo` with steps
+   - Feature/product page → `FAQPage` if it has Q&A, otherwise `WebPage`
+   - Landing page → `Organization` / `SoftwareApplication` (already in root layout)
+3. **Open Graph + Twitter meta** — title, description, `og:type`, image. Use the `metadata` export.
+4. **Internal links** — link to at least 2-3 other pages on the site from new content.
+5. **External links** — link to authoritative sources (docs.rs, rust-lang.org, tokio.rs, etc.) where relevant.
+6. **Sitemap entry** — new routes are auto-included via `app/sitemap.ts`; blog posts via `getAllPosts()`. Static pages must be added manually to the sitemap array.
+
+Validate schemas after deploy: https://search.google.com/test/rich-results

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -15,6 +15,7 @@ HERO_VERSION=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+ Now Available' website/componen
 CHANGELOG_VERSION=$(grep '## \[' CHANGELOG.md | grep -v Unreleased | head -1 | sed 's/.*\[\(.*\)\].*/\1/')
 DOCS_CHANGELOG_VERSION=$(grep '## \[' docs-site/docs/pages/changelog.mdx | grep -v Unreleased | head -1 | sed 's/.*\[\(.*\)\].*/\1/')
 CLAUDE_VERSION=$(grep -oE 'Current version: \*\*[0-9]+\.[0-9]+\.[0-9]+\*\*' CLAUDE.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+AGENTS_VERSION=$(grep -oE 'Current version: \*\*[0-9]+\.[0-9]+\.[0-9]+\*\*' AGENTS.md 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 BLOG_CURRENT_VERSION=$(grep -oE 'Current version.*\[?[0-9]+\.[0-9]+\.[0-9]+' website/content/posts/ultimo-vs-axum-comparison.mdx 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 
 echo "📦 Version Check (source of truth: Cargo.toml)"
@@ -26,6 +27,7 @@ echo "Website hero badge (hero-section):    $HERO_VERSION"
 echo "Changelog (CHANGELOG.md):             $CHANGELOG_VERSION"
 echo "Docs Changelog (changelog.mdx):       $DOCS_CHANGELOG_VERSION"
 echo "CLAUDE.md:                            $CLAUDE_VERSION"
+echo "AGENTS.md:                            $AGENTS_VERSION"
 echo "Blog comparison post:                 $BLOG_CURRENT_VERSION"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
@@ -43,6 +45,7 @@ check "Website hero badge" "$HERO_VERSION"
 check "Changelog version" "$CHANGELOG_VERSION"
 check "Docs changelog version" "$DOCS_CHANGELOG_VERSION"
 [ -n "$CLAUDE_VERSION" ] && check "CLAUDE.md version" "$CLAUDE_VERSION"
+[ -n "$AGENTS_VERSION" ] && check "AGENTS.md version" "$AGENTS_VERSION"
 [ -n "$BLOG_CURRENT_VERSION" ] && check "Blog comparison post" "$BLOG_CURRENT_VERSION"
 
 # ── Crate install snippets (README + every docs page) ─────────────────

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -63,6 +63,12 @@ if [ -f CLAUDE.md ]; then
   echo "  updated CLAUDE.md"
 fi
 
+# AGENTS.md: Current version: **X.X.X**
+if [ -f AGENTS.md ]; then
+  sed -i.bak -E "s/(Current version: \*\*)[0-9]+\.[0-9]+\.[0-9]+(\*\*)/\1$VERSION\2/" AGENTS.md && rm -f AGENTS.md.bak
+  echo "  updated AGENTS.md"
+fi
+
 # Blog comparison post: "Current version" table cell
 BLOG_COMPARE="website/content/posts/ultimo-vs-axum-comparison.mdx"
 if [ -f "$BLOG_COMPARE" ]; then


### PR DESCRIPTION
Commits the agent-onboarding artifacts so the repo is friendly to contributors using Codex / other coding agents:

- **`AGENTS.md`** — a developer reference (like `CLAUDE.md`) for coding agents.
- **`.agents/skills/ship-feature/SKILL.md`** — the ship-feature workflow skill.

Also:
- Refreshed the stale version line (`0.5.1` → `0.6.0`).
- Wired `AGENTS.md`'s `Current version: **X**` into `sync-versions.sh` + the `version-sync` CI gate (mirroring the existing `CLAUDE.md` handling), so it can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)