### PR TITLE
feat(handler)!: typed request extractors (Path/Query/Json/Valid)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Library unit tests
         run: cargo test -p ultimo --lib
 
+      - name: Typed extractor tests
+        run: cargo test -p ultimo --test extractors
+
       # The integration tests in ultimo/tests/*.rs are NOT covered by `--lib`
       # and require BOTH the `websocket` and `test-helpers` features to compile.
       # This is the gap that previously let them rot silently.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,6 +3885,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha1",
  "sha2",
  "sqlx",

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -565,6 +565,40 @@ use ultimo::rpc::{JsonRpcRequest, JsonRpcResponse, JsonRpcErrorResponse, JsonRpc
 
 ---
 
+## Typed extractors
+
+Handlers may take typed parameters instead of a raw `Context`. Each implements
+`FromRequest` and is parsed from the request automatically; a failure
+short-circuits with the right status.
+
+```rust
+use ultimo::extract::{Path, Query, Json, Valid};
+
+// GET /users/:id?verbose=true
+app.get("/users/:id", |Path(id): Path<u32>, Query(opts): Query<Opts>| async move {
+    // id: u32, opts: Opts — already parsed
+});
+
+// POST /users — deserialize the JSON body AND validate it
+app.post("/users", |Valid(body): Valid<CreateUser>| async move {
+    // body: CreateUser — validated (422 if invalid)
+});
+```
+
+| Extractor | Source | On failure |
+|---|---|---|
+| `Path<T>` | route `:params` — a single scalar (`Path<u32>`) or a struct of param names | 400 |
+| `Query<T>` | query string | 400 |
+| `Json<T>` | request body | 400 |
+| `Valid<T>` | request body + `validator` | 400 (parse) · **422** (invalid) |
+| `Context` | the whole request | — |
+
+Handlers may take up to 8 extractors. `|ctx: Context|` handlers keep working
+unchanged (`Context` is itself an extractor). Validation failures return **422
+Unprocessable Entity**.
+
+---
+
 ## Middleware
 
 ### Built-in Middleware

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -20,13 +20,9 @@ a stable **1.0**.
   from your Rust types (tRPC-style subscriptions, in Rust).
 - ❗ **End-to-end typed errors** — RPC errors surfaced as typed results in the
   generated client.
-- 🎯 **Typed handler extractors** — declare typed path / query / body / header
-  params on a handler; they're parsed and validated automatically, with a
-  structured **422** on bad input. Ultimo already gives type-safe _output_ (the
-  TS client); this gives type-safe _input_ — the handler signature becomes the
-  contract. Inspired by FastAPI / axum.
 - ✅ **Validation from types** — derive request validation from the type
-  (Pydantic-style), wired into the extractor and RPC boundary.
+  (Pydantic-style), wired into the extractor and RPC boundary. _(Shipped with
+  typed extractors — see the `Valid<T>` extractor.)_
 - 🪄 **`#[derive(UltimoType)]`** — a thin wrapper so client types derive without
   adding `ts-rs` to your own `Cargo.toml`.
 
@@ -137,7 +133,7 @@ dependencies and rot as each vendor's API changes).
 | Interactive API Docs (`serve_docs`)                     | ✅ Available     | 0.5.1    |
 | Deployment Guides                                       | ✅ Available     | 0.5.1    |
 | Advanced Rate Limiting                                  | ✅ Available     | 0.5.1    |
-| Typed Handler Extractors + Validation                   | 📋 Planned       | 0.7.0    |
+| Typed Handler Extractors + Validation                   | ✅ Available     | 0.7.0    |
 | Typed RPC Subscriptions / SSE                           | 📋 Planned       | 0.7.0    |
 | OAuth2                                                  | 📋 Planned       | 0.7.0    |
 | Auth Providers (OIDC/JWKS + presets)                    | 📋 Planned       | 0.7.0    |
@@ -239,7 +235,7 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 
 ### v0.7.0 — Real-time, auth, & production gaps
 
-- **Typed handler extractors + validation-from-types** (type-safe input)
+- ✅ **Typed handler extractors + validation-from-types** (type-safe input; `Path`/`Query`/`Json`/`Valid`, 400/422)
 - Typed RPC subscriptions / SSE (derived event types)
 - OAuth2 provider integration
 - **Auth providers (OIDC/JWKS)** — RS256/ES256 + remote JWKS, presets for

--- a/docs/superpowers/plans/2026-08-06-typed-handler-extractors.md
+++ b/docs/superpowers/plans/2026-08-06-typed-handler-extractors.md
@@ -1,0 +1,700 @@
+# Typed Handler Extractors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let route handlers declare typed `Path`/`Query`/`Json`/`Valid` parameters that Ultimo parses and validates automatically, with 400 on malformed input and 422 on validation failure.
+
+**Architecture:** One async `FromRequest` trait; every extractor borrows `&Context` (the body is already buffered/cached, so no ownership transfer). A declarative macro generates `IntoHandler` for handler fns of arity 0..=8 where every parameter is `FromRequest`; `Context: FromRequest` keeps existing `|ctx: Context|` handlers working. `Query` uses `serde_urlencoded`; `Path` uses `serde_urlencoded` for multi-param structs and a small scalar deserializer for a single param.
+
+**Tech Stack:** Rust, `async-trait` (already a dep), `serde`, `serde_json` (already deps), `serde_urlencoded` (add as direct dep; already in the lockfile transitively).
+
+**Spec:** `docs/superpowers/specs/2026-08-06-typed-handler-extractors-design.md`
+
+## Global Constraints
+
+- 100% safe Rust (`#![forbid(unsafe_code)]`); no `unsafe`.
+- Typed extractors are **core** (no Cargo feature gate).
+- Handler return type stays `Result<Response>` (input side only; no `IntoResponse` sugar).
+- Backward compatible: existing `|ctx: Context| async move { … }` handlers must compile and behave unchanged.
+- Error mapping: malformed/undeserializable → `UltimoError::BadRequest` (400); validation failure → `UltimoError::Validation` (422).
+- `Params` is `HashMap<String, String>` (unordered); `Context` has `pub req: Request`; body accessors (`ctx.req.json()/bytes()`) are async and cached.
+
+## Facts pinned by spike (do not re-derive)
+
+- `Request` (in `ultimo/src/context.rs`) stores a private `uri: hyper::Uri`; there is **no** public raw-query accessor yet → Task 1 adds `query_string()`.
+- `serde_urlencoded::from_str::<T>` deserializes a `k=v&…` string type-directed (correct for both `String` and numeric fields), but **errors on a bare single value** (`"42"` → "expected map").
+- The `serde_json` coercion bridge mis-handles `Path<String>` when the value looks numeric → **not used** for Path.
+- `serde_urlencoded::to_string(&HashMap<String,String>)` reconstructs a query string from the param map (order nondeterministic — irrelevant for struct fields).
+
+---
+
+### Task 1: Foundations — dep, `query_string()` accessor, and 400→422 flip
+
+**Files:**
+- Modify: `ultimo/Cargo.toml` (deps)
+- Modify: `ultimo/src/context.rs` (add `Request::query_string`)
+- Modify: `ultimo/src/error.rs` (Validation status 400→422 + its unit test)
+
+**Interfaces:**
+- Produces: `Request::query_string(&self) -> Option<&str>`; `UltimoError::Validation.status_code() == 422`.
+
+- [ ] **Step 1: Add `serde_urlencoded` as a direct dependency**
+
+In `ultimo/Cargo.toml` under `[dependencies]`, add:
+
+```toml
+serde_urlencoded = "0.7"
+```
+
+- [ ] **Step 2: Write the failing test for the 422 flip**
+
+In `ultimo/src/error.rs`, find the existing test asserting the Validation status is 400 and change it to expect 422:
+
+```rust
+    // (in the error tests module) validation now maps to 422 Unprocessable Entity
+    let err = UltimoError::Validation {
+        message: "Validation failed".to_string(),
+        details: vec![],
+    };
+    assert_eq!(err.status_code(), 422);
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `cargo test -p ultimo --lib error::`
+Expected: FAIL — Validation currently returns 400.
+
+- [ ] **Step 4: Flip the status mapping**
+
+In `ultimo/src/error.rs` `status_code()`, change the Validation arm:
+
+```rust
+            UltimoError::Validation { .. } => 422,
+```
+
+- [ ] **Step 5: Add the `query_string` accessor**
+
+In `ultimo/src/context.rs`, in `impl Request`, next to `query()`:
+
+```rust
+    /// The raw query string (everything after `?`), if present.
+    pub fn query_string(&self) -> Option<&str> {
+        self.uri.query()
+    }
+```
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `cargo test -p ultimo --lib error:: && cargo build -p ultimo`
+Expected: PASS / clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultimo/Cargo.toml Cargo.lock ultimo/src/context.rs ultimo/src/error.rs
+git commit -m "feat(core): validation -> 422; add Request::query_string; serde_urlencoded dep"
+```
+
+---
+
+### Task 2: `FromRequest` trait + `Context`/`Json`/`Query`/`Valid` extractors
+
+**Files:**
+- Create: `ultimo/src/extract.rs`
+- Modify: `ultimo/src/lib.rs` (add `pub mod extract;` + re-exports)
+- Test: unit tests inside `ultimo/src/extract.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub trait FromRequest: Sized { async fn from_request(ctx: &Context) -> Result<Self>; }` (via `#[async_trait::async_trait]`).
+  - `pub struct Json<T>(pub T);`, `pub struct Query<T>(pub T);`, `pub struct Valid<T>(pub T);`
+  - `impl FromRequest for Context` (clones the context).
+- Consumes: `Context`, `ctx.req.json()`, `ctx.req.query_string()` (Task 1), `crate::validate`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ultimo/src/extract.rs` with the tests first (a helper builds a `Context` from parts):
+
+```rust
+//! Typed request extractors: implement `FromRequest` to pull typed data from a
+//! request. Handlers may take any number of these as parameters.
+
+use crate::context::Context;
+use crate::error::{Result, UltimoError};
+use serde::de::DeserializeOwned;
+use validator::Validate;
+
+/// A type that can be extracted from the request context.
+#[async_trait::async_trait]
+pub trait FromRequest: Sized {
+    async fn from_request(ctx: &Context) -> Result<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::{Context, Request};
+    use bytes::Bytes;
+    use serde::Deserialize;
+
+    fn ctx_with(query: &str, body: &[u8]) -> Context {
+        let parts = hyper::Request::builder()
+            .uri(format!("http://x/?{query}"))
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let req = Request::from_parts(parts, Bytes::copy_from_slice(body), Default::default());
+        Context::from_request_for_test(req)
+    }
+
+    #[derive(Deserialize)]
+    struct Filter {
+        page: u32,
+        q: String,
+    }
+
+    #[tokio::test]
+    async fn query_parses_typed_fields() {
+        let ctx = ctx_with("page=2&q=rust", b"");
+        let Query(f) = Query::<Filter>::from_request(&ctx).await.unwrap();
+        assert_eq!(f.page, 2);
+        assert_eq!(f.q, "rust");
+    }
+
+    #[tokio::test]
+    async fn query_malformed_is_400() {
+        let ctx = ctx_with("page=notanumber&q=x", b"");
+        let err = Query::<Filter>::from_request(&ctx).await.unwrap_err();
+        assert_eq!(err.status_code(), 400);
+    }
+
+    #[derive(Deserialize)]
+    struct Body {
+        name: String,
+    }
+
+    #[tokio::test]
+    async fn json_parses_body() {
+        let ctx = ctx_with("", br#"{"name":"ada"}"#);
+        let Json(b) = Json::<Body>::from_request(&ctx).await.unwrap();
+        assert_eq!(b.name, "ada");
+    }
+
+    #[derive(Deserialize, Validate)]
+    struct NewUser {
+        #[validate(length(min = 3))]
+        name: String,
+    }
+
+    #[tokio::test]
+    async fn valid_ok_and_422() {
+        let ok = ctx_with("", br#"{"name":"ada"}"#);
+        assert!(Valid::<NewUser>::from_request(&ok).await.is_ok());
+
+        let bad = ctx_with("", br#"{"name":"a"}"#);
+        let err = Valid::<NewUser>::from_request(&bad).await.unwrap_err();
+        assert_eq!(err.status_code(), 422);
+    }
+}
+```
+
+- [ ] **Step 2: Add a test-only Context constructor if one does not exist**
+
+`Context::from_request_for_test` is used by the tests. If `ultimo/src/context.rs` has no equivalent public/`pub(crate)` test constructor, add one next to the existing constructors:
+
+```rust
+    /// Build a Context wrapping `req` with no DB, for tests.
+    #[cfg(test)]
+    pub(crate) fn from_request_for_test(req: Request) -> Self { /* mirror the fields set by the real constructor, DB = None */ }
+```
+
+Match the real constructor's field initialization (see `context.rs:252` area); set any store/state fields to their empty defaults and the database to `None`.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p ultimo --lib extract::`
+Expected: FAIL — `Json`/`Query`/`Valid` not defined.
+
+- [ ] **Step 4: Implement the extractors**
+
+Add to `ultimo/src/extract.rs` (above the tests):
+
+```rust
+/// Extracts and deserializes the JSON request body.
+pub struct Json<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Send> FromRequest for Json<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        ctx.req.json::<T>().await.map(Json)
+    }
+}
+
+/// Extracts and deserializes typed query-string parameters.
+pub struct Query<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Send> FromRequest for Query<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        let qs = ctx.req.query_string().unwrap_or("");
+        serde_urlencoded::from_str::<T>(qs)
+            .map(Query)
+            .map_err(|e| UltimoError::BadRequest(format!("Invalid query parameters: {e}")))
+    }
+}
+
+/// Extracts the JSON body and runs `validator` validation (422 on failure).
+pub struct Valid<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Validate + Send> FromRequest for Valid<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        let value = ctx.req.json::<T>().await?; // 400 on malformed JSON
+        crate::validate(&value)?; // UltimoError::Validation -> 422
+        Ok(Valid(value))
+    }
+}
+
+/// The full request context (identity extractor — keeps `|ctx: Context|` handlers working).
+#[async_trait::async_trait]
+impl FromRequest for Context {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        Ok(ctx.clone())
+    }
+}
+```
+
+> If `Context` is not `Clone`, derive/implement `Clone` for it in `context.rs` (its fields — `Request` with `Arc<RwLock<..>>` body, maps, optional DB handle — are all cheaply clonable; add `#[derive(Clone)]` or a manual impl). This is required for the identity extractor.
+
+- [ ] **Step 5: Wire the module + re-exports**
+
+In `ultimo/src/lib.rs`, add `pub mod extract;` and re-export the common items (mirror how other modules are surfaced, e.g. in the prelude):
+
+```rust
+pub mod extract;
+pub use extract::{FromRequest, Json, Query, Valid};
+```
+
+Add `FromRequest, Json, Query, Valid, Path` (Path lands in Task 3) to the `prelude` module as well.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `cargo test -p ultimo --lib extract::`
+Expected: PASS (query typed + 400, json, valid ok + 422).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultimo/src/extract.rs ultimo/src/lib.rs ultimo/src/context.rs
+git commit -m "feat(extract): FromRequest trait + Json/Query/Valid/Context extractors"
+```
+
+---
+
+### Task 3: `Path` extractor (single-scalar + struct)
+
+**Files:**
+- Modify: `ultimo/src/extract.rs` (add `Path` + a scalar deserializer)
+- Test: unit tests inside `ultimo/src/extract.rs`
+
+**Interfaces:**
+- Produces: `pub struct Path<T>(pub T);` with `impl FromRequest for Path<T> where T: DeserializeOwned`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `ultimo/src/extract.rs`:
+
+```rust
+    fn ctx_with_params(pairs: &[(&str, &str)]) -> Context {
+        let parts = hyper::Request::builder().uri("http://x/").body(()).unwrap().into_parts().0;
+        let params: crate::router::Params =
+            pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        let req = Request::from_parts(parts, bytes::Bytes::new(), params);
+        Context::from_request_for_test(req)
+    }
+
+    #[tokio::test]
+    async fn path_single_u32() {
+        let ctx = ctx_with_params(&[("id", "42")]);
+        let Path(id) = Path::<u32>::from_request(&ctx).await.unwrap();
+        assert_eq!(id, 42);
+    }
+
+    #[tokio::test]
+    async fn path_single_string_numeric_value_stays_string() {
+        let ctx = ctx_with_params(&[("id", "42")]);
+        let Path(id) = Path::<String>::from_request(&ctx).await.unwrap();
+        assert_eq!(id, "42"); // NOT coerced to a number
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Coord {
+        x: u32,
+        y: u32,
+    }
+
+    #[tokio::test]
+    async fn path_struct_multi_param() {
+        let ctx = ctx_with_params(&[("x", "3"), ("y", "5")]);
+        let Path(c) = Path::<Coord>::from_request(&ctx).await.unwrap();
+        assert_eq!((c.x, c.y), (3, 5));
+    }
+
+    #[tokio::test]
+    async fn path_single_bad_is_400() {
+        let ctx = ctx_with_params(&[("id", "notanumber")]);
+        let err = Path::<u32>::from_request(&ctx).await.unwrap_err();
+        assert_eq!(err.status_code(), 400);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ultimo --lib extract::tests::path`
+Expected: FAIL — `Path` not defined.
+
+- [ ] **Step 3: Implement `Path` + the scalar deserializer**
+
+Add to `ultimo/src/extract.rs`. The single-param case uses a tiny type-directed scalar deserializer that parses numbers/bools and passes strings through; the multi-param case round-trips the param map through `serde_urlencoded`.
+
+```rust
+use serde::de::{self, Deserializer, Visitor};
+use std::fmt;
+
+/// Extracts typed path parameters captured by the route (`:name` segments).
+/// A single-parameter route deserializes into a scalar (`Path<u32>`); a
+/// multi-parameter route deserializes into a struct whose fields match the
+/// parameter names (`Path<Struct>`).
+pub struct Path<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Send> FromRequest for Path<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        let params = ctx.req.params();
+        let value: T = if params.len() == 1 {
+            let raw = params.values().next().expect("len==1");
+            T::deserialize(ScalarStr(raw))
+                .map_err(|e| UltimoError::BadRequest(format!("Invalid path parameter: {e}")))?
+        } else {
+            let qs = serde_urlencoded::to_string(params)
+                .map_err(|e| UltimoError::BadRequest(format!("Invalid path parameters: {e}")))?;
+            serde_urlencoded::from_str::<T>(&qs)
+                .map_err(|e| UltimoError::BadRequest(format!("Invalid path parameters: {e}")))?
+        };
+        Ok(Path(value))
+    }
+}
+
+/// A serde deserializer over a single string that parses numeric/bool targets
+/// but passes strings through unchanged (so `Path<String>` of "42" stays "42").
+struct ScalarStr<'a>(&'a str);
+
+#[derive(Debug)]
+struct ScalarErr(String);
+impl fmt::Display for ScalarErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(&self.0) }
+}
+impl std::error::Error for ScalarErr {}
+impl de::Error for ScalarErr {
+    fn custom<M: fmt::Display>(msg: M) -> Self { ScalarErr(msg.to_string()) }
+}
+
+macro_rules! scalar_parse {
+    ($method:ident, $visit:ident, $ty:ty) => {
+        fn $method<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+            let parsed: $ty = self.0.parse().map_err(|_| {
+                ScalarErr(format!("cannot parse '{}' as {}", self.0, stringify!($ty)))
+            })?;
+            v.$visit(parsed)
+        }
+    };
+}
+
+impl<'de> Deserializer<'de> for ScalarStr<'de> {
+    type Error = ScalarErr;
+
+    scalar_parse!(deserialize_i8, visit_i8, i8);
+    scalar_parse!(deserialize_i16, visit_i16, i16);
+    scalar_parse!(deserialize_i32, visit_i32, i32);
+    scalar_parse!(deserialize_i64, visit_i64, i64);
+    scalar_parse!(deserialize_u8, visit_u8, u8);
+    scalar_parse!(deserialize_u16, visit_u16, u16);
+    scalar_parse!(deserialize_u32, visit_u32, u32);
+    scalar_parse!(deserialize_u64, visit_u64, u64);
+    scalar_parse!(deserialize_f32, visit_f32, f32);
+    scalar_parse!(deserialize_f64, visit_f64, f64);
+    scalar_parse!(deserialize_bool, visit_bool, bool);
+
+    fn deserialize_str<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_borrowed_str(self.0)
+    }
+    fn deserialize_string<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_str(self.0)
+    }
+    fn deserialize_any<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_borrowed_str(self.0)
+    }
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self, _name: &'static str, v: V,
+    ) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_newtype_struct(self)
+    }
+
+    serde::forward_to_deserialize_any! {
+        char bytes byte_buf option unit unit_struct seq tuple tuple_struct
+        map struct enum identifier ignored_any
+    }
+}
+```
+
+> Verify the exact `serde` `Deserializer` associated items compile (this is the spike step): `cargo build -p ultimo` and fix any signature drift against the installed `serde` before running tests.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p ultimo --lib extract::tests::path`
+Expected: PASS (single u32, single String stays string, struct multi-param, bad → 400).
+
+- [ ] **Step 5: Add `Path` to the re-exports**
+
+Ensure `ultimo/src/lib.rs` re-exports and prelude include `Path` (added in Task 2 Step 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/src/extract.rs ultimo/src/lib.rs
+git commit -m "feat(extract): Path extractor (single-scalar + struct params)"
+```
+
+---
+
+### Task 4: Macro'd `IntoHandler` for arities 0..=8 + backward compat
+
+**Files:**
+- Modify: `ultimo/src/handler.rs` (replace the single `Fn(Context)` impl with a macro)
+- Test: integration test `ultimo/tests/extractors.rs`
+
+**Interfaces:**
+- Consumes: `FromRequest` (Task 2), all extractors.
+- Produces: `IntoHandler` for `Fn(T1..Tn) -> Fut` (`n = 0..=8`, each `Ti: FromRequest`, `F: Clone`), returning `Result<Response>`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `ultimo/tests/extractors.rs`:
+
+```rust
+//! Integration tests for typed handler extractors.
+//! Run with: cargo test -p ultimo --test extractors
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::Request as HyperRequest;
+use serde::Deserialize;
+use ultimo::prelude::*;
+use ultimo::extract::{Path, Query, Valid};
+
+#[derive(Deserialize)]
+struct Page {
+    page: u32,
+}
+
+#[derive(Deserialize, validator::Validate)]
+struct NewUser {
+    #[validate(length(min = 3))]
+    name: String,
+}
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/items/:id", |Path(id): Path<u32>, Query(p): Query<Page>| async move {
+        response::helpers::text(format!("id={id} page={}", p.page))
+    });
+    app.post("/users", |Valid(u): Valid<NewUser>| async move {
+        response::helpers::text(format!("created {}", u.name))
+    });
+    // Backward-compat: a Context-only handler still works.
+    app.get("/ping", |_ctx: Context| async move { response::helpers::text("pong") });
+    app
+}
+
+fn get(uri: &str) -> HyperRequest<Full<Bytes>> {
+    HyperRequest::builder().uri(uri).body(Full::new(Bytes::new())).unwrap()
+}
+
+#[tokio::test]
+async fn extracts_path_and_query() {
+    let res = app().oneshot(get("/items/7?page=3")).await;
+    assert_eq!(res.status(), 200);
+    let body = http_body_util::BodyExt::collect(res.into_body()).await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"id=7 page=3");
+}
+
+#[tokio::test]
+async fn malformed_path_is_400() {
+    let res = app().oneshot(get("/items/notanumber?page=3")).await;
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn valid_body_ok_and_422() {
+    let ok = HyperRequest::builder().method("POST").uri("/users")
+        .body(Full::new(Bytes::from_static(br#"{"name":"ada"}"#))).unwrap();
+    assert_eq!(app().oneshot(ok).await.status(), 200);
+
+    let bad = HyperRequest::builder().method("POST").uri("/users")
+        .body(Full::new(Bytes::from_static(br#"{"name":"a"}"#))).unwrap();
+    assert_eq!(app().oneshot(bad).await.status(), 422);
+}
+
+#[tokio::test]
+async fn context_handler_still_works() {
+    assert_eq!(app().oneshot(get("/ping")).await.status(), 200);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ultimo --test extractors`
+Expected: FAIL to compile — multi-parameter handlers do not implement `IntoHandler` yet.
+
+- [ ] **Step 3: Replace the handler impl with the arity macro**
+
+In `ultimo/src/handler.rs`, delete the existing `impl<F, Fut> IntoHandler for F where F: Fn(Context) -> Fut` block and replace it with a macro that generates impls for tuples of extractors:
+
+```rust
+use crate::extract::FromRequest;
+
+macro_rules! impl_into_handler {
+    ( $( $ty:ident ),* ) => {
+        impl<F, Fut, $( $ty ),*> IntoHandler for F
+        where
+            F: Fn( $( $ty ),* ) -> Fut + Clone + Send + Sync + 'static,
+            Fut: Future<Output = Result<Response>> + Send + 'static,
+            $( $ty: FromRequest + Send + 'static, )*
+        {
+            #[allow(non_snake_case, unused_variables)]
+            fn into_handler(self) -> BoxedHandler {
+                Arc::new(move |ctx: Context| {
+                    let handler = self.clone();
+                    Box::pin(async move {
+                        $( let $ty = <$ty as FromRequest>::from_request(&ctx).await?; )*
+                        handler( $( $ty ),* ).await
+                    })
+                })
+            }
+        }
+    };
+}
+
+impl_into_handler!();
+impl_into_handler!(T1);
+impl_into_handler!(T1, T2);
+impl_into_handler!(T1, T2, T3);
+impl_into_handler!(T1, T2, T3, T4);
+impl_into_handler!(T1, T2, T3, T4, T5);
+impl_into_handler!(T1, T2, T3, T4, T5, T6);
+impl_into_handler!(T1, T2, T3, T4, T5, T6, T7);
+impl_into_handler!(T1, T2, T3, T4, T5, T6, T7, T8);
+```
+
+> The arity-1 impl (`impl_into_handler!(T1)`) plus `Context: FromRequest` (Task 2) subsumes the old `Fn(Context)` impl — that is what keeps `|ctx: Context|` handlers working. The `F: Clone` bound is new (needed to move the handler into the per-request async block); ordinary closures capturing `Arc`/`Clone` state satisfy it.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p ultimo --test extractors`
+Expected: PASS (path+query, 400, 422, context-handler).
+
+- [ ] **Step 5: Confirm the whole default suite still compiles/passes**
+
+Run: `cargo test -p ultimo --lib && cargo build -p ultimo --all-targets`
+Expected: PASS — existing Context-only handlers across the codebase still compile under the new impls.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/src/handler.rs ultimo/tests/extractors.rs
+git commit -m "feat(handler): typed extractor handlers via arity macro (0..=8); keep Context handlers"
+```
+
+---
+
+### Task 5: Docs, roadmap, CI, verification gate
+
+**Files:**
+- Modify: `docs-site/docs/pages/api-reference.mdx` (document the extractors)
+- Modify: `docs-site/docs/pages/roadmap.mdx` (mark shipped)
+- Modify: `.github/workflows/ci.yml` (run the extractors integration test)
+- Modify: `CHANGELOG.md` note is handled by release-plz commits — do NOT hand-edit
+
+- [ ] **Step 1: Document extractors in the API reference**
+
+In `docs-site/docs/pages/api-reference.mdx`, add a "Typed Extractors" subsection near the handler/Context docs:
+
+````mdx
+### Typed extractors
+
+Handlers may take typed parameters instead of a raw `Context`. Each implements
+`FromRequest` and is parsed from the request automatically:
+
+```rust
+use ultimo::extract::{Path, Query, Valid};
+
+// GET /users/:id?verbose=true
+app.get("/users/:id", |Path(id): Path<u32>, Query(q): Query<Opts>| async move { /* … */ });
+
+// POST /users  — deserializes the JSON body AND validates it
+app.post("/users", |Valid(body): Valid<CreateUser>| async move { /* … */ });
+```
+
+| Extractor | Source | Failure |
+|---|---|---|
+| `Path<T>` | route `:params` (single scalar, or a struct of names) | 400 |
+| `Query<T>` | query string | 400 |
+| `Json<T>` | request body | 400 |
+| `Valid<T>` | request body + `validator` | 400 (parse) / **422** (invalid) |
+| `Context` | the whole request | — |
+
+`|ctx: Context|` handlers keep working unchanged (`Context` is itself an
+extractor). Validation failures now return **422 Unprocessable Entity**.
+````
+
+- [ ] **Step 2: Mark the roadmap item shipped**
+
+In `docs-site/docs/pages/roadmap.mdx`, change the `Typed Handler Extractors + Validation` Feature Status row from `📋 Planned | 0.7.0` to `✅ Available | 0.7.0`, and turn the matching v0.7.0 timeline bullet into a `✅` shipped line.
+
+- [ ] **Step 3: Add the integration test to CI**
+
+In `.github/workflows/ci.yml`, in the `test` job's default-feature test area, add:
+
+```yaml
+      - name: Typed extractor tests
+        run: cargo test -p ultimo --test extractors
+```
+
+- [ ] **Step 4: Run the verification gate**
+
+Run:
+```bash
+cargo fmt --all --check
+cargo clippy -p ultimo --lib --all-targets -- -D warnings
+cargo test -p ultimo --lib
+cargo test -p ultimo --test extractors
+bash scripts/check-versions.sh
+```
+Expected: all clean/pass. (`cargo fmt --all` first if needed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs-site/docs/pages/api-reference.mdx docs-site/docs/pages/roadmap.mdx .github/workflows/ci.yml
+git commit -m "docs+ci: document typed extractors, mark roadmap shipped, run extractor tests"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `FromRequest` trait + `extract.rs` (Task 2); `Path`/`Query`/`Json`/`Valid`/`Context` (Tasks 2–3); macro'd `IntoHandler` 0..=8 replacing `Fn(Context)` with `Context: FromRequest` backward-compat (Task 4); 400/422 semantics + `Validation`→422 + its test (Task 1 + Task 2 Valid); `serde_urlencoded` dep + `query_string()` (Task 1); tests unit + integration + backward-compat (Tasks 2–4); docs (Task 5). Header/IntoResponse explicitly out of scope. ✔
+- **Type consistency:** `FromRequest::from_request(ctx: &Context) -> Result<Self>` is used identically across all extractors and the macro. Extractor names `Path`/`Query`/`Json`/`Valid` match spec and re-exports. `F: Clone` bound documented as new.
+- **Risk flags:** Task 3's `ScalarStr` deserializer and Task 4's macro are the two type-heavy pieces — each has a compile-spike step and concrete TDD assertions (single `u32`, numeric-looking `String`, struct, 400/422, backward-compat) that lock behavior. `Context` must be `Clone` (Task 2 note).
+- **Edge case (documented, out of scope for v1):** a single-parameter route deserialized into a *struct* target hits the scalar branch and will error; use the bare type for single params, a struct for multiple.

--- a/docs/superpowers/specs/2026-08-06-typed-handler-extractors-design.md
+++ b/docs/superpowers/specs/2026-08-06-typed-handler-extractors-design.md
@@ -1,0 +1,144 @@
+# Typed Handler Extractors — Design
+
+**Date:** 2026-08-06
+**Status:** Approved (brainstorm), pending spec review
+**Roadmap:** 0.7 — "Typed Handler Extractors + Validation"
+
+## Goal
+
+Let route handlers declare **typed** path / query / body parameters that Ultimo
+parses (and optionally validates) automatically, returning the right HTTP error
+on bad input. This completes the type-safe story on the **input** side —
+mirroring the type-safe **output** already delivered by the generated TypeScript
+client.
+
+```rust
+// before
+app.get("/users/:id", |ctx: Context| async move {
+    let id: u32 = ctx.req.param("id")?.parse().map_err(|_| UltimoError::BadRequest("bad id".into()))?;
+    // ...
+});
+
+// after
+app.get("/users/:id", |Path(id): Path<u32>, Query(f): Query<Filter>| async move {
+    // id: u32 and f: Filter already parsed; malformed input → 400 automatically
+});
+
+app.post("/users", |Valid(body): Valid<CreateUser>| async move {
+    // body deserialized AND validated; invalid → 422 with field details
+});
+```
+
+## Enabling insight
+
+Ultimo's `Context` **already buffers and caches the request body** (`ctx.req.json()`
+/ `bytes()` are documented as callable multiple times). So every extractor can
+borrow `&Context` and read what it needs — path params, the query string, or the
+cached body — with **no body-ownership transfer**. This removes the reason axum
+splits `FromRequestParts` (non-body) from `FromRequest` (body-consuming): we need
+**one** trait.
+
+## Architecture
+
+### The `FromRequest` trait (new module `ultimo/src/extract.rs`)
+
+```rust
+#[async_trait::async_trait]
+pub trait FromRequest: Sized {
+    async fn from_request(ctx: &Context) -> Result<Self>;
+}
+```
+
+(`async-trait` is already a dependency.)
+
+### Extractors shipped in v1
+
+| Extractor | Reads from `&Context` | Failure → status |
+|---|---|---|
+| `Path<T: DeserializeOwned>` | captured route params (`:name`) | parse error → **400** |
+| `Query<T: DeserializeOwned>` | the URI query string | parse error → **400** |
+| `Json<T: DeserializeOwned>` | the cached request body | deserialize error → **400** |
+| `Valid<T: DeserializeOwned + Validate>` | the cached body (deserialize **then** `validate`) | parse → **400**, validation → **422** |
+| `Context` | itself | never |
+
+- `Query<T>` deserializes the query string with `serde_urlencoded` (coerces
+  strings into `T`'s field types).
+- `Path<T>` deserializes the captured params (a `name → string` map) into `T`
+  via a small string-coercing deserializer — supports the single-param case
+  (`Path<u32>` on a one-`:param` route) and the struct case (`Path<Struct>` whose
+  fields match the `:param` names). Exact deserializer mechanics are pinned in
+  the implementation plan (spike first, as with ts-rs).
+- **`Context` implements `FromRequest`** (returns the context), so every existing
+  `|ctx: Context| async move { … }` handler keeps compiling **unchanged** — it is
+  now simply a one-extractor handler.
+
+### `IntoHandler` for multi-parameter handlers (`ultimo/src/handler.rs`)
+
+Replace the single `impl IntoHandler for Fn(Context) -> Fut` with a macro that
+generates impls for `Fn(T1, …, Tn) -> Fut` where every `Ti: FromRequest`, for
+arities `n = 0..=8`:
+
+```rust
+// generated for each arity; each Ti extracted from &ctx in order, then the
+// handler is called. Return type stays Result<Response>.
+impl<F, Fut, T1, /* … */> IntoHandler for F
+where
+    F: Fn(T1, /* … */) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Response>> + Send + 'static,
+    T1: FromRequest + Send + 'static, /* … */
+{ /* build BoxedHandler: extract each Ti, short-circuit on Err, call self */ }
+```
+
+Different arities are distinct `Fn` traits → no coherence overlap. Because
+`Context: FromRequest`, the arity-1 impl subsumes the old `Fn(Context)` case, so
+removing the special impl is **non-breaking for users**.
+
+### Error semantics
+
+- **Syntactically malformed / undeserializable** input (bad path/query/JSON) →
+  `UltimoError::BadRequest` → **400**.
+- **Well-formed but invalid** (`Valid<T>` validation failure) →
+  `UltimoError::Validation` → **422**.
+- **Change required:** `UltimoError::Validation` currently maps to **400**
+  (`error.rs`). Flip it to **422** (Unprocessable Entity — the correct code for
+  validation failures, and what FastAPI uses). `Valid<T>` reuses the existing
+  `validate()` helper, so this makes all validation errors consistent. This is an
+  intentional, minor behavior change (existing `validate()` callers move
+  400→422); noted in the changelog. It is not an API-signature change, so
+  `semver-checks` is unaffected. The existing `error.rs` unit test asserting
+  `Validation.status_code() == 400` must be updated to `422` as part of this
+  change.
+
+## Data flow
+
+`dispatch` builds `Context` (already does), then the `BoxedHandler` (produced by
+`into_handler`) calls `Ti::from_request(&ctx).await?` for each parameter in order
+and invokes the user's async fn with the extracted values. Any extractor `Err`
+short-circuits into the standard error→response path (which now yields 400/422).
+
+## Testing
+
+- **Unit tests per extractor** (`extract.rs`): success + failure-status for
+  `Path`, `Query`, `Json`, `Valid` (including 422 on validation failure), and
+  `Context` round-trip. Build a `Context` via the existing test helpers /
+  `oneshot` seam.
+- **Integration test**: register a handler taking multiple extractors
+  (`Path` + `Query` + `Valid`) and dispatch via `Ultimo::oneshot`, asserting a
+  200 on good input, 400 on malformed, 422 on invalid.
+- **Backward-compat test**: an existing-style `|ctx: Context|` handler still
+  compiles and responds (guards the `IntoHandler` change).
+
+## Scope
+
+- **v1:** `Path`, `Query`, `Json`, `Valid` + `Context`; arities 0..=8; 400/422
+  semantics; input side only.
+- **Out of scope:** `Header<T>` typed extractor (reachable today via
+  `ctx.req.header`; add on demand); `State`/extension extractors; returning a
+  serializable value directly from handlers (`IntoResponse` sugar — a separate
+  later item); optional/`Option<T>` extractor combinators.
+
+## Dependencies
+
+- `serde_urlencoded` for `Query`/`Path` string→type coercion (small, pure Rust;
+  add as a direct dependency if not already resolvable). No feature gate — typed
+  extractors are core, not opt-in.

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -19,6 +19,7 @@ hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_urlencoded = "0.7"
 validator = { workspace = true }
 multer = { workspace = true }
 ts-rs = { workspace = true, optional = true }

--- a/ultimo/src/app.rs
+++ b/ultimo/src/app.rs
@@ -156,32 +156,56 @@ impl Ultimo {
     }
 
     /// Add a GET route
-    pub fn get(&mut self, path: &str, handler: impl IntoHandler + 'static) -> &mut Self {
+    pub fn get<Args>(
+        &mut self,
+        path: &str,
+        handler: impl IntoHandler<Args> + 'static,
+    ) -> &mut Self {
         self.add_route(Method::GET, path, handler)
     }
 
     /// Add a POST route
-    pub fn post(&mut self, path: &str, handler: impl IntoHandler + 'static) -> &mut Self {
+    pub fn post<Args>(
+        &mut self,
+        path: &str,
+        handler: impl IntoHandler<Args> + 'static,
+    ) -> &mut Self {
         self.add_route(Method::POST, path, handler)
     }
 
     /// Add a PUT route
-    pub fn put(&mut self, path: &str, handler: impl IntoHandler + 'static) -> &mut Self {
+    pub fn put<Args>(
+        &mut self,
+        path: &str,
+        handler: impl IntoHandler<Args> + 'static,
+    ) -> &mut Self {
         self.add_route(Method::PUT, path, handler)
     }
 
     /// Add a DELETE route
-    pub fn delete(&mut self, path: &str, handler: impl IntoHandler + 'static) -> &mut Self {
+    pub fn delete<Args>(
+        &mut self,
+        path: &str,
+        handler: impl IntoHandler<Args> + 'static,
+    ) -> &mut Self {
         self.add_route(Method::DELETE, path, handler)
     }
 
     /// Add a PATCH route
-    pub fn patch(&mut self, path: &str, handler: impl IntoHandler + 'static) -> &mut Self {
+    pub fn patch<Args>(
+        &mut self,
+        path: &str,
+        handler: impl IntoHandler<Args> + 'static,
+    ) -> &mut Self {
         self.add_route(Method::PATCH, path, handler)
     }
 
     /// Add an OPTIONS route
-    pub fn options(&mut self, path: &str, handler: impl IntoHandler + 'static) -> &mut Self {
+    pub fn options<Args>(
+        &mut self,
+        path: &str,
+        handler: impl IntoHandler<Args> + 'static,
+    ) -> &mut Self {
         self.add_route(Method::OPTIONS, path, handler)
     }
 
@@ -297,11 +321,11 @@ impl Ultimo {
     }
 
     /// Add a route with any method
-    fn add_route(
+    fn add_route<Args>(
         &mut self,
         method: Method,
         path: &str,
-        handler: impl IntoHandler + 'static,
+        handler: impl IntoHandler<Args> + 'static,
     ) -> &mut Self {
         let handler_id = self.handlers.len();
         self.handlers.push(handler.into_handler());

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -20,6 +20,7 @@ use tokio::sync::RwLock;
 use crate::database::Database;
 
 /// Request wraps the incoming HTTP request and provides easy access to request data
+#[derive(Clone)]
 pub struct Request {
     method: hyper::Method,
     uri: hyper::Uri,
@@ -223,6 +224,7 @@ fn parse_forwarded_for(header: &str) -> Option<IpAddr> {
 }
 
 /// Context holds request data and provides response building methods
+#[derive(Clone)]
 pub struct Context {
     pub req: Request,
     state: Arc<RwLock<HashMap<String, String>>>,

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -81,6 +81,11 @@ impl Request {
         })
     }
 
+    /// The raw query string (everything after `?`), if present.
+    pub fn query_string(&self) -> Option<&str> {
+        self.uri.query()
+    }
+
     /// Get all query parameters at once
     pub fn queries(&self) -> HashMap<String, Vec<String>> {
         let mut result: HashMap<String, Vec<String>> = HashMap::new();

--- a/ultimo/src/error.rs
+++ b/ultimo/src/error.rs
@@ -57,7 +57,7 @@ impl UltimoError {
     pub fn status_code(&self) -> u16 {
         match self {
             UltimoError::Http { status, .. } => *status,
-            UltimoError::Validation { .. } => 400,
+            UltimoError::Validation { .. } => 422,
             UltimoError::Unauthorized(_) => 401,
             UltimoError::Forbidden(_) => 403,
             UltimoError::NotFound(_) => 404,
@@ -234,7 +234,7 @@ mod tests {
             message: "Validation failed".to_string(),
             details: vec![],
         };
-        assert_eq!(err.status_code(), 400);
+        assert_eq!(err.status_code(), 422);
     }
 
     #[test]

--- a/ultimo/src/extract.rs
+++ b/ultimo/src/extract.rs
@@ -1,0 +1,134 @@
+//! Typed request extractors: implement `FromRequest` to pull typed data from a
+//! request. Handlers may take any number of these as parameters, e.g.
+//! `|Path(id): Path<u32>, Query(q): Query<Filter>| async move { … }`.
+
+use crate::context::Context;
+use crate::error::{Result, UltimoError};
+use serde::de::DeserializeOwned;
+use validator::Validate;
+
+/// A type that can be extracted from the request context.
+///
+/// Every extractor borrows `&Context`; the request body is buffered and cached,
+/// so multiple body-reading extractors on the same handler are fine.
+#[async_trait::async_trait]
+pub trait FromRequest: Sized {
+    async fn from_request(ctx: &Context) -> Result<Self>;
+}
+
+/// Extracts and deserializes the JSON request body.
+pub struct Json<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Send> FromRequest for Json<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        ctx.req.json::<T>().await.map(Json)
+    }
+}
+
+/// Extracts and deserializes typed query-string parameters.
+pub struct Query<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Send> FromRequest for Query<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        let qs = ctx.req.query_string().unwrap_or("");
+        serde_urlencoded::from_str::<T>(qs)
+            .map(Query)
+            .map_err(|e| UltimoError::BadRequest(format!("Invalid query parameters: {e}")))
+    }
+}
+
+/// Extracts the JSON body and runs `validator` validation (422 on failure).
+pub struct Valid<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Validate + Send> FromRequest for Valid<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        let value = ctx.req.json::<T>().await?; // 400 on malformed JSON
+        crate::validate(&value)?; // UltimoError::Validation -> 422
+        Ok(Valid(value))
+    }
+}
+
+/// The full request context — the identity extractor, so existing
+/// `|ctx: Context| async move { … }` handlers keep working unchanged.
+#[async_trait::async_trait]
+impl FromRequest for Context {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        Ok(ctx.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use serde::Deserialize;
+
+    fn ctx_with(query: &str, body: &[u8]) -> Context {
+        let parts = hyper::Request::builder()
+            .uri(format!("http://x/?{query}"))
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        Context::from_parts(parts, Bytes::copy_from_slice(body), Default::default())
+    }
+
+    #[derive(Deserialize)]
+    struct Filter {
+        page: u32,
+        q: String,
+    }
+
+    #[tokio::test]
+    async fn query_parses_typed_fields() {
+        let ctx = ctx_with("page=2&q=rust", b"");
+        let Query(f) = Query::<Filter>::from_request(&ctx).await.unwrap();
+        assert_eq!(f.page, 2);
+        assert_eq!(f.q, "rust");
+    }
+
+    #[tokio::test]
+    async fn query_malformed_is_400() {
+        let ctx = ctx_with("page=notanumber&q=x", b"");
+        let err = Query::<Filter>::from_request(&ctx).await.err().unwrap();
+        assert_eq!(err.status_code(), 400);
+    }
+
+    #[derive(Deserialize)]
+    struct Body {
+        name: String,
+    }
+
+    #[tokio::test]
+    async fn json_parses_body() {
+        let ctx = ctx_with("", br#"{"name":"ada"}"#);
+        let Json(b) = Json::<Body>::from_request(&ctx).await.unwrap();
+        assert_eq!(b.name, "ada");
+    }
+
+    #[derive(Deserialize, Validate)]
+    struct NewUser {
+        #[validate(length(min = 3))]
+        name: String,
+    }
+
+    #[tokio::test]
+    async fn valid_ok_and_422() {
+        let ok = ctx_with("", br#"{"name":"ada"}"#);
+        assert!(Valid::<NewUser>::from_request(&ok).await.is_ok());
+
+        let bad = ctx_with("", br#"{"name":"a"}"#);
+        let err = Valid::<NewUser>::from_request(&bad).await.err().unwrap();
+        assert_eq!(err.status_code(), 422);
+    }
+
+    #[tokio::test]
+    async fn context_identity_extractor() {
+        let ctx = ctx_with("", b"");
+        let extracted = Context::from_request(&ctx).await.unwrap();
+        assert_eq!(extracted.req.method(), &hyper::Method::GET);
+    }
+}

--- a/ultimo/src/extract.rs
+++ b/ultimo/src/extract.rs
@@ -4,7 +4,8 @@
 
 use crate::context::Context;
 use crate::error::{Result, UltimoError};
-use serde::de::DeserializeOwned;
+use serde::de::{self, DeserializeOwned, Deserializer, Visitor};
+use std::fmt;
 use validator::Validate;
 
 /// A type that can be extracted from the request context.
@@ -48,6 +49,100 @@ impl<T: DeserializeOwned + Validate + Send> FromRequest for Valid<T> {
         let value = ctx.req.json::<T>().await?; // 400 on malformed JSON
         crate::validate(&value)?; // UltimoError::Validation -> 422
         Ok(Valid(value))
+    }
+}
+
+/// Extracts typed path parameters captured by the route (`:name` segments).
+/// A single-parameter route deserializes into a scalar (`Path<u32>`); a
+/// multi-parameter route deserializes into a struct whose fields match the
+/// parameter names (`Path<Struct>`).
+pub struct Path<T>(pub T);
+
+#[async_trait::async_trait]
+impl<T: DeserializeOwned + Send> FromRequest for Path<T> {
+    async fn from_request(ctx: &Context) -> Result<Self> {
+        let params = ctx.req.params();
+        let value: T = if params.len() == 1 {
+            let raw = params.values().next().expect("len == 1");
+            T::deserialize(ScalarStr(raw))
+                .map_err(|e| UltimoError::BadRequest(format!("Invalid path parameter: {e}")))?
+        } else {
+            let qs = serde_urlencoded::to_string(params)
+                .map_err(|e| UltimoError::BadRequest(format!("Invalid path parameters: {e}")))?;
+            serde_urlencoded::from_str::<T>(&qs)
+                .map_err(|e| UltimoError::BadRequest(format!("Invalid path parameters: {e}")))?
+        };
+        Ok(Path(value))
+    }
+}
+
+/// A serde deserializer over a single string that parses numeric/bool targets
+/// but passes strings through unchanged (so `Path<String>` of "42" stays "42").
+struct ScalarStr<'a>(&'a str);
+
+#[derive(Debug)]
+struct ScalarErr(String);
+impl fmt::Display for ScalarErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for ScalarErr {}
+impl de::Error for ScalarErr {
+    fn custom<M: fmt::Display>(msg: M) -> Self {
+        ScalarErr(msg.to_string())
+    }
+}
+
+macro_rules! scalar_parse {
+    ($method:ident, $visit:ident, $ty:ty) => {
+        fn $method<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+            let parsed: $ty = self.0.parse().map_err(|_| {
+                ScalarErr(format!("cannot parse '{}' as {}", self.0, stringify!($ty)))
+            })?;
+            v.$visit(parsed)
+        }
+    };
+}
+
+impl<'de> Deserializer<'de> for ScalarStr<'de> {
+    type Error = ScalarErr;
+
+    scalar_parse!(deserialize_i8, visit_i8, i8);
+    scalar_parse!(deserialize_i16, visit_i16, i16);
+    scalar_parse!(deserialize_i32, visit_i32, i32);
+    scalar_parse!(deserialize_i64, visit_i64, i64);
+    scalar_parse!(deserialize_u8, visit_u8, u8);
+    scalar_parse!(deserialize_u16, visit_u16, u16);
+    scalar_parse!(deserialize_u32, visit_u32, u32);
+    scalar_parse!(deserialize_u64, visit_u64, u64);
+    scalar_parse!(deserialize_f32, visit_f32, f32);
+    scalar_parse!(deserialize_f64, visit_f64, f64);
+    scalar_parse!(deserialize_bool, visit_bool, bool);
+
+    fn deserialize_str<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_borrowed_str(self.0)
+    }
+    fn deserialize_string<V: Visitor<'de>>(
+        self,
+        v: V,
+    ) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_str(self.0)
+    }
+    fn deserialize_any<V: Visitor<'de>>(self, v: V) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_borrowed_str(self.0)
+    }
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        v: V,
+    ) -> std::result::Result<V::Value, Self::Error> {
+        v.visit_newtype_struct(self)
+    }
+
+    serde::forward_to_deserialize_any! {
+        char bytes byte_buf option unit unit_struct seq tuple tuple_struct
+        map struct enum identifier ignored_any
     }
 }
 
@@ -123,6 +218,54 @@ mod tests {
         let bad = ctx_with("", br#"{"name":"a"}"#);
         let err = Valid::<NewUser>::from_request(&bad).await.err().unwrap();
         assert_eq!(err.status_code(), 422);
+    }
+
+    fn ctx_with_params(pairs: &[(&str, &str)]) -> Context {
+        let parts = hyper::Request::builder()
+            .uri("http://x/")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let params: crate::router::Params = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Context::from_parts(parts, Bytes::new(), params)
+    }
+
+    #[tokio::test]
+    async fn path_single_u32() {
+        let ctx = ctx_with_params(&[("id", "42")]);
+        let Path(id) = Path::<u32>::from_request(&ctx).await.unwrap();
+        assert_eq!(id, 42);
+    }
+
+    #[tokio::test]
+    async fn path_single_string_numeric_value_stays_string() {
+        let ctx = ctx_with_params(&[("id", "42")]);
+        let Path(id) = Path::<String>::from_request(&ctx).await.unwrap();
+        assert_eq!(id, "42"); // NOT coerced to a number
+    }
+
+    #[derive(Deserialize)]
+    struct Coord {
+        x: u32,
+        y: u32,
+    }
+
+    #[tokio::test]
+    async fn path_struct_multi_param() {
+        let ctx = ctx_with_params(&[("x", "3"), ("y", "5")]);
+        let Path(c) = Path::<Coord>::from_request(&ctx).await.unwrap();
+        assert_eq!((c.x, c.y), (3, 5));
+    }
+
+    #[tokio::test]
+    async fn path_single_bad_is_400() {
+        let ctx = ctx_with_params(&[("id", "notanumber")]);
+        let err = Path::<u32>::from_request(&ctx).await.err().unwrap();
+        assert_eq!(err.status_code(), 400);
     }
 
     #[tokio::test]

--- a/ultimo/src/handler.rs
+++ b/ultimo/src/handler.rs
@@ -9,21 +9,58 @@ use std::sync::Arc;
 pub type BoxedHandler =
     Arc<dyn Fn(Context) -> Pin<Box<dyn Future<Output = Result<Response>> + Send>> + Send + Sync>;
 
-/// Trait for types that can be converted into handlers
-pub trait IntoHandler {
+/// Trait for types that can be converted into handlers.
+///
+/// `Args` is the tuple of extractor parameter types the handler takes; it lets
+/// the compiler distinguish handlers of different arities (a plain
+/// `trait IntoHandler` would leave those type parameters unconstrained and the
+/// per-arity impls overlapping). It is always inferred at the call site.
+pub trait IntoHandler<Args> {
     fn into_handler(self) -> BoxedHandler;
 }
 
-/// Implement IntoHandler for async functions with Context parameter
-impl<F, Fut> IntoHandler for F
-where
-    F: Fn(Context) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<Response>> + Send + 'static,
-{
-    fn into_handler(self) -> BoxedHandler {
-        Arc::new(move |ctx| Box::pin(self(ctx)))
-    }
+use crate::extract::FromRequest;
+
+/// Implement `IntoHandler` for async functions whose parameters are all
+/// extractors (`FromRequest`). Generated for arities 0..=8. Each parameter is
+/// extracted from the request in order; any extractor error short-circuits into
+/// the standard error → response path (e.g. 400 / 422).
+///
+/// `Context` itself implements `FromRequest`, so the arity-1 impl subsumes the
+/// previous `Fn(Context)` handler — existing `|ctx: Context|` handlers keep
+/// working. The `Clone` bound lets the handler be moved into the per-request
+/// async block; ordinary closures capturing `Arc`/`Clone` state satisfy it.
+macro_rules! impl_into_handler {
+    ( $( $ty:ident ),* ) => {
+        impl<F, Fut, $( $ty ),*> IntoHandler<( $( $ty, )* )> for F
+        where
+            F: Fn( $( $ty ),* ) -> Fut + Clone + Send + Sync + 'static,
+            Fut: Future<Output = Result<Response>> + Send + 'static,
+            $( $ty: FromRequest + Send + 'static, )*
+        {
+            #[allow(non_snake_case, unused_variables, unused_mut)]
+            fn into_handler(self) -> BoxedHandler {
+                Arc::new(move |ctx: Context| {
+                    let handler = self.clone();
+                    Box::pin(async move {
+                        $( let $ty = <$ty as FromRequest>::from_request(&ctx).await?; )*
+                        handler( $( $ty ),* ).await
+                    })
+                })
+            }
+        }
+    };
 }
+
+impl_into_handler!();
+impl_into_handler!(T1);
+impl_into_handler!(T1, T2);
+impl_into_handler!(T1, T2, T3);
+impl_into_handler!(T1, T2, T3, T4);
+impl_into_handler!(T1, T2, T3, T4, T5);
+impl_into_handler!(T1, T2, T3, T4, T5, T6);
+impl_into_handler!(T1, T2, T3, T4, T5, T6, T7);
+impl_into_handler!(T1, T2, T3, T4, T5, T6, T7, T8);
 
 #[cfg(test)]
 mod tests {

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -33,6 +33,7 @@ pub mod app;
 pub mod context;
 pub mod cookie;
 pub mod error;
+pub mod extract;
 pub mod handler;
 pub mod middleware;
 pub mod openapi;
@@ -66,6 +67,7 @@ pub(crate) mod static_files;
 pub use app::Ultimo;
 pub use context::Context;
 pub use error::{Result, UltimoError};
+pub use extract::{FromRequest, Json, Query, Valid};
 pub use rpc::{
     error_code, JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, JsonRpcRequest, JsonRpcResponse,
 };
@@ -77,6 +79,7 @@ pub mod prelude {
     pub use crate::app::Ultimo;
     pub use crate::context::Context;
     pub use crate::error::{Result, UltimoError};
+    pub use crate::extract::{FromRequest, Json, Query, Valid};
     pub use crate::middleware;
     pub use crate::rpc::{
         JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, JsonRpcRequest, JsonRpcResponse,

--- a/ultimo/src/lib.rs
+++ b/ultimo/src/lib.rs
@@ -67,7 +67,7 @@ pub(crate) mod static_files;
 pub use app::Ultimo;
 pub use context::Context;
 pub use error::{Result, UltimoError};
-pub use extract::{FromRequest, Json, Query, Valid};
+pub use extract::{FromRequest, Json, Path, Query, Valid};
 pub use rpc::{
     error_code, JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, JsonRpcRequest, JsonRpcResponse,
 };
@@ -79,7 +79,7 @@ pub mod prelude {
     pub use crate::app::Ultimo;
     pub use crate::context::Context;
     pub use crate::error::{Result, UltimoError};
-    pub use crate::extract::{FromRequest, Json, Query, Valid};
+    pub use crate::extract::{FromRequest, Json, Path, Query, Valid};
     pub use crate::middleware;
     pub use crate::rpc::{
         JsonRpcError, JsonRpcErrorResponse, JsonRpcOutput, JsonRpcRequest, JsonRpcResponse,

--- a/ultimo/tests/extractors.rs
+++ b/ultimo/tests/extractors.rs
@@ -1,0 +1,84 @@
+//! Integration tests for typed handler extractors.
+//! Run with: cargo test -p ultimo --test extractors
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::Request as HyperRequest;
+use serde::Deserialize;
+use ultimo::extract::{Path, Query, Valid};
+use ultimo::prelude::*;
+
+#[derive(Deserialize)]
+struct Page {
+    page: u32,
+}
+
+#[derive(Deserialize, validator::Validate)]
+struct NewUser {
+    #[validate(length(min = 3))]
+    name: String,
+}
+
+fn app() -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.get(
+        "/items/:id",
+        |Path(id): Path<u32>, Query(p): Query<Page>| async move {
+            ultimo::response::helpers::text(format!("id={id} page={}", p.page))
+        },
+    );
+    app.post("/users", |Valid(u): Valid<NewUser>| async move {
+        ultimo::response::helpers::text(format!("created {}", u.name))
+    });
+    // Backward-compat: a Context-only handler still works.
+    app.get("/ping", |_ctx: Context| async move {
+        ultimo::response::helpers::text("pong")
+    });
+    app
+}
+
+fn get(uri: &str) -> HyperRequest<Full<Bytes>> {
+    HyperRequest::builder()
+        .uri(uri)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn extracts_path_and_query() {
+    let res = app().oneshot(get("/items/7?page=3")).await;
+    assert_eq!(res.status(), 200);
+    let body = http_body_util::BodyExt::collect(res.into_body())
+        .await
+        .unwrap()
+        .to_bytes();
+    assert_eq!(&body[..], b"id=7 page=3");
+}
+
+#[tokio::test]
+async fn malformed_path_is_400() {
+    let res = app().oneshot(get("/items/notanumber?page=3")).await;
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn valid_body_ok_and_422() {
+    let ok = HyperRequest::builder()
+        .method("POST")
+        .uri("/users")
+        .body(Full::new(Bytes::from_static(br#"{"name":"ada"}"#)))
+        .unwrap();
+    assert_eq!(app().oneshot(ok).await.status(), 200);
+
+    let bad = HyperRequest::builder()
+        .method("POST")
+        .uri("/users")
+        .body(Full::new(Bytes::from_static(br#"{"name":"a"}"#)))
+        .unwrap();
+    assert_eq!(app().oneshot(bad).await.status(), 422);
+}
+
+#[tokio::test]
+async fn context_handler_still_works() {
+    assert_eq!(app().oneshot(get("/ping")).await.status(), 200);
+}


### PR DESCRIPTION
Typed handler extractors — the type-safe **input** side, mirroring the type-safe TS client **output**. Roadmap 0.7.

## What's added
- `FromRequest` trait (async; every extractor borrows `&Context`, enabled by the cached body — no ownership split).
- Extractors: **`Path<T>`** (single scalar or a struct of `:param` names), **`Query<T>`**, **`Json<T>`**, **`Valid<T>`** (deserialize + `validator`), and **`Context`** (identity — existing handlers unchanged).
- `IntoHandler<Args>` is now generic over the argument tuple; a macro generates impls for handlers of **0..=8** extractor params. `get/post/…` gain an inferred `<Args>` generic.
- `Path` uses a small custom `ScalarStr` deserializer for the single-param case (parses numbers/bools, keeps `Path<String>` of `"42"` a string) and `serde_urlencoded` for multi-param structs.

```rust
app.get("/users/:id", |Path(id): Path<u32>, Query(q): Query<Opts>| async move { … });
app.post("/users", |Valid(u): Valid<CreateUser>| async move { … }); // 422 if invalid
```

## Behavior change (intentional)
`UltimoError::Validation` now maps to **422 Unprocessable Entity** (was 400) — correct semantics, matches FastAPI. Not an API-signature change (semver-checks unaffected); affects all `validate()` callers. Malformed/undeserializable input stays **400**.

## Backward compatibility
`|ctx: Context|` handlers compile and behave unchanged (`Context: FromRequest`; the arity-1 impl subsumes the old `Fn(Context)` impl). Verified across the full feature surface.

## Test plan
- [x] 9 extractor unit tests (Path scalar/string/struct/400, Query typed/400, Json, Valid ok/422, Context) — 175 lib tests green
- [x] 4 integration tests via `oneshot` (path+query 200, malformed 400, valid 200/422, Context handler) — new `ultimo/tests/extractors.rs`, wired into CI
- [x] fmt + clippy (full feature surface) + version-sync clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)