### PR TITLE
chore: release v0.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.6.1** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.7.0** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-06
+
+### Added
+
+- **Typed handler extractors** — handlers can declare typed `Path<T>`, `Query<T>`, `Json<T>`, and `Valid<T>` parameters (up to 8) that are parsed automatically from the request; `Context` remains available as an identity extractor. Malformed input returns **400**; `Valid<T>` validation failures return **422**. (#167)
+
+### Changed
+
+- **BREAKING:** the route methods (`get`/`post`/`put`/`delete`/`patch`/`options`) and `IntoHandler` are now generic over the handler's extractor argument tuple (`IntoHandler<Args>`). Existing `|ctx: Context| async move { … }` handlers compile and behave unchanged (`Context` implements the new `FromRequest` extractor trait); only explicit turbofish calls to the route methods would need updating. (#167)
+- **`UltimoError::Validation` now maps to HTTP 422** (Unprocessable Entity) instead of 400, matching typed-extractor validation semantics. Affects all `validate()` callers. (#167)
+
 ## [0.6.1] - 2026-08-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.6.1** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.7.0** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3863,7 +3863,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the framework is 100% safe Rust (`#![forbid(unsafe_code)]`).
 
 ```toml
 [dependencies]
-ultimo = "0.6"
+ultimo = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```
@@ -120,7 +120,7 @@ Everything is opt-in (`default = []`):
 | `diesel-postgres` · `diesel-mysql` · `diesel-sqlite` | Diesel integration per backend                                    |
 
 ```toml
-ultimo = { version = "0.6", features = ["websocket", "jwt", "sqlx-postgres"] }
+ultimo = { version = "0.7", features = ["websocket", "jwt", "sqlx-postgres"] }
 ```
 
 ## CLI

--- a/docs-site/docs/pages/api-keys.mdx
+++ b/docs-site/docs/pages/api-keys.mdx
@@ -19,7 +19,7 @@ clients on purpose.
 
 ```toml
 [dependencies]
-ultimo = { version = "0.6", features = ["api-key"] }
+ultimo = { version = "0.7", features = ["api-key"] }
 ```
 
 ## Quick start

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -1008,7 +1008,7 @@ Enable optional functionality through Cargo features:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.6", features = ["sqlx-postgres"] }
+ultimo = { version = "0.7", features = ["sqlx-postgres"] }
 ```
 
 ### Available Features
@@ -1029,7 +1029,7 @@ All features are off by default (`default = []`).
 - `diesel-postgres` / `diesel-mysql` / `diesel-sqlite` - Diesel integration per backend
 
 ```toml
-ultimo = { version = "0.6", features = ["websocket", "session", "sqlx-postgres"] }
+ultimo = { version = "0.7", features = ["websocket", "session", "sqlx-postgres"] }
 ```
 
 ---

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-06
+
+### Added
+
+- **Typed handler extractors** — handlers can declare typed `Path<T>`, `Query<T>`, `Json<T>`, and `Valid<T>` parameters (up to 8) that are parsed automatically from the request; `Context` remains available as an identity extractor. Malformed input returns **400**; `Valid<T>` validation failures return **422**. (#167)
+
+### Changed
+
+- **BREAKING:** the route methods (`get`/`post`/`put`/`delete`/`patch`/`options`) and `IntoHandler` are now generic over the handler's extractor argument tuple (`IntoHandler<Args>`). Existing `|ctx: Context| async move { … }` handlers compile and behave unchanged (`Context` implements the new `FromRequest` extractor trait); only explicit turbofish calls to the route methods would need updating. (#167)
+- **`UltimoError::Validation` now maps to HTTP 422** (Unprocessable Entity) instead of 400, matching typed-extractor validation semantics. Affects all `validate()` callers. (#167)
+
 ## [0.6.1] - 2026-08-06
 
 ### Added

--- a/docs-site/docs/pages/diesel.mdx
+++ b/docs-site/docs/pages/diesel.mdx
@@ -18,7 +18,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.6", features = ["diesel-postgres"] }
+ultimo = { version = "0.7", features = ["diesel-postgres"] }
 diesel = { version = "2", features = ["postgres", "r2d2"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/docs-site/docs/pages/getting-started.mdx
+++ b/docs-site/docs/pages/getting-started.mdx
@@ -8,7 +8,7 @@ Add Ultimo to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = "0.6"
+ultimo = "0.7"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/docs-site/docs/pages/jwt.mdx
+++ b/docs-site/docs/pages/jwt.mdx
@@ -16,7 +16,7 @@ JWT support is opt-in:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.6", features = ["jwt"] }
+ultimo = { version = "0.7", features = ["jwt"] }
 ```
 
 ## Quick start

--- a/docs-site/docs/pages/middleware.mdx
+++ b/docs-site/docs/pages/middleware.mdx
@@ -86,7 +86,7 @@ no C dependencies). Prefers brotli over gzip when the client accepts both, skips
 already-encoded responses and binary MIME types, and always sets `Vary: Accept-Encoding`.
 
 ```toml
-ultimo = { version = "0.6", features = ["compression"] }
+ultimo = { version = "0.7", features = ["compression"] }
 ```
 
 Quick start with sensible defaults (brotli + gzip, 1 KB minimum body):

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -233,7 +233,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - ~~Deployment guides (Docker, Fly.io/Railway, AWS, DigitalOcean, Azure, GCR, K8s)~~ ✅ Shipped
 - ~~Advanced rate limiting (per-user, per-endpoint)~~ ✅ Shipped
 
-### v0.7.0 — Real-time, auth, & production gaps
+### v0.7.0 (Current) — Real-time, auth, & production gaps
 
 - ✅ **Typed handler extractors + validation-from-types** (type-safe input; `Path`/`Query`/`Json`/`Valid`, 400/422)
 - Typed RPC subscriptions / SSE (derived event types)

--- a/docs-site/docs/pages/security.mdx
+++ b/docs-site/docs/pages/security.mdx
@@ -105,7 +105,7 @@ middleware issues a random token in a (non-HttpOnly) cookie; on unsafe methods
 are compared in **constant time** (mismatch → 403). Safe methods are exempt.
 
 ```rust
-// Cargo.toml: ultimo = { version = "0.6", features = ["csrf"] }
+// Cargo.toml: ultimo = { version = "0.7", features = ["csrf"] }
 app.use_middleware(ultimo::csrf::csrf());
 
 // or customized:

--- a/docs-site/docs/pages/sessions.mdx
+++ b/docs-site/docs/pages/sessions.mdx
@@ -7,7 +7,7 @@ Cookies are a core helper; sessions are middleware over a pluggable store.
 
 ```toml
 [dependencies]
-ultimo = { version = "0.6", features = ["session"] }
+ultimo = { version = "0.7", features = ["session"] }
 ```
 
 ## Register the middleware

--- a/docs-site/docs/pages/sqlx.mdx
+++ b/docs-site/docs/pages/sqlx.mdx
@@ -18,7 +18,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultimo = { version = "0.6", features = ["sqlx-postgres"] }
+ultimo = { version = "0.7", features = ["sqlx-postgres"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/docs-site/docs/pages/static-files.mdx
+++ b/docs-site/docs/pages/static-files.mdx
@@ -6,7 +6,7 @@ support Single Page Application (SPA) routing with a fallback to `index.html`.
 Requires the `static-files` Cargo feature:
 
 ```toml
-ultimo = { version = "0.6", features = ["static-files"] }
+ultimo = { version = "0.7", features = ["static-files"] }
 ```
 
 ## Serving a directory

--- a/docs-site/docs/pages/testing.mdx
+++ b/docs-site/docs/pages/testing.mdx
@@ -10,7 +10,7 @@ Add `ultimo` with the `testing` feature as a **dev-dependency**:
 
 ```toml
 [dev-dependencies]
-ultimo = { version = "0.6", features = ["testing"] }
+ultimo = { version = "0.7", features = ["testing"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/ultimo/CHANGELOG.md
+++ b/ultimo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.6.1...ultimo-v0.7.0) - 2026-08-06
+
+### Added
+
+- *(handler)* [**breaking**] typed request extractors (Path/Query/Json/Valid) ([#167](https://github.com/ultimo-rs/ultimo/pull/167))
+
 ## [0.6.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.6.0...ultimo-v0.6.1) - 2026-08-06
 
 ### Added

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.6.1 Now Available
+          v0.7.0 Now Available
         </div>
 
         <h1 className="font-bold tracking-tight mb-6 max-w-4xl text-center">

--- a/website/content/posts/ultimo-vs-axum-comparison.mdx
+++ b/website/content/posts/ultimo-vs-axum-comparison.mdx
@@ -300,7 +300,7 @@ Let's be direct: **Axum has a larger ecosystem and is more mature.** It reached 
 
 | Metric                  | Ultimo                                           | Axum                       |
 | ----------------------- | ------------------------------------------------ | -------------------------- |
-| **Current version**     | [0.6.1](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
+| **Current version**     | [0.7.0](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
 | **First release**       | 2024                                             | 2021                       |
 | **Community crates**    | Growing                                          | Hundreds                   |
 | **Production users**    | Early adopters                                   | Major companies            |

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `ultimo-cli`: 0.6.1 -> 0.7.0

### ⚠ `ultimo` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  ultimo::app::Ultimo::get takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:159
  ultimo::app::Ultimo::post takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:168
  ultimo::app::Ultimo::put takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:177
  ultimo::app::Ultimo::delete takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:186
  ultimo::app::Ultimo::patch takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:195
  ultimo::app::Ultimo::options takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:204
  ultimo::prelude::Ultimo::get takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:159
  ultimo::prelude::Ultimo::post takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:168
  ultimo::prelude::Ultimo::put takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:177
  ultimo::prelude::Ultimo::delete takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:186
  ultimo::prelude::Ultimo::patch takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:195
  ultimo::prelude::Ultimo::options takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:204
  ultimo::Ultimo::get takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:159
  ultimo::Ultimo::post takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:168
  ultimo::Ultimo::put takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:177
  ultimo::Ultimo::delete takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:186
  ultimo::Ultimo::patch takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:195
  ultimo::Ultimo::options takes 1 generic types instead of 0, in /tmp/.tmpxk6xOp/ultimo/ultimo/src/app.rs:204
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ultimo`

<blockquote>

## [0.7.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.6.1...ultimo-v0.7.0) - 2026-08-06

### Added

- *(handler)* [**breaking**] typed request extractors (Path/Query/Json/Valid) ([#167](https://github.com/ultimo-rs/ultimo/pull/167))
</blockquote>

## `ultimo-cli`

<blockquote>

## [0.6.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-cli-v0.5.1...ultimo-cli-v0.6.0) - 2026-07-08

### Added

- *(cli)* implement `ultimo generate --watch` + scaffold generate-client in templates ([#155](https://github.com/ultimo-rs/ultimo/pull/155))
- *(cli)* implement `ultimo dev` hot-reload dev server ([#130](https://github.com/ultimo-rs/ultimo/pull/130))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).