### PR TITLE
feat(oidc)!: verify OIDC/JWKS (RS256/ES256) tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - name: clippy (client-gen, lib)
         run: cargo clippy -p ultimo --lib --features "client-gen" -- -D warnings
 
+      # oidc (JWKS verification via reqwest) — lib only.
+      - name: clippy (oidc, lib)
+        run: cargo clippy -p ultimo --lib --features "oidc" -- -D warnings
+
   # ── Unit + integration tests (no DB system deps) ──────────────────────
   test:
     name: test (${{ matrix.os }})
@@ -120,6 +124,12 @@ jobs:
           cargo test -p ultimo --features "api-key" --doc
           cargo test -p ultimo --features "jwt" --test authz
           cargo test -p ultimo --features "session" --doc
+
+      # OIDC/JWKS verification (RS256/ES256 against a provider's JWKS).
+      - name: OIDC/JWKS tests (oidc feature)
+        run: |
+          cargo test -p ultimo --features "oidc" --lib auth::jwks
+          cargo test -p ultimo --features "oidc" --test oidc
 
       # Static file serving + SPA fallback. Pure Rust, no system deps.
       # Tests in ultimo/tests/static_files.rs cover path traversal, ETag/304,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,8 +1184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1189,9 +1197,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1471,6 +1481,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -1783,12 +1794,14 @@ dependencies = [
  "js-sys",
  "p256",
  "p384",
+ "pem",
  "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
  "sha2",
  "signature",
+ "simple_asn1",
  "zeroize",
 ]
 
@@ -1893,6 +1906,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2085,6 +2104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2287,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2473,6 +2512,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -2705,6 +2799,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2712,6 +2808,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2719,6 +2816,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2787,6 +2885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +2941,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3079,6 +3184,18 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -3882,7 +3999,9 @@ dependencies = [
  "multer",
  "proptest",
  "r2d2",
+ "rand 0.8.6",
  "reqwest 0.12.28",
+ "rsa",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4170,6 +4289,16 @@ name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1197,11 +1217,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1211,8 +1229,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2535,14 +2556,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2565,7 +2587,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2622,6 +2644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2690,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3129,7 +3177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3140,7 +3188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Everything is opt-in (`default = []`):
 | `static-files`                                       | Static file serving + SPA fallback (`serve_static`, `serve_spa`)  |
 | `compression`                                        | Automatic gzip/brotli response compression (pure Rust, no C deps) |
 | `client-gen`                                         | Derive RPC client TypeScript types from Rust types (via `ts-rs`)  |
+| `oidc`                                               | Verify OIDC/JWKS (RS256/ES256) tokens — Clerk, Auth0, Cognito, Supabase |
 | `testing`                                            | In-process `TestClient`, assertions, fixtures                     |
 | `test-helpers`                                       | WebSocket test helpers (for integration tests)                    |
 | `sqlx-postgres` · `sqlx-mysql` · `sqlx-sqlite`       | SQLx integration per backend                                      |

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -1023,6 +1023,7 @@ All features are off by default (`default = []`).
 - `static-files` - Static file serving + SPA fallback (`serve_static`, `serve_spa`) ([Static Files](/static-files))
 - `compression` - Automatic gzip/brotli response compression (`compression()`, `Compression`) ([Compression](/middleware#compression))
 - `client-gen` - Derive RPC client TypeScript types from Rust types via `ts-rs`; `query`/`mutation` infer types from `#[derive(TS)]` structs (string-typed `query_with_types`/`mutation_with_types` remain as escape hatches)
+- `oidc` - Verify RS256/ES256 tokens against a provider's JWKS endpoint (`Jwt::jwks`, `Jwt::oidc`, `Jwt::jwks_from_set`) with fetch/cache/rotation ([JWT](/jwt))
 - `testing` - Testing utilities: `TestClient`, assertions, helpers ([Testing](/testing))
 - `test-helpers` - WebSocket test helpers (for integration tests)
 - `sqlx-postgres` / `sqlx-mysql` / `sqlx-sqlite` - SQLx integration per backend

--- a/docs-site/docs/pages/jwt.mdx
+++ b/docs-site/docs/pages/jwt.mdx
@@ -94,6 +94,47 @@ By default the middleware returns **`401 Unauthorized`** (with a
 request passes through with no claims attached, and your handler decides what to
 do when `ctx.jwt_claims()` is `None`.
 
+## OIDC providers (JWKS)
+
+Verify tokens issued by an OIDC provider (Clerk, Auth0, Cognito, Supabase, …)
+against its published **JWKS** — RS256/ES256 public keys, fetched and cached.
+Requires the `oidc` feature:
+
+```toml
+ultimo = { version = "0.7", features = ["oidc"] }
+```
+
+```rust
+// Discover the JWKS from the issuer (reads /.well-known/openid-configuration):
+app.use_middleware(
+    Jwt::oidc("https://your-tenant.auth0.com/")
+        .audience("your-api-identifier")
+        .build(),
+);
+
+// …or point directly at a JWKS URL:
+app.use_middleware(Jwt::jwks("https://example.com/.well-known/jwks.json").build());
+```
+
+Keys are fetched over HTTPS, cached per the endpoint's `Cache-Control: max-age`
+(1 hour otherwise), and refetched automatically when a token arrives with an
+unknown `kid` (key rotation). All the builder options above (`issuer`,
+`audience`, `leeway`, `from_bearer`, `from_cookie`, `optional`) apply. Only
+asymmetric algorithms are accepted on this path — `HS*`/`none` tokens are
+rejected, preventing algorithm-confusion attacks.
+
+### Issuer cookbook
+
+| Provider    | `issuer` for `Jwt::oidc(..)`                               |
+| ----------- | --------------------------------------------------------- |
+| Clerk       | `https://<subdomain>.clerk.accounts.dev`                  |
+| Auth0       | `https://<tenant>.auth0.com/`                             |
+| AWS Cognito | `https://cognito-idp.<region>.amazonaws.com/<pool-id>`    |
+| Supabase    | `https://<project>.supabase.co/auth/v1`                   |
+
+For air-gapped setups, `Jwt::jwks_from_set(set)` verifies against an in-memory
+`JwkSet` with no network access.
+
 ## Security notes
 
 - **HS256 only (today).** RS256/EdDSA (asymmetric keys) are planned. The

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -61,10 +61,6 @@ One principle throughout: a **generic capability in core**, plus **thin presets
 / adapters** and **cookbook guides** — never bundled vendor SDKs (which bloat
 dependencies and rot as each vendor's API changes).
 
-- 🔑 **Auth providers (OIDC/JWKS)** — verify RS256/ES256 JWTs against a
-  provider's JWKS endpoint (caching + key rotation, `iss`/`aud` validation),
-  with presets/guides for Clerk, Cognito, Auth0, Supabase, WorkOS, Keycloak.
-  Extends the `jwt` feature.
 - 📈 **Observability** — OpenTelemetry traces + metrics, and a Prometheus
   endpoint (built on the `tracing` already used internally).
 - 🧰 **Redis** — one integration backing sessions, the rate-limit store, and
@@ -136,7 +132,7 @@ dependencies and rot as each vendor's API changes).
 | Typed Handler Extractors + Validation                   | ✅ Available     | 0.7.0    |
 | Typed RPC Subscriptions / SSE                           | 📋 Planned       | 0.7.0    |
 | OAuth2                                                  | 📋 Planned       | 0.7.0    |
-| Auth Providers (OIDC/JWKS + presets)                    | 📋 Planned       | 0.7.0    |
+| Auth Providers (OIDC/JWKS)                              | ✅ Available     | 0.7.0    |
 | Observability (OpenTelemetry + Prometheus)              | 📋 Planned       | 0.7.0    |
 | Streaming Responses                                     | 📋 Planned       | 0.7.0    |
 | Request Timeouts + HTTP Graceful Shutdown               | 📋 Planned       | 0.7.0    |
@@ -238,8 +234,9 @@ Ultimo's two headline pillars: **secure-by-default** and **proven performance**.
 - ✅ **Typed handler extractors + validation-from-types** (type-safe input; `Path`/`Query`/`Json`/`Valid`, 400/422)
 - Typed RPC subscriptions / SSE (derived event types)
 - OAuth2 provider integration
-- **Auth providers (OIDC/JWKS)** — RS256/ES256 + remote JWKS, presets for
-  Clerk / Cognito / Auth0 / Supabase
+- ✅ **Auth providers (OIDC/JWKS)** — RS256/ES256 + remote JWKS (fetch/cache/
+  rotation), OIDC discovery, cookbook for Clerk / Cognito / Auth0 / Supabase
+  (`oidc` feature)
 - **Observability** — OpenTelemetry traces + metrics, Prometheus endpoint
 - Streaming responses
 - Request timeouts + HTTP graceful shutdown

--- a/docs/superpowers/plans/2026-08-06-oidc-jwks.md
+++ b/docs/superpowers/plans/2026-08-06-oidc-jwks.md
@@ -1,0 +1,826 @@
+# OIDC / JWKS Auth Providers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify RS256/ES256 JWTs from an OIDC provider against its remote JWKS endpoint (fetch + cache + rotation, `iss`/`aud`/`exp`), reusing the existing `jwt` middleware's claim/principal attachment.
+
+**Architecture:** `Jwt` gains a `KeySource` enum — `Static` (today's HS256, sync) vs `Jwks(JwksClient)` (async). `JwksClient` holds a **fetch closure** (reqwest for `jwks`/`oidc`; a fixed set for `jwks_from_set`/tests) plus a TTL cache, so caching/rotation are unit-testable offline. The middleware calls an async `verify_claims` that branches on the key source and then runs the existing principal/claims attach.
+
+**Tech Stack:** `jsonwebtoken` 10 (`rust_crypto`; `jwk::{Jwk,JwkSet}`, `DecodingKey::from_jwk`), `reqwest` (optional, rustls), `rsa`+`rand` (dev-only, for offline test keys).
+
+**Spec:** `docs/superpowers/specs/2026-08-06-oidc-jwks-design.md`
+
+## Global Constraints
+
+- All new code behind a new **`oidc`** Cargo feature (`= ["jwt", "dep:reqwest", "jsonwebtoken/use_pem"]`); off by default. HS256 `Jwt` behavior unchanged.
+- `reqwest` optional dep: `default-features = false, features = ["json", "rustls-tls"]` (rustls — no OpenSSL/C).
+- 100% safe Rust (`#![forbid(unsafe_code)]`).
+- All auth failures → **401** (log cause via `tracing`; never leak provider internals).
+- Additive to the public API (new `pub fn`s; `Jwt`'s fields are private) — not a SemVer break.
+
+## Facts pinned by spike (do not re-derive)
+
+- jsonwebtoken 10 requires a crypto provider; Ultimo already enables `rust_crypto`. RS256/ES256 verify via `DecodingKey::from_jwk` works under it. `use_pem` (added by the `oidc` feature) is needed for the **test** to sign RS256 via `EncodingKey::from_rsa_pem`; runtime JWKS never touches PEM.
+- Offline test recipe (verified): `RsaPrivateKey::new(&mut rng, 2048)` → `to_pkcs1_pem(LineEnding::LF)` for signing; `sk.n()`/`sk.e()` (`rsa::traits::PublicKeyParts`) → `to_bytes_be()` → `base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(..)` for the JWK `n`/`e`; assemble `{"keys":[{"kty":"RSA","use":"sig","alg":"RS256","kid":..,"n":..,"e":..}]}` → `serde_json::from_value::<JwkSet>`.
+- `base64` 0.21 is already a dep; `Engine` API: `use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};`.
+- `JwkSet::find(kid) -> Option<&Jwk>`; `decode_header(token).kid` gives the token's key id.
+
+---
+
+### Task 1: `oidc` feature, deps, and the `KeySource` refactor
+
+Add the feature/deps and refactor `Jwt` to hold a `KeySource` — a pure internal refactor that leaves HS256 behavior identical.
+
+**Files:**
+- Modify: `ultimo/Cargo.toml` (feature + optional reqwest + dev-deps)
+- Modify: `ultimo/src/auth/jwt.rs` (struct + `hs256`/`decode`/`sign`)
+
+**Interfaces:**
+- Produces: `enum KeySource { Static { encoding: Option<EncodingKey>, decoding: DecodingKey } , #[cfg(feature="oidc")] Jwks(JwksClient) }`; `Jwt { key: KeySource, validation: Validation, source: TokenSource, optional: bool }`.
+
+- [ ] **Step 1: Add feature + deps**
+
+In `ultimo/Cargo.toml`: add optional reqwest under `[dependencies]`:
+
+```toml
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+```
+
+Add the feature under `[features]`:
+
+```toml
+# OIDC / JWKS verification (RS256/ES256 against a provider's JWKS endpoint)
+oidc = ["jwt", "dep:reqwest", "jsonwebtoken/use_pem"]
+```
+
+Under `[dev-dependencies]` add the offline-key generators:
+
+```toml
+rsa = { version = "0.9", features = ["std"] }
+rand = "0.8"
+```
+
+> Note: `reqwest` is also a plain dev-dependency (default features). That's fine — feature unification only affects test builds; the `oidc` runtime dep stays rustls-only.
+
+- [ ] **Step 2: Refactor `Jwt` to a `KeySource` (no behavior change)**
+
+In `ultimo/src/auth/jwt.rs`, replace the struct's `encoding`/`decoding` fields with a `key: KeySource`, and add the enum:
+
+```rust
+enum KeySource {
+    /// HS256 / fixed symmetric key — synchronous verify; supports `sign`.
+    Static {
+        encoding: Option<EncodingKey>,
+        decoding: DecodingKey,
+    },
+    #[cfg(feature = "oidc")]
+    Jwks(JwksClient),
+}
+
+#[derive(Clone)]
+pub struct Jwt {
+    key: KeySource,
+    validation: Validation,
+    source: TokenSource,
+    optional: bool,
+}
+```
+
+`KeySource` must be `Clone` (the `Jwt: Clone` derive requires it). `EncodingKey`/`DecodingKey` are `Clone`; `JwksClient` will derive `Clone` (Task 3). Add `#[derive(Clone)]` to `KeySource`.
+
+- [ ] **Step 3: Update `hs256`, `decode`, `sign` for the enum**
+
+```rust
+    pub fn hs256(secret: impl AsRef<[u8]>) -> Self {
+        let secret = secret.as_ref();
+        Self {
+            key: KeySource::Static {
+                encoding: Some(EncodingKey::from_secret(secret)),
+                decoding: DecodingKey::from_secret(secret),
+            },
+            validation: Validation::new(Algorithm::HS256),
+            source: TokenSource::Bearer,
+            optional: false,
+        }
+    }
+
+    pub fn sign<T: Serialize>(&self, claims: &T) -> Result<String> {
+        match &self.key {
+            KeySource::Static { encoding: Some(enc), .. } => {
+                jwt_encode(&Header::new(Algorithm::HS256), claims, enc)
+                    .map_err(|e| UltimoError::Internal(format!("JWT signing failed: {e}")))
+            }
+            _ => Err(UltimoError::Internal(
+                "this Jwt cannot sign (verify-only / JWKS)".into(),
+            )),
+        }
+    }
+
+    pub fn decode<T: DeserializeOwned>(&self, token: &str) -> Result<T> {
+        match &self.key {
+            KeySource::Static { decoding, .. } => jwt_decode::<T>(token, decoding, &self.validation)
+                .map(|data| data.claims)
+                .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}"))),
+            #[cfg(feature = "oidc")]
+            KeySource::Jwks(_) => Err(UltimoError::Internal(
+                "JWKS verification is async; use the middleware or verify_claims".into(),
+            )),
+        }
+    }
+```
+
+- [ ] **Step 4: Build both ways**
+
+Run: `cargo build -p ultimo --features jwt && cargo build -p ultimo --features oidc`
+Expected: both compile. (`oidc` won't fully build until `JwksClient` exists — if the `#[cfg(feature="oidc")] Jwks(JwksClient)` variant blocks compilation, temporarily stub `pub struct JwksClient;` with `#[derive(Clone)]`; Task 3 fleshes it out. Prefer to land Task 1 + Task 3 together if the stub is awkward.)
+
+- [ ] **Step 5: Existing JWT tests still pass**
+
+Run: `cargo test -p ultimo --features jwt --lib auth::jwt && cargo test -p ultimo --features jwt --test jwt`
+Expected: PASS unchanged (HS256 behavior identical).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/Cargo.toml Cargo.lock ultimo/src/auth/jwt.rs
+git commit -m "refactor(jwt): KeySource enum + oidc feature/deps (HS256 unchanged)"
+```
+
+---
+
+### Task 2: `JwksClient` (fetch closure + TTL cache + rotation) with offline tests
+
+**Files:**
+- Create: `ultimo/src/auth/jwks.rs`
+- Modify: `ultimo/src/auth/mod.rs` (`#[cfg(feature = "oidc")] mod jwks;` + re-export)
+
+**Interfaces:**
+- Produces: `pub struct JwksClient` (`Clone`); `JwksClient::from_fetch(f)`, `JwksClient::from_set(JwkSet)`; `async fn decoding_key(&self, kid: &str) -> Result<DecodingKey>`.
+- Consumes: `jsonwebtoken::{DecodingKey, jwk::JwkSet}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ultimo/src/auth/jwks.rs` with the cache/rotation tests first (offline — a fetch closure returns a controlled set and counts calls):
+
+```rust
+//! Remote JWKS client: fetches a provider's JSON Web Key Set, caches it with a
+//! TTL, and refetches once on a cache-miss (key rotation). The fetch step is a
+//! closure so the caching logic is testable without network.
+
+use crate::error::{Result, UltimoError};
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::DecodingKey;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+type FetchFut = Pin<Box<dyn Future<Output = Result<(JwkSet, Duration)>> + Send>>;
+type FetchFn = Arc<dyn Fn() -> FetchFut + Send + Sync>;
+
+struct Cached {
+    set: JwkSet,
+    expires_at: Instant,
+}
+
+#[derive(Clone)]
+pub struct JwksClient {
+    fetch: FetchFn,
+    cache: Arc<RwLock<Option<Cached>>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+    use rsa::traits::PublicKeyParts;
+    use rsa::RsaPrivateKey;
+
+    // Build a (private PEM, JwkSet) pair for a given kid — offline test keys.
+    fn keypair(kid: &str) -> (String, JwkSet) {
+        let mut rng = rand::thread_rng();
+        let sk = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+        let pem = sk.to_pkcs1_pem(rsa::pkcs1::LineEnding::LF).unwrap().to_string();
+        let n = URL_SAFE_NO_PAD.encode(sk.n().to_bytes_be());
+        let e = URL_SAFE_NO_PAD.encode(sk.e().to_bytes_be());
+        let set = serde_json::from_value(serde_json::json!({
+            "keys": [{ "kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e }]
+        }))
+        .unwrap();
+        (pem, set)
+    }
+
+    #[tokio::test]
+    async fn from_set_serves_key_without_fetching() {
+        let (_pem, set) = keypair("k1");
+        let client = JwksClient::from_set(set);
+        assert!(client.decoding_key("k1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn unknown_kid_triggers_one_refetch_then_fails() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let (_pem, set) = keypair("k1");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let client = JwksClient::from_fetch(move || {
+            let set = set.clone();
+            calls2.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move { Ok((set, Duration::from_secs(3600))) }) as FetchFut
+        });
+        // known key: fetch once
+        assert!(client.decoding_key("k1").await.is_ok());
+        // unknown key: forces exactly one refetch, then errors
+        assert!(client.decoding_key("missing").await.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ultimo --features oidc --lib auth::jwks`
+Expected: FAIL — `from_set` / `from_fetch` / `decoding_key` not defined.
+
+- [ ] **Step 3: Implement `JwksClient`**
+
+Add to `ultimo/src/auth/jwks.rs` (above the tests):
+
+```rust
+impl JwksClient {
+    /// Construct from a raw fetch closure returning `(JwkSet, ttl)`.
+    pub fn from_fetch<F>(f: F) -> Self
+    where
+        F: Fn() -> FetchFut + Send + Sync + 'static,
+    {
+        Self {
+            fetch: Arc::new(f),
+            cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Verify against a fixed in-memory key set (offline / air-gapped / tests).
+    pub fn from_set(set: JwkSet) -> Self {
+        let client = Self::from_fetch(move || {
+            let set = set.clone();
+            Box::pin(async move { Ok((set, Duration::from_secs(31_536_000))) }) as FetchFut
+        });
+        client
+    }
+
+    /// Resolve a decoding key for `kid`, fetching/caching as needed. On a
+    /// cache-miss for `kid`, refetch exactly once (handles key rotation).
+    pub async fn decoding_key(&self, kid: &str) -> Result<DecodingKey> {
+        if let Some(key) = self.lookup_fresh(kid).await {
+            return Ok(key);
+        }
+        self.refetch().await?;
+        self.lookup_any(kid).await.ok_or_else(|| {
+            UltimoError::Unauthorized(format!("no JWKS key matches kid '{kid}'"))
+        })
+    }
+
+    /// Cache hit only if fresh (not expired) and it contains `kid`.
+    async fn lookup_fresh(&self, kid: &str) -> Option<DecodingKey> {
+        let guard = self.cache.read().await;
+        match guard.as_ref() {
+            Some(c) if c.expires_at > Instant::now() => {
+                c.set.find(kid).and_then(|jwk| DecodingKey::from_jwk(jwk).ok())
+            }
+            _ => None,
+        }
+    }
+
+    /// Look up `kid` in whatever is currently cached (post-refetch), regardless
+    /// of freshness.
+    async fn lookup_any(&self, kid: &str) -> Option<DecodingKey> {
+        let guard = self.cache.read().await;
+        guard
+            .as_ref()
+            .and_then(|c| c.set.find(kid))
+            .and_then(|jwk| DecodingKey::from_jwk(jwk).ok())
+    }
+
+    async fn refetch(&self) -> Result<()> {
+        let (set, ttl) = (self.fetch)().await?;
+        *self.cache.write().await = Some(Cached {
+            set,
+            expires_at: Instant::now() + ttl,
+        });
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: Wire the module**
+
+In `ultimo/src/auth/mod.rs`:
+
+```rust
+#[cfg(feature = "oidc")]
+pub mod jwks;
+#[cfg(feature = "oidc")]
+pub use jwks::JwksClient;
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p ultimo --features oidc --lib auth::jwks`
+Expected: PASS (from_set serves a key; unknown-kid refetches exactly once then errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/src/auth/jwks.rs ultimo/src/auth/mod.rs
+git commit -m "feat(oidc): JwksClient with fetch-closure + TTL cache + rotation"
+```
+
+---
+
+### Task 3: `Jwt::jwks_from_set` + async `verify_claims` + middleware wiring
+
+Verify RS256 end-to-end via the middleware, offline.
+
+**Files:**
+- Modify: `ultimo/src/auth/jwt.rs` (constructors, `verify_claims`, `build`)
+- Test: `ultimo/tests/oidc.rs`
+
+**Interfaces:**
+- Consumes: `JwksClient` (Task 2).
+- Produces: `Jwt::jwks_from_set(JwkSet) -> Self`; `async fn verify_claims(&self, token: &str) -> Result<serde_json::Value>`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `ultimo/tests/oidc.rs`:
+
+```rust
+//! Integration tests for OIDC/JWKS verification (offline — keys are generated
+//! in-test and injected via `Jwt::jwks_from_set`).
+//! Run with: cargo test -p ultimo --features oidc --test oidc
+
+#![cfg(feature = "oidc")]
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use bytes::Bytes;
+use http_body_util::Full;
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::traits::PublicKeyParts;
+use rsa::RsaPrivateKey;
+use serde::Serialize;
+use ultimo::auth::jwt::Jwt;
+use ultimo::prelude::*;
+
+#[derive(Serialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+    iss: String,
+    aud: String,
+}
+
+struct Signer {
+    pem: String,
+    set: JwkSet,
+    kid: String,
+}
+
+fn signer(kid: &str) -> Signer {
+    let mut rng = rand::thread_rng();
+    let sk = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+    let pem = sk.to_pkcs1_pem(rsa::pkcs1::LineEnding::LF).unwrap().to_string();
+    let n = URL_SAFE_NO_PAD.encode(sk.n().to_bytes_be());
+    let e = URL_SAFE_NO_PAD.encode(sk.e().to_bytes_be());
+    let set = serde_json::from_value(serde_json::json!({
+        "keys": [{ "kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e }]
+    }))
+    .unwrap();
+    Signer { pem, set, kid: kid.to_string() }
+}
+
+impl Signer {
+    fn token(&self, claims: &Claims) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(self.kid.clone());
+        let enc = EncodingKey::from_rsa_pem(self.pem.as_bytes()).unwrap();
+        encode(&header, claims, &enc).unwrap()
+    }
+}
+
+fn app(set: JwkSet) -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(
+        Jwt::jwks_from_set(set)
+            .issuer("https://issuer.example")
+            .audience("my-api")
+            .build(),
+    );
+    app.get("/me", |ctx: Context| async move {
+        match ctx.jwt_claims().await {
+            Some(_) => response::helpers::text("ok"),
+            None => response::helpers::text("anon"),
+        }
+    });
+    app
+}
+
+fn bearer(token: &str) -> hyper::Request<Full<Bytes>> {
+    hyper::Request::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+fn good_claims() -> Claims {
+    Claims { sub: "u1".into(), exp: 4102444800, iss: "https://issuer.example".into(), aud: "my-api".into() }
+}
+
+#[tokio::test]
+async fn valid_rs256_token_is_accepted() {
+    let s = signer("k1");
+    let token = s.token(&good_claims());
+    let res = app(s.set).oneshot(bearer(&token)).await;
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn token_signed_by_unknown_key_is_401() {
+    let real = signer("k1");
+    let attacker = signer("k2"); // different key + kid
+    let token = attacker.token(&good_claims());
+    let res = app(real.set).oneshot(bearer(&token)).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn wrong_audience_is_401() {
+    let s = signer("k1");
+    let mut c = good_claims();
+    c.aud = "other-api".into();
+    let token = s.token(&c);
+    let res = app(s.set).oneshot(bearer(&token)).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn missing_token_is_401() {
+    let s = signer("k1");
+    let res = app(s.set)
+        .oneshot(hyper::Request::builder().uri("/me").body(Full::new(Bytes::new())).unwrap())
+        .await;
+    assert_eq!(res.status(), 401);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ultimo --features oidc --test oidc`
+Expected: FAIL to compile — `Jwt::jwks_from_set` doesn't exist.
+
+- [ ] **Step 3: Add `jwks_from_set` + a shared jwks builder helper**
+
+In `ultimo/src/auth/jwt.rs`, add (behind `#[cfg(feature = "oidc")]`), plus `use crate::auth::jwks::JwksClient;` and `use jsonwebtoken::{decode_header, jwk::JwkSet};`:
+
+```rust
+    /// Verify against a fixed in-memory JWKS (offline / air-gapped / tests).
+    #[cfg(feature = "oidc")]
+    pub fn jwks_from_set(set: JwkSet) -> Self {
+        Self::from_jwks_client(JwksClient::from_set(set))
+    }
+
+    #[cfg(feature = "oidc")]
+    fn from_jwks_client(client: JwksClient) -> Self {
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.algorithms = vec![
+            Algorithm::RS256,
+            Algorithm::RS384,
+            Algorithm::RS512,
+            Algorithm::ES256,
+            Algorithm::ES384,
+        ];
+        Self {
+            key: KeySource::Jwks(client),
+            validation,
+            source: TokenSource::Bearer,
+            optional: false,
+        }
+    }
+```
+
+- [ ] **Step 4: Add async `verify_claims` and call it from the middleware**
+
+Add the async verifier:
+
+```rust
+    /// Verify a token and return its claims as JSON, handling both the static
+    /// (sync) and JWKS (async fetch) key sources.
+    async fn verify_claims(&self, token: &str) -> Result<serde_json::Value> {
+        match &self.key {
+            KeySource::Static { decoding, .. } => {
+                jwt_decode::<serde_json::Value>(token, decoding, &self.validation)
+                    .map(|d| d.claims)
+                    .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+            }
+            #[cfg(feature = "oidc")]
+            KeySource::Jwks(client) => {
+                let kid = decode_header(token)
+                    .ok()
+                    .and_then(|h| h.kid)
+                    .ok_or_else(|| UltimoError::Unauthorized("JWT missing 'kid'".into()))?;
+                let key = client.decoding_key(&kid).await?;
+                jwt_decode::<serde_json::Value>(token, &key, &self.validation)
+                    .map(|d| d.claims)
+                    .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+            }
+        }
+    }
+```
+
+In `build()`, replace `match cfg.decode::<serde_json::Value>(&token)` with an async call:
+
+```rust
+                match extract_token(&cfg, &ctx) {
+                    Some(token) => match cfg.verify_claims(&token).await {
+                        Ok(claims) => {
+                            let principal = crate::auth::Principal {
+                                id: claims.get("sub").and_then(|v| v.as_str()).map(String::from),
+                                scopes: extract_scopes(&claims),
+                            };
+                            ctx.set_jwt_claims(claims).await;
+                            ctx.set_principal(principal).await;
+                            next(ctx).await
+                        }
+                        Err(_) if cfg.optional => next(ctx).await,
+                        Err(_) => Ok(unauthorized()),
+                    },
+                    None if cfg.optional => next(ctx).await,
+                    None => Ok(unauthorized()),
+                }
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p ultimo --features oidc --test oidc`
+Expected: PASS (valid accepted; unknown key, wrong aud, missing token → 401).
+
+- [ ] **Step 6: Confirm HS256 middleware still works**
+
+Run: `cargo test -p ultimo --features jwt --test jwt && cargo test -p ultimo --features jwt --lib auth::jwt`
+Expected: PASS (static path unchanged; `verify_claims` static arm mirrors the old `decode`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultimo/src/auth/jwt.rs ultimo/tests/oidc.rs
+git commit -m "feat(oidc): jwks_from_set + async verify_claims + middleware wiring"
+```
+
+---
+
+### Task 4: Remote fetch — `Jwt::jwks(url)` and `Jwt::oidc(issuer)`
+
+Wire real HTTP fetch + discovery into the fetch closure.
+
+**Files:**
+- Modify: `ultimo/src/auth/jwks.rs` (reqwest fetchers)
+- Modify: `ultimo/src/auth/jwt.rs` (`jwks`/`oidc` constructors)
+
+**Interfaces:**
+- Produces: `JwksClient::from_url(String)`, `JwksClient::from_issuer(String)`; `Jwt::jwks(url)`, `Jwt::oidc(issuer)`.
+
+- [ ] **Step 1: Add the reqwest-backed constructors to `JwksClient`**
+
+In `ultimo/src/auth/jwks.rs`:
+
+```rust
+/// Parse `max-age` (seconds) from a Cache-Control header value.
+fn max_age(cache_control: Option<&str>) -> Option<Duration> {
+    let cc = cache_control?;
+    cc.split(',')
+        .filter_map(|d| d.trim().strip_prefix("max-age="))
+        .find_map(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+impl JwksClient {
+    /// Fetch from a known JWKS URL.
+    pub fn from_url(url: String) -> Self {
+        let http = reqwest::Client::new();
+        Self::from_fetch(move || {
+            let (http, url) = (http.clone(), url.clone());
+            Box::pin(async move { fetch_jwks(&http, &url).await }) as FetchFut
+        })
+    }
+
+    /// Discover the JWKS URL from an OIDC issuer, then fetch it.
+    pub fn from_issuer(issuer: String) -> Self {
+        let http = reqwest::Client::new();
+        Self::from_fetch(move || {
+            let (http, issuer) = (http.clone(), issuer.clone());
+            Box::pin(async move {
+                let disco = format!(
+                    "{}/.well-known/openid-configuration",
+                    issuer.trim_end_matches('/')
+                );
+                #[derive(serde::Deserialize)]
+                struct Disco {
+                    jwks_uri: String,
+                }
+                let cfg: Disco = http
+                    .get(&disco)
+                    .send()
+                    .await
+                    .and_then(|r| r.error_for_status())
+                    .map_err(|e| UltimoError::Unauthorized(format!("OIDC discovery failed: {e}")))?
+                    .json()
+                    .await
+                    .map_err(|e| UltimoError::Unauthorized(format!("OIDC discovery parse: {e}")))?;
+                fetch_jwks(&http, &cfg.jwks_uri).await
+            }) as FetchFut
+        })
+    }
+}
+
+async fn fetch_jwks(http: &reqwest::Client, url: &str) -> Result<(JwkSet, Duration)> {
+    let resp = http
+        .get(url)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+        .map_err(|e| UltimoError::Unauthorized(format!("JWKS fetch failed: {e}")))?;
+    let ttl = max_age(
+        resp.headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok()),
+    )
+    .unwrap_or(Duration::from_secs(3600));
+    let set: JwkSet = resp
+        .json()
+        .await
+        .map_err(|e| UltimoError::Unauthorized(format!("JWKS parse failed: {e}")))?;
+    Ok((set, ttl))
+}
+```
+
+- [ ] **Step 2: Add the `Jwt` constructors**
+
+In `ultimo/src/auth/jwt.rs`:
+
+```rust
+    /// Verify against a provider's JWKS endpoint (RS256/ES256, cached + rotated).
+    #[cfg(feature = "oidc")]
+    pub fn jwks(jwks_url: impl Into<String>) -> Self {
+        Self::from_jwks_client(JwksClient::from_url(jwks_url.into()))
+    }
+
+    /// Verify against a provider discovered from its OIDC issuer
+    /// (`{issuer}/.well-known/openid-configuration` -> `jwks_uri`).
+    #[cfg(feature = "oidc")]
+    pub fn oidc(issuer: impl Into<String>) -> Self {
+        Self::from_jwks_client(JwksClient::from_issuer(issuer.into()))
+    }
+```
+
+- [ ] **Step 3: Add a unit test for `max_age` parsing**
+
+In `ultimo/src/auth/jwks.rs` tests module:
+
+```rust
+    #[test]
+    fn max_age_parsing() {
+        assert_eq!(super::max_age(Some("public, max-age=600")), Some(Duration::from_secs(600)));
+        assert_eq!(super::max_age(Some("no-store")), None);
+        assert_eq!(super::max_age(None), None);
+    }
+```
+
+- [ ] **Step 4: Build + test (offline suite unaffected; constructors compile)**
+
+Run: `cargo build -p ultimo --features oidc && cargo test -p ultimo --features oidc --lib auth::jwks`
+Expected: PASS. (`jwks`/`oidc` do real network only when a token is verified; the offline tests don't exercise them. A live smoke test is out of scope for CI.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/src/auth/jwks.rs ultimo/src/auth/jwt.rs
+git commit -m "feat(oidc): Jwt::jwks(url) + Jwt::oidc(issuer) with discovery + cache-control TTL"
+```
+
+---
+
+### Task 5: Docs, roadmap, CI, verification gate
+
+**Files:**
+- Modify: `docs-site/docs/pages/jwt.mdx` (OIDC/JWKS section + provider cookbook)
+- Modify: `docs-site/docs/pages/roadmap.mdx`
+- Modify: `docs-site/docs/pages/api-reference.mdx` (feature list + constructors)
+- Modify: `README.md` (feature flags table)
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Document OIDC/JWKS + provider cookbook**
+
+In `docs-site/docs/pages/jwt.mdx`, add a section:
+
+````mdx
+## OIDC providers (JWKS)
+
+Verify tokens from an OIDC provider (Clerk, Auth0, Cognito, Supabase, …) against
+its JWKS endpoint. Requires the `oidc` feature.
+
+```toml
+ultimo = { version = "0.7", features = ["oidc"] }
+```
+
+```rust
+// Discover the JWKS from the issuer:
+app.use_middleware(Jwt::oidc("https://your-tenant.auth0.com/").audience("your-api").build());
+
+// Or point directly at a JWKS URL:
+app.use_middleware(Jwt::jwks("https://example.com/.well-known/jwks.json").build());
+```
+
+RS256/ES256 tokens are verified against the provider's public keys (fetched,
+cached per `Cache-Control`, and refetched on key rotation). Set `.issuer(..)` /
+`.audience(..)` to enforce those claims.
+
+### Issuer cookbook
+
+| Provider | `issuer` for `Jwt::oidc(..)` |
+|---|---|
+| Clerk | `https://<subdomain>.clerk.accounts.dev` |
+| Auth0 | `https://<tenant>.auth0.com/` |
+| AWS Cognito | `https://cognito-idp.<region>.amazonaws.com/<pool-id>` |
+| Supabase | `https://<project>.supabase.co/auth/v1` |
+
+For air-gapped setups, `Jwt::jwks_from_set(set)` verifies against an in-memory
+`JwkSet` with no network access.
+````
+
+- [ ] **Step 2: Update the API reference + README feature tables**
+
+In `docs-site/docs/pages/api-reference.mdx` Available Features list, add:
+
+```
+- `oidc` - Verify RS256/ES256 tokens against a provider's JWKS endpoint (`Jwt::jwks`, `Jwt::oidc`, `Jwt::jwks_from_set`) ([JWT](/jwt))
+```
+
+In `README.md` feature-flags table, add a row:
+
+```
+| `oidc`                                               | Verify OIDC/JWKS (RS256/ES256) tokens — Clerk, Auth0, Cognito, Supabase |
+```
+
+- [ ] **Step 3: Mark the roadmap shipped**
+
+In `docs-site/docs/pages/roadmap.mdx`, change `Auth Providers (OIDC/JWKS + presets)` from `📋 Planned | 0.7.0` to `✅ Available | 0.7.0`, and turn the matching v0.7.0 timeline bullet into a `✅` line.
+
+- [ ] **Step 4: Add the oidc tests to CI**
+
+In `.github/workflows/ci.yml`, in the `test` job, add:
+
+```yaml
+      - name: OIDC/JWKS tests (oidc feature)
+        run: |
+          cargo test -p ultimo --features "oidc" --lib auth::jwks
+          cargo test -p ultimo --features "oidc" --test oidc
+```
+
+And in the lint job, add an oidc clippy line near the other feature clippy runs:
+
+```yaml
+      - name: clippy (oidc, lib)
+        run: cargo clippy -p ultimo --lib --features "oidc" -- -D warnings
+```
+
+- [ ] **Step 5: Verification gate**
+
+Run:
+```bash
+cargo fmt --all --check
+cargo clippy -p ultimo --lib --features "oidc" -- -D warnings
+cargo test -p ultimo --features "oidc" --lib auth::jwks
+cargo test -p ultimo --features "oidc" --test oidc
+cargo test -p ultimo --features "jwt" --test jwt
+bash scripts/check-versions.sh
+```
+Expected: all clean/pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs-site/docs/pages/jwt.mdx docs-site/docs/pages/api-reference.mdx docs-site/docs/pages/roadmap.mdx README.md .github/workflows/ci.yml
+git commit -m "docs+ci: OIDC/JWKS docs + provider cookbook, roadmap, CI"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `oidc` feature + optional reqwest/rustls (Task 1); `KeySource` refactor (Task 1); `JwksClient` fetch+cache+rotation (Task 2); `jwks_from_set` + async verify + middleware reuse of principal/claims attach (Task 3); `Jwt::jwks`/`oidc` + discovery + `Cache-Control` TTL (Task 4); offline RSA test recipe + 401 cases (Tasks 2–3); cookbook + roadmap + feature tables + CI (Task 5). Verify-only RS256/ES256; OAuth2 flows out of scope. ✔
+- **Type consistency:** `JwksClient::{from_fetch, from_set, from_url, from_issuer, decoding_key}` and `Jwt::{jwks, oidc, jwks_from_set, from_jwks_client, verify_claims}` are named identically across tasks. `KeySource` variant shapes match between Task 1 and Task 3.
+- **Risk flags:** the `#[cfg(feature="oidc")] Jwks(JwksClient)` variant means Task 1 and Task 3 are tightly coupled — land them together if the Task-1 stub is awkward (noted in Task 1 Step 4). Real network fetch/discovery (Task 4) is not exercised in CI; the offline `jwks_from_set` path is the tested core, and `max_age` parsing is unit-tested.
+- **Additive API:** new `pub fn`s only; `Jwt` fields are private → no SemVer break (unlike the extractors change), so `semver-checks` should pass without a forced bump.

--- a/docs/superpowers/specs/2026-08-06-oidc-jwks-design.md
+++ b/docs/superpowers/specs/2026-08-06-oidc-jwks-design.md
@@ -1,0 +1,135 @@
+# OIDC / JWKS Auth Providers — Design
+
+**Date:** 2026-08-06
+**Status:** Approved (brainstorm), pending spec review
+**Roadmap:** 0.7 — "Auth Providers (OIDC/JWKS + presets)"
+**Builds on:** the `jwt` feature (currently HS256-only)
+
+## Goal
+
+Verify **RS256/ES256** JWTs issued by an OIDC provider against its **remote JWKS
+endpoint** (fetch + cache + key rotation, validating `iss`/`aud`/`exp`), so
+Ultimo apps can accept tokens from Clerk, Auth0, Cognito, Supabase, and any other
+standard OIDC provider — not just the symmetric HS256 tokens the framework signs
+itself.
+
+## Verification flow
+
+1. Read the token's JOSE header (`jsonwebtoken::decode_header`) → `kid`.
+2. Look up the key in the cached `JwkSet` (`JwkSet::find(kid)`).
+3. Build a `DecodingKey` from the JWK (`DecodingKey::from_jwk` — no manual
+   RSA/EC component handling).
+4. `jsonwebtoken::decode::<Claims>` with a `Validation` accepting the asymmetric
+   algorithms and enforcing `iss`/`aud`/`exp`.
+5. If the `kid` is absent from the cache, refetch the JWKS once and retry
+   (handles provider key rotation), then fail if still missing.
+
+## Architecture
+
+### Extend `Jwt` with a key source (Approach A)
+
+`Jwt` currently holds a single `DecodingKey` + `Validation` (+ an `EncodingKey`
+for `sign`). Introduce a key-source enum so the same builder serves both the
+symmetric and JWKS cases:
+
+```rust
+enum KeySource {
+    /// HS256 / fixed key — synchronous verify; supports `sign`.
+    Static { encoding: Option<EncodingKey>, decoding: DecodingKey },
+    /// Remote JWKS — asynchronous verify; verify-only.
+    #[cfg(feature = "oidc")]
+    Jwks(JwksClient),
+}
+```
+
+- All existing builder options carry over unchanged: `issuer`, `audience`,
+  `leeway`, `from_bearer`, `from_cookie`, `optional`.
+- `sign()` stays available only for the `Static` (HS256) path; JWKS is
+  verify-only (asymmetric public keys).
+- The existing `hs256(secret)` constructor produces `KeySource::Static`.
+
+New constructors (behind `oidc`):
+
+```rust
+// Verify against a known JWKS endpoint.
+Jwt::jwks(jwks_url: impl Into<String>) -> Self;
+// Verify against a provider discovered from its issuer
+// ({issuer}/.well-known/openid-configuration -> jwks_uri).
+Jwt::oidc(issuer: impl Into<String>) -> Self;
+// Offline / air-gapped / tests: verify against an in-memory key set.
+Jwt::jwks_from_set(keys: jsonwebtoken::jwk::JwkSet) -> Self;
+```
+
+### `JwksClient` (new, behind `oidc`)
+
+```rust
+pub struct JwksClient {
+    source: JwksSource,               // Url(String) | Discover(issuer String)
+    http: reqwest::Client,
+    cache: Arc<RwLock<Option<CachedJwks>>>,   // set + expiry
+}
+struct CachedJwks { set: JwkSet, expires_at: Instant }
+```
+
+- `async fn decoding_key(&self, kid: &str) -> Result<(DecodingKey, Algorithm)>`:
+  serve from cache when fresh and the `kid` is present; otherwise resolve the
+  `jwks_uri` (discovery on first use if `source` is an issuer), fetch the JWKS,
+  update the cache, and look up the `kid`. One forced refetch on cache-miss
+  covers rotation.
+- **Cache TTL:** honor the JWKS response `Cache-Control: max-age` when present;
+  otherwise default to 1 hour. `jwks_from_set` seeds the cache with a far-future
+  expiry so it never fetches.
+- The verify path in the middleware is async for the `Jwks` source; the `Static`
+  source keeps the existing synchronous `decode`.
+
+### Packaging
+
+- New feature: `oidc = ["jwt", "dep:reqwest"]`, off by default.
+- `reqwest` added as an **optional** dependency with
+  `default-features = false, features = ["json", "rustls-tls"]` — rustls (pure
+  Rust), no OpenSSL/native-tls C dependency, consistent with the crate's ethos.
+  (`reqwest` is already a dev-dependency; this promotes it to an optional
+  runtime dep.)
+- `jsonwebtoken`'s JWK support (`jwk::{Jwk, JwkSet}`, `DecodingKey::from_jwk`) is
+  available in the pinned 10.4 — no extra jsonwebtoken feature needed.
+
+## Providers
+
+OIDC discovery covers Clerk / Auth0 / Cognito / Supabase generically (all serve
+`.well-known/openid-configuration`), so v1 ships **discovery + explicit
+`jwks(url)`** plus a **cookbook** documenting each provider's `issuer` — not four
+coded presets (they would be one-line issuer strings, better as docs).
+
+Cookbook issuer forms (docs): Clerk `https://<subdomain>.clerk.accounts.dev`,
+Auth0 `https://<tenant>.auth0.com/`, Cognito
+`https://cognito-idp.<region>.amazonaws.com/<pool-id>`, Supabase
+`https://<project>.supabase.co/auth/v1`.
+
+## Error handling
+
+- Missing/invalid token (when not `optional`) → **401 Unauthorized**.
+- JWKS fetch/discovery failure, or `kid` not found after refetch, or unsupported
+  algorithm → **401** (log the cause via `tracing`; never leak provider internals
+  to the client).
+- `iss`/`aud`/`exp` mismatch → **401**.
+
+## Testing
+
+- **No network in tests.** A test generates an RSA keypair, builds a `JwkSet`
+  from the public key (with a `kid`), signs a token with the private key, and
+  constructs the verifier via `Jwt::jwks_from_set(set)`. Cases: valid token
+  accepted + claims attached; wrong `kid` → 401; expired → 401; bad `aud`/`iss`
+  → 401; unknown key → 401.
+- An integration test dispatches through the middleware via `Ultimo::oneshot`
+  with a `jwks_from_set` verifier and asserts a guarded route returns 200 for a
+  good token and 401 otherwise.
+- `jwks_from_set` doubles as a real offline/air-gapped feature, not just a test
+  seam.
+
+## Scope
+
+- **v1:** RS256/ES256 (+ RS384/512, ES384) verification via remote JWKS,
+  OIDC discovery, cache + rotation, `iss`/`aud`/`exp`, `jwks_from_set`, cookbook.
+- **Out of scope:** OAuth2 login/redirect/token-exchange flows; opaque-token
+  introspection; per-provider coded presets; JWE (encrypted tokens); automatic
+  scope→`Principal` mapping beyond what the existing JWT path already does.

--- a/ultimo/Cargo.toml
+++ b/ultimo/Cargo.toml
@@ -49,6 +49,9 @@ sha2 = { version = "0.10", optional = true }
 # Static file serving (optional) — pure-Rust MIME detection
 mime_guess = { version = "2", optional = true }
 
+# OIDC/JWKS auth (optional) — fetch a provider's JWKS over HTTPS (rustls, no C)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+
 # Response compression (optional) — both pure Rust, no C deps
 flate2  = { version = "1", optional = true }
 brotli  = { version = "8", optional = true }
@@ -70,6 +73,9 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
 reqwest = { version = "0.12", features = ["json"] }
+# Offline test keys for OIDC/JWKS verification (generate an RSA keypair + JWKS).
+rsa = { version = "0.9", features = ["std"] }
+rand = "0.8"
 
 [features]
 default = []
@@ -91,6 +97,9 @@ csrf = ["dep:getrandom"]
 
 # JWT authentication middleware (HS256)
 jwt = ["dep:jsonwebtoken"]
+
+# OIDC/JWKS verification (RS256/ES256 against a provider's JWKS endpoint)
+oidc = ["jwt", "dep:reqwest", "jsonwebtoken/use_pem"]
 
 # API-key authentication middleware (pluggable store, SHA-256 hashed keys)
 api-key = ["dep:sha2"]

--- a/ultimo/src/auth/jwks.rs
+++ b/ultimo/src/auth/jwks.rs
@@ -1,0 +1,220 @@
+//! Remote JWKS client: fetches a provider's JSON Web Key Set, caches it with a
+//! TTL, and refetches once on a cache-miss (key rotation). The fetch step is a
+//! closure so the caching logic is testable without network.
+
+use crate::error::{Result, UltimoError};
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::DecodingKey;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+type FetchFut = Pin<Box<dyn Future<Output = Result<(JwkSet, Duration)>> + Send>>;
+type FetchFn = Arc<dyn Fn() -> FetchFut + Send + Sync>;
+
+struct Cached {
+    set: JwkSet,
+    expires_at: Instant,
+}
+
+/// Resolves JWK decoding keys for a provider, with a TTL cache and
+/// rotation-aware refetch.
+#[derive(Clone)]
+pub struct JwksClient {
+    fetch: FetchFn,
+    cache: Arc<RwLock<Option<Cached>>>,
+}
+
+/// Parse `max-age` (seconds) from a `Cache-Control` header value.
+fn max_age(cache_control: Option<&str>) -> Option<Duration> {
+    let cc = cache_control?;
+    cc.split(',')
+        .filter_map(|d| d.trim().strip_prefix("max-age="))
+        .find_map(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+impl JwksClient {
+    /// Construct from a raw fetch closure returning `(JwkSet, ttl)`.
+    pub fn from_fetch<F>(f: F) -> Self
+    where
+        F: Fn() -> FetchFut + Send + Sync + 'static,
+    {
+        Self {
+            fetch: Arc::new(f),
+            cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Verify against a fixed in-memory key set (offline / air-gapped / tests).
+    pub fn from_set(set: JwkSet) -> Self {
+        Self::from_fetch(move || {
+            let set = set.clone();
+            Box::pin(async move { Ok((set, Duration::from_secs(31_536_000))) }) as FetchFut
+        })
+    }
+
+    /// Fetch from a known JWKS URL.
+    #[cfg(feature = "oidc")]
+    pub fn from_url(url: String) -> Self {
+        let http = reqwest::Client::new();
+        Self::from_fetch(move || {
+            let (http, url) = (http.clone(), url.clone());
+            Box::pin(async move { fetch_jwks(&http, &url).await }) as FetchFut
+        })
+    }
+
+    /// Discover the JWKS URL from an OIDC issuer, then fetch it.
+    #[cfg(feature = "oidc")]
+    pub fn from_issuer(issuer: String) -> Self {
+        let http = reqwest::Client::new();
+        Self::from_fetch(move || {
+            let (http, issuer) = (http.clone(), issuer.clone());
+            Box::pin(async move {
+                let disco = format!(
+                    "{}/.well-known/openid-configuration",
+                    issuer.trim_end_matches('/')
+                );
+                #[derive(serde::Deserialize)]
+                struct Disco {
+                    jwks_uri: String,
+                }
+                let cfg: Disco = http
+                    .get(&disco)
+                    .send()
+                    .await
+                    .and_then(|r| r.error_for_status())
+                    .map_err(|e| UltimoError::Unauthorized(format!("OIDC discovery failed: {e}")))?
+                    .json()
+                    .await
+                    .map_err(|e| UltimoError::Unauthorized(format!("OIDC discovery parse: {e}")))?;
+                fetch_jwks(&http, &cfg.jwks_uri).await
+            }) as FetchFut
+        })
+    }
+
+    /// Resolve a decoding key for `kid`, fetching/caching as needed. On a
+    /// cache-miss for `kid`, refetch exactly once (handles key rotation).
+    pub async fn decoding_key(&self, kid: &str) -> Result<DecodingKey> {
+        if let Some(key) = self.lookup_fresh(kid).await {
+            return Ok(key);
+        }
+        self.refetch().await?;
+        self.lookup_any(kid)
+            .await
+            .ok_or_else(|| UltimoError::Unauthorized(format!("no JWKS key matches kid '{kid}'")))
+    }
+
+    /// Cache hit only if fresh (not expired) and it contains `kid`.
+    async fn lookup_fresh(&self, kid: &str) -> Option<DecodingKey> {
+        let guard = self.cache.read().await;
+        match guard.as_ref() {
+            Some(c) if c.expires_at > Instant::now() => c
+                .set
+                .find(kid)
+                .and_then(|jwk| DecodingKey::from_jwk(jwk).ok()),
+            _ => None,
+        }
+    }
+
+    /// Look up `kid` in whatever is currently cached (post-refetch), regardless
+    /// of freshness.
+    async fn lookup_any(&self, kid: &str) -> Option<DecodingKey> {
+        let guard = self.cache.read().await;
+        guard
+            .as_ref()
+            .and_then(|c| c.set.find(kid))
+            .and_then(|jwk| DecodingKey::from_jwk(jwk).ok())
+    }
+
+    async fn refetch(&self) -> Result<()> {
+        let (set, ttl) = (self.fetch)().await?;
+        *self.cache.write().await = Some(Cached {
+            set,
+            expires_at: Instant::now() + ttl,
+        });
+        Ok(())
+    }
+}
+
+#[cfg(feature = "oidc")]
+async fn fetch_jwks(http: &reqwest::Client, url: &str) -> Result<(JwkSet, Duration)> {
+    let resp = http
+        .get(url)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+        .map_err(|e| UltimoError::Unauthorized(format!("JWKS fetch failed: {e}")))?;
+    let ttl = max_age(
+        resp.headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok()),
+    )
+    .unwrap_or(Duration::from_secs(3600));
+    let set: JwkSet = resp
+        .json()
+        .await
+        .map_err(|e| UltimoError::Unauthorized(format!("JWKS parse failed: {e}")))?;
+    Ok((set, ttl))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+    use rsa::traits::PublicKeyParts;
+    use rsa::RsaPrivateKey;
+
+    // Build a (private PEM, JwkSet) pair for a given kid — offline test keys.
+    fn keypair(kid: &str) -> (String, JwkSet) {
+        let mut rng = rand::thread_rng();
+        let sk = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+        let pem = sk
+            .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+            .unwrap()
+            .to_string();
+        let n = URL_SAFE_NO_PAD.encode(sk.n().to_bytes_be());
+        let e = URL_SAFE_NO_PAD.encode(sk.e().to_bytes_be());
+        let set = serde_json::from_value(serde_json::json!({
+            "keys": [{ "kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e }]
+        }))
+        .unwrap();
+        (pem, set)
+    }
+
+    #[tokio::test]
+    async fn from_set_serves_key_without_fetching() {
+        let (_pem, set) = keypair("k1");
+        let client = JwksClient::from_set(set);
+        assert!(client.decoding_key("k1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn unknown_kid_triggers_one_refetch_then_fails() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let (_pem, set) = keypair("k1");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let client = JwksClient::from_fetch(move || {
+            let set = set.clone();
+            calls2.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move { Ok((set, Duration::from_secs(3600))) }) as FetchFut
+        });
+        assert!(client.decoding_key("k1").await.is_ok());
+        assert!(client.decoding_key("missing").await.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn max_age_parsing() {
+        assert_eq!(
+            max_age(Some("public, max-age=600")),
+            Some(Duration::from_secs(600))
+        );
+        assert_eq!(max_age(Some("no-store")), None);
+        assert_eq!(max_age(None), None);
+    }
+}

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -36,10 +36,22 @@ enum TokenSource {
 /// JWT auth configuration. Verifies (`build`) and issues (`sign`) tokens using a
 /// shared HS256 secret. Secure-by-default: `exp` is validated, the algorithm is
 /// pinned to HS256, and `alg: none` / algorithm-confusion tokens are rejected.
+/// Where a `Jwt` gets its verification key.
+#[derive(Clone)]
+enum KeySource {
+    /// HS256 / fixed symmetric key — synchronous verify; supports `sign`.
+    Static {
+        encoding: Option<EncodingKey>,
+        decoding: DecodingKey,
+    },
+    /// Remote JWKS — asynchronous verify; verify-only.
+    #[cfg(feature = "oidc")]
+    Jwks(crate::auth::jwks::JwksClient),
+}
+
 #[derive(Clone)]
 pub struct Jwt {
-    encoding: EncodingKey,
-    decoding: DecodingKey,
+    key: KeySource,
     validation: Validation,
     source: TokenSource,
     /// When false (default), a missing/invalid token yields 401. When true, the
@@ -52,8 +64,10 @@ impl Jwt {
     pub fn hs256(secret: impl AsRef<[u8]>) -> Self {
         let secret = secret.as_ref();
         Self {
-            encoding: EncodingKey::from_secret(secret),
-            decoding: DecodingKey::from_secret(secret),
+            key: KeySource::Static {
+                encoding: Some(EncodingKey::from_secret(secret)),
+                decoding: DecodingKey::from_secret(secret),
+            },
             validation: Validation::new(Algorithm::HS256),
             source: TokenSource::Bearer,
             optional: false,
@@ -100,16 +114,35 @@ impl Jwt {
 
     /// Issue a signed HS256 token for the given claims (which must include `exp`).
     pub fn sign<T: Serialize>(&self, claims: &T) -> Result<String> {
-        jwt_encode(&Header::new(Algorithm::HS256), claims, &self.encoding)
-            .map_err(|e| UltimoError::Internal(format!("JWT signing failed: {e}")))
+        match &self.key {
+            KeySource::Static {
+                encoding: Some(enc),
+                ..
+            } => jwt_encode(&Header::new(Algorithm::HS256), claims, enc)
+                .map_err(|e| UltimoError::Internal(format!("JWT signing failed: {e}"))),
+            _ => Err(UltimoError::Internal(
+                "this Jwt cannot sign (verify-only / JWKS)".into(),
+            )),
+        }
     }
 
     /// Verify a token and deserialize its claims. Errors on bad signature,
     /// expired/`nbf` violations, wrong `iss`/`aud`, or `alg: none`.
+    ///
+    /// Synchronous — for the JWKS key source (which fetches keys asynchronously)
+    /// verification happens in the middleware; this returns an error.
     pub fn decode<T: DeserializeOwned>(&self, token: &str) -> Result<T> {
-        jwt_decode::<T>(token, &self.decoding, &self.validation)
-            .map(|data| data.claims)
-            .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+        match &self.key {
+            KeySource::Static { decoding, .. } => {
+                jwt_decode::<T>(token, decoding, &self.validation)
+                    .map(|data| data.claims)
+                    .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+            }
+            #[cfg(feature = "oidc")]
+            KeySource::Jwks(_) => Err(UltimoError::Internal(
+                "JWKS verification is async; use the middleware".into(),
+            )),
+        }
     }
 }
 

--- a/ultimo/src/auth/jwt.rs
+++ b/ultimo/src/auth/jwt.rs
@@ -23,6 +23,8 @@ use jsonwebtoken::{
     Validation,
 };
 use serde::{de::DeserializeOwned, Serialize};
+#[cfg(feature = "oidc")]
+use {crate::auth::jwks::JwksClient, jsonwebtoken::decode_header, jsonwebtoken::jwk::JwkSet};
 
 /// Where the middleware looks for the token on an incoming request.
 #[derive(Debug, Clone)]
@@ -144,6 +146,86 @@ impl Jwt {
             )),
         }
     }
+
+    /// Verify against a fixed in-memory JWKS (offline / air-gapped / tests).
+    #[cfg(feature = "oidc")]
+    pub fn jwks_from_set(set: JwkSet) -> Self {
+        Self::from_jwks_client(JwksClient::from_set(set))
+    }
+
+    /// Verify against a provider's JWKS endpoint (RS256/ES256, cached + rotated).
+    #[cfg(feature = "oidc")]
+    pub fn jwks(jwks_url: impl Into<String>) -> Self {
+        Self::from_jwks_client(JwksClient::from_url(jwks_url.into()))
+    }
+
+    /// Verify against a provider discovered from its OIDC issuer
+    /// (`{issuer}/.well-known/openid-configuration` -> `jwks_uri`).
+    #[cfg(feature = "oidc")]
+    pub fn oidc(issuer: impl Into<String>) -> Self {
+        Self::from_jwks_client(JwksClient::from_issuer(issuer.into()))
+    }
+
+    #[cfg(feature = "oidc")]
+    fn from_jwks_client(client: JwksClient) -> Self {
+        // The concrete algorithm is pinned per-request to the token header's
+        // (asymmetric) `alg` in `verify_claims` — a `Validation` may only list
+        // algorithms of one key family, so we can't pre-list RSA + EC together.
+        Self {
+            key: KeySource::Jwks(client),
+            validation: Validation::new(Algorithm::RS256),
+            source: TokenSource::Bearer,
+            optional: false,
+        }
+    }
+
+    /// Verify a token and return its claims as JSON, handling both the static
+    /// (sync) and JWKS (async fetch) key sources.
+    async fn verify_claims(&self, token: &str) -> Result<serde_json::Value> {
+        match &self.key {
+            KeySource::Static { decoding, .. } => {
+                jwt_decode::<serde_json::Value>(token, decoding, &self.validation)
+                    .map(|d| d.claims)
+                    .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+            }
+            #[cfg(feature = "oidc")]
+            KeySource::Jwks(client) => {
+                let header = decode_header(token)
+                    .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT header: {e}")))?;
+                // Only asymmetric algorithms are valid against JWKS public keys.
+                // Rejecting HS*/none prevents the classic algorithm-confusion
+                // attack (an attacker signing HS256 with the RSA public key).
+                if !matches!(
+                    header.alg,
+                    Algorithm::RS256
+                        | Algorithm::RS384
+                        | Algorithm::RS512
+                        | Algorithm::PS256
+                        | Algorithm::PS384
+                        | Algorithm::PS512
+                        | Algorithm::ES256
+                        | Algorithm::ES384
+                        | Algorithm::EdDSA
+                ) {
+                    return Err(UltimoError::Unauthorized(format!(
+                        "unsupported JWT algorithm for JWKS: {:?}",
+                        header.alg
+                    )));
+                }
+                let kid = header
+                    .kid
+                    .ok_or_else(|| UltimoError::Unauthorized("JWT missing 'kid'".into()))?;
+                let key = client.decoding_key(&kid).await?;
+                // Pin the validation to exactly this token's algorithm (one
+                // family), preserving iss/aud/exp/leeway from the builder.
+                let mut validation = self.validation.clone();
+                validation.algorithms = vec![header.alg];
+                jwt_decode::<serde_json::Value>(token, &key, &validation)
+                    .map(|d| d.claims)
+                    .map_err(|e| UltimoError::Unauthorized(format!("invalid JWT: {e}")))
+            }
+        }
+    }
 }
 
 use crate::Context;
@@ -190,7 +272,7 @@ impl Jwt {
             let cfg = cfg.clone();
             Box::pin(async move {
                 match extract_token(&cfg, &ctx) {
-                    Some(token) => match cfg.decode::<serde_json::Value>(&token) {
+                    Some(token) => match cfg.verify_claims(&token).await {
                         Ok(claims) => {
                             let principal = crate::auth::Principal {
                                 id: claims.get("sub").and_then(|v| v.as_str()).map(String::from),

--- a/ultimo/src/auth/mod.rs
+++ b/ultimo/src/auth/mod.rs
@@ -10,6 +10,11 @@
 #[cfg(feature = "jwt")]
 pub mod jwt;
 
+#[cfg(feature = "oidc")]
+pub mod jwks;
+#[cfg(feature = "oidc")]
+pub use jwks::JwksClient;
+
 #[cfg(feature = "api-key")]
 pub mod api_key;
 

--- a/ultimo/tests/oidc.rs
+++ b/ultimo/tests/oidc.rs
@@ -1,0 +1,135 @@
+//! Integration tests for OIDC/JWKS verification (offline — keys are generated
+//! in-test and injected via `Jwt::jwks_from_set`).
+//! Run with: cargo test -p ultimo --features oidc --test oidc
+
+#![cfg(feature = "oidc")]
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use bytes::Bytes;
+use http_body_util::Full;
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::traits::PublicKeyParts;
+use rsa::RsaPrivateKey;
+use serde::Serialize;
+use ultimo::auth::jwt::Jwt;
+use ultimo::prelude::*;
+
+#[derive(Serialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+    iss: String,
+    aud: String,
+}
+
+struct Signer {
+    pem: String,
+    set: JwkSet,
+    kid: String,
+}
+
+fn signer(kid: &str) -> Signer {
+    let mut rng = rand::thread_rng();
+    let sk = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+    let pem = sk
+        .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+        .unwrap()
+        .to_string();
+    let n = URL_SAFE_NO_PAD.encode(sk.n().to_bytes_be());
+    let e = URL_SAFE_NO_PAD.encode(sk.e().to_bytes_be());
+    let set = serde_json::from_value(serde_json::json!({
+        "keys": [{ "kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e }]
+    }))
+    .unwrap();
+    Signer {
+        pem,
+        set,
+        kid: kid.to_string(),
+    }
+}
+
+impl Signer {
+    fn token(&self, claims: &Claims) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(self.kid.clone());
+        let enc = EncodingKey::from_rsa_pem(self.pem.as_bytes()).unwrap();
+        encode(&header, claims, &enc).unwrap()
+    }
+}
+
+fn app(set: JwkSet) -> Ultimo {
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(
+        Jwt::jwks_from_set(set)
+            .issuer("https://issuer.example")
+            .audience("my-api")
+            .build(),
+    );
+    app.get("/me", |ctx: Context| async move {
+        match ctx.jwt_claims().await {
+            Some(_) => ultimo::response::helpers::text("ok"),
+            None => ultimo::response::helpers::text("anon"),
+        }
+    });
+    app
+}
+
+fn bearer(token: &str) -> hyper::Request<Full<Bytes>> {
+    hyper::Request::builder()
+        .uri("/me")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+fn good_claims() -> Claims {
+    Claims {
+        sub: "u1".into(),
+        exp: 4102444800,
+        iss: "https://issuer.example".into(),
+        aud: "my-api".into(),
+    }
+}
+
+#[tokio::test]
+async fn valid_rs256_token_is_accepted() {
+    let s = signer("k1");
+    let token = s.token(&good_claims());
+    let res = app(s.set).oneshot(bearer(&token)).await;
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn token_signed_by_unknown_key_is_401() {
+    let real = signer("k1");
+    let attacker = signer("k2"); // different key + kid
+    let token = attacker.token(&good_claims());
+    let res = app(real.set).oneshot(bearer(&token)).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn wrong_audience_is_401() {
+    let s = signer("k1");
+    let mut c = good_claims();
+    c.aud = "other-api".into();
+    let token = s.token(&c);
+    let res = app(s.set).oneshot(bearer(&token)).await;
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn missing_token_is_401() {
+    let s = signer("k1");
+    let res = app(s.set)
+        .oneshot(
+            hyper::Request::builder()
+                .uri("/me")
+                .body(Full::new(Bytes::new()))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(res.status(), 401);
+}


### PR DESCRIPTION
Adds the `oidc` feature: verify RS256/ES256 JWTs from an OIDC provider against its remote JWKS endpoint. Unlocks Clerk / Auth0 / Cognito / Supabase. Roadmap 0.7.

## What's added
- New opt-in **`oidc`** feature (`= ["jwt", "dep:reqwest", "jsonwebtoken/use_pem"]`); `reqwest` is optional + rustls-only (no C).
- `Jwt` gains a `KeySource` enum — HS256 `Static` (unchanged) vs `Jwks`. Constructors: **`Jwt::jwks(url)`**, **`Jwt::oidc(issuer)`** (OIDC discovery of `jwks_uri`), **`Jwt::jwks_from_set(set)`** (offline/air-gapped).
- `JwksClient`: fetch (reqwest) + TTL cache (honors `Cache-Control: max-age`, else 1h) + **rotation** (one refetch on unknown `kid`). Fetch is a closure, so caching/rotation are unit-tested with **zero network**.
- Async `verify_claims` pins the token's asymmetric alg per-request and **rejects `HS*`/`none`** (blocks the RSA/HMAC confusion attack); reuses the existing `iss`/`aud`/`exp` + principal/claims attach.
- Cookbook (Clerk/Auth0/Cognito/Supabase issuers) in the JWT docs — discovery covers them all, so no coded per-vendor presets.

## Backward compatibility & SemVer
Purely **additive** — new `pub fn`s; `Jwt`'s fields are private; HS256 path unchanged. So `semver-checks` should pass without a forced break (ships as a minor).

## Test plan
- [x] `auth::jwks` unit tests: `from_set` serves a key; unknown-kid refetches exactly once then 401; `max_age` parsing
- [x] `tests/oidc.rs` (offline RSA keypair → JwkSet): valid RS256 accepted; unknown key / wrong aud / missing token → 401
- [x] HS256 `jwt` tests unchanged (6 pass); 175 lib tests green
- [x] fmt + clippy (`oidc` lib) + version-sync clean; CI runs the oidc suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)