### PR TITLE
chore: release v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4028,7 +4028,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/ultimo/CHANGELOG.md
+++ b/ultimo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.7.0...ultimo-v0.8.1) - 2026-08-06
+
+### Added
+
+- *(oidc)* [**breaking**] verify OIDC/JWKS (RS256/ES256) tokens ([#169](https://github.com/ultimo-rs/ultimo/pull/169))
+
 ## [0.8.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.7.0...ultimo-v0.8.0) - 2026-08-06
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.7.0 -> 0.8.1
* `ultimo-cli`: 0.8.0 -> 0.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `ultimo`

<blockquote>

## [0.8.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.7.0...ultimo-v0.8.1) - 2026-08-06

### Added

- *(oidc)* [**breaking**] verify OIDC/JWKS (RS256/ES256) tokens ([#169](https://github.com/ultimo-rs/ultimo/pull/169))
</blockquote>

## `ultimo-cli`

<blockquote>

## [0.6.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-cli-v0.5.1...ultimo-cli-v0.6.0) - 2026-07-08

### Added

- *(cli)* implement `ultimo generate --watch` + scaffold generate-client in templates ([#155](https://github.com/ultimo-rs/ultimo/pull/155))
- *(cli)* implement `ultimo dev` hot-reload dev server ([#130](https://github.com/ultimo-rs/ultimo/pull/130))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).