### PR TITLE
chore: release v0.6.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.6.0** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.6.1** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-06
+
+### Added
+
+- **Frontend client adapters** — generate TanStack Query React hooks from the RPC registry (`generate_react_hooks` / `generate_react_hooks_file`, `client-gen` feature). Emits an `UltimoProvider` context, a `queryKeys` factory, and a `useQuery`/`useMutation` hook per procedure, with input/output types derived from the generated client's method signatures. (#164)
+- Generated client type declarations are now `export`ed so consumers (and the hooks module) can import them. (#164)
+
 ## [0.6.0] - 2026-07-08
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.6.0** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.6.1** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3863,7 +3863,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-06
+
+### Added
+
+- **Frontend client adapters** — generate TanStack Query React hooks from the RPC registry (`generate_react_hooks` / `generate_react_hooks_file`, `client-gen` feature). Emits an `UltimoProvider` context, a `queryKeys` factory, and a `useQuery`/`useMutation` hook per procedure, with input/output types derived from the generated client's method signatures. (#164)
+- Generated client type declarations are now `export`ed so consumers (and the hooks module) can import them. (#164)
+
 ## [0.6.0] - 2026-07-08
 
 ### Security

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -227,7 +227,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - ✅ **Hot reload** — `ultimo dev` with file-watching auto-restart
 - ✅ **IP allow/deny middleware** — CIDR-aware `IpFilter` (allow-list / deny-list)
 
-### v0.6.0 (Current) — Finish the codegen story + ship-readiness
+### v0.6.0 — Finish the codegen story + ship-readiness
 
 - ~~Codegen: scaffold `generate-client` into `ultimo new` templates; TypeScript
   docs rewrite; `ultimo generate --watch`~~ ✅ Shipped

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/ultimo/CHANGELOG.md
+++ b/ultimo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.6.0...ultimo-v0.6.1) - 2026-08-06
+
+### Added
+
+- *(rpc)* generate TanStack Query React hooks (client-gen) ([#164](https://github.com/ultimo-rs/ultimo/pull/164))
+
 ## [0.6.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.5.1...ultimo-v0.6.0) - 2026-07-08
 
 ### Added

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.6.0 Now Available
+          v0.6.1 Now Available
         </div>
 
         <h1 className="font-bold tracking-tight mb-6 max-w-4xl text-center">

--- a/website/content/posts/ultimo-vs-axum-comparison.mdx
+++ b/website/content/posts/ultimo-vs-axum-comparison.mdx
@@ -300,7 +300,7 @@ Let's be direct: **Axum has a larger ecosystem and is more mature.** It reached 
 
 | Metric                  | Ultimo                                           | Axum                       |
 | ----------------------- | ------------------------------------------------ | -------------------------- |
-| **Current version**     | [0.6.0](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
+| **Current version**     | [0.6.1](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
 | **First release**       | 2024                                             | 2021                       |
 | **Community crates**    | Growing                                          | Hundreds                   |
 | **Production users**    | Early adopters                                   | Major companies            |

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `ultimo-cli`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `ultimo`

<blockquote>

## [0.6.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.6.0...ultimo-v0.6.1) - 2026-08-06

### Added

- *(rpc)* generate TanStack Query React hooks (client-gen) ([#164](https://github.com/ultimo-rs/ultimo/pull/164))
</blockquote>

## `ultimo-cli`

<blockquote>

## [0.6.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-cli-v0.5.1...ultimo-cli-v0.6.0) - 2026-07-08

### Added

- *(cli)* implement `ultimo generate --watch` + scaffold generate-client in templates ([#155](https://github.com/ultimo-rs/ultimo/pull/155))
- *(cli)* implement `ultimo dev` hot-reload dev server ([#130](https://github.com/ultimo-rs/ultimo/pull/130))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).