### PR TITLE
feat!: streaming response bodies (UltimoBody + ctx.stream)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       # Tests in ultimo/tests/compression.rs cover gzip, brotli, skip rules,
       # Vary header, double-compress guard, and builder min_size override.
       - name: Compression tests (compression feature)
-        run: cargo test -p ultimo --features "compression" --test compression
+        run: cargo test -p ultimo --features "compression" --test compression --test streaming
 
       # TypeScript client generation (ts-rs type derivation). Covers the decl
       # collector, derived query/mutation, and the golden-file client test.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,6 +3519,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "streaming-example"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "hyper 1.10.1",
+ "tokio",
+ "ultimo",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-demo", "examples/database-sqlx", "examples/database-diesel", "examples/database-api-styles", "examples/websocket-chat", "examples/websocket-chat-react", "examples/session-auth", "examples/jwt-auth", "examples/spa-demo", "ultimo-cli", "coverage-tool"]
+members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-demo", "examples/database-sqlx", "examples/database-diesel", "examples/database-api-styles", "examples/websocket-chat", "examples/websocket-chat-react", "examples/session-auth", "examples/jwt-auth", "examples/spa-demo", "examples/streaming", "ultimo-cli", "coverage-tool"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ the framework is 100% safe Rust (`#![forbid(unsafe_code)]`).
 - 🚀 **Automatic TypeScript clients** — define your API in Rust, get a fully typed TS client generated for you.
 - 🔄 **REST + JSON-RPC 2.0 in one app** — plain HTTP routes and RPC procedures side by side, with batch requests and notifications.
 - 🔌 **WebSockets** — RFC 6455 with a built-in pub/sub system (zero extra deps).
+- 🌊 **Streaming responses** — chunked/streaming bodies via `ctx.stream(...)`.
 - 🔐 **Auth, built in** — JWT and API-key middleware plus scope-based [authorization guards](https://docs.ultimo.dev/authorization).
 - 🛡️ **Secure by default** — 100% safe Rust, secure sessions/cookies, CSRF, security-headers middleware, request body-size limits, and supply-chain CI.
 - ⚡ **Fast** — native Rust on the Hyper + Tokio core, O(1) constant-time routing, benchmarks regression-guarded in CI ([details](https://docs.ultimo.dev/performance)).

--- a/docs-site/docs/pages/api-reference.mdx
+++ b/docs-site/docs/pages/api-reference.mdx
@@ -4,6 +4,13 @@ Complete API reference for the Ultimo web framework.
 
 ## Core Types
 
+### `UltimoBody`
+
+The response body type (`type Response = hyper::Response<UltimoBody>`). Two
+variants: `Full` (buffered — the fast path, produced by `text`/`json`/`html`) and
+`Stream` (produced by `Context::stream`). `BoxError` is the streaming error type
+(`Box<dyn std::error::Error + Send + Sync>`).
+
 ### `Ultimo`
 
 The main application struct that manages routing, middleware, and server lifecycle.
@@ -200,6 +207,24 @@ Return an HTML response with `Content-Type: text/html`.
 
 ```rust
 ctx.html("<h1>Hello</h1>").await
+```
+
+##### `stream<S>(&self, body: S) -> Result<Response>`
+
+Return a chunked/streaming response body from a `Stream<Item = Result<Bytes, BoxError>>`.
+No `Content-Length` is set. Queued `header`/`status` are applied.
+
+```rust
+use hyper::body::Bytes;
+use ultimo::response::BoxError;
+
+async fn download(ctx: Context) -> Result<Response> {
+    let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![
+        Ok(Bytes::from("part-1")),
+        Ok(Bytes::from("part-2")),
+    ];
+    ctx.stream(futures_util::stream::iter(chunks)).await
+}
 ```
 
 ##### `redirect(&self, location: &str) -> Result<Response>`

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -28,7 +28,6 @@ a stable **1.0**.
 
 ### Real-time & streaming
 
-- 🌊 **Streaming responses** — large-body / chunked streaming.
 - 🗜️ **WebSocket compression** — per-message deflate (RFC 7692).
 
 ### Auth & sessions
@@ -134,7 +133,7 @@ dependencies and rot as each vendor's API changes).
 | OAuth2                                                  | 📋 Planned       | 0.7.0    |
 | Auth Providers (OIDC/JWKS)                              | ✅ Available     | 0.7.0    |
 | Observability (OpenTelemetry + Prometheus)              | 📋 Planned       | 0.7.0    |
-| Streaming Responses                                     | 📋 Planned       | 0.7.0    |
+| Streaming Responses                                     | ✅ Available     | 0.9.0    |
 | Request Timeouts + HTTP Graceful Shutdown               | 📋 Planned       | 0.7.0    |
 | Redis (sessions · cache · rate-limit)                   | 📋 Planned       | 0.8.0    |
 | WebSocket Compression                                   | 📋 Planned       | 0.8.0    |

--- a/docs-site/docs/pages/streaming.mdx
+++ b/docs-site/docs/pages/streaming.mdx
@@ -1,0 +1,60 @@
+# Streaming Responses
+
+Return a response body incrementally instead of buffering it all in memory.
+Useful for large downloads, proxied bodies, and as the foundation for
+Server-Sent Events.
+
+Streaming is always available — no Cargo feature required.
+
+## `ctx.stream(...)`
+
+`ctx.stream` takes a `Stream` of byte chunks and sends them as they arrive. The
+response is chunked (no `Content-Length`).
+
+```rust
+use hyper::body::Bytes;
+use ultimo::prelude::*;
+use ultimo::response::BoxError;
+
+async fn numbers(ctx: Context) -> Result<Response> {
+    // Any `Stream<Item = Result<Bytes, BoxError>>` works.
+    let chunks: Vec<std::result::Result<Bytes, BoxError>> =
+        (0..5).map(|n| Ok(Bytes::from(format!("line {n}\n")))).collect();
+    ctx.stream(futures_util::stream::iter(chunks)).await
+}
+```
+
+Set a content type first if you need one:
+
+```rust
+async fn csv(ctx: Context) -> Result<Response> {
+    ctx.header("Content-Type", "text/csv").await;
+    let rows: Vec<std::result::Result<Bytes, BoxError>> = vec![
+        Ok(Bytes::from("a,b,c\n")),
+        Ok(Bytes::from("1,2,3\n")),
+    ];
+    ctx.stream(futures_util::stream::iter(rows)).await
+}
+```
+
+## Errors
+
+If a stream item yields `Err(_)`, the response connection is aborted. Emit
+`Ok(_)` chunks for normal data and reserve `Err(_)` for genuine failures.
+
+## Interaction with compression
+
+The `compression` middleware **skips streaming bodies** — it never buffers a
+stream (that would defeat streaming and risk unbounded memory). Buffered
+responses (`text`/`json`/`html`) are still compressed as usual.
+
+## The body type
+
+`Response` is `hyper::Response<UltimoBody>`. `UltimoBody::Full` is the buffered
+fast path (what `text`/`json`/`html` produce); `UltimoBody::Stream` is what
+`ctx.stream` produces. You rarely construct it directly.
+
+## Full example
+
+See [`examples/streaming`](https://github.com/ultimo-rs/ultimo/tree/main/examples/streaming):
+`cargo run -p streaming-example`, then open `http://127.0.0.1:3000`.

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -92,6 +92,10 @@ export default defineConfig({
           link: "/static-files",
         },
         {
+          text: "Streaming Responses",
+          link: "/streaming",
+        },
+        {
           text: "WebSocket",
           link: "/websocket",
         },

--- a/docs/superpowers/plans/2026-08-16-streaming-responses.md
+++ b/docs/superpowers/plans/2026-08-16-streaming-responses.md
@@ -1,0 +1,826 @@
+# Streaming Responses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let handlers return chunked/streaming response bodies via `ctx.stream(...)`, replacing the hardwired `Full<Bytes>` response body with an `UltimoBody` enum that keeps a zero-boxing fast path for buffered responses.
+
+**Architecture:** `pub type Response = HyperResponse<UltimoBody>` where `UltimoBody` is a two-variant enum (`Full(Full<Bytes>)` fast-path + `Stream(BoxBody<Bytes, BoxError>)`) implementing `hyper::body::Body`. `ctx.stream(s)` wraps a `Stream<Item = Result<Bytes, BoxError>>` into the streaming variant. Compression skips streaming bodies. Buffered responses stay allocation-identical to today.
+
+**Tech Stack:** Rust, Hyper 1.0, `http_body_util` (`StreamBody`, `BodyExt::boxed`, `BoxBody`, `Full`), `futures-util` (already a runtime dep), `hyper::body::{Body, Frame, SizeHint}`.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-streaming-responses-design.md`
+
+## Deviations from the spec (intentional refinements, discovered while planning)
+
+1. **No new dependency.** `futures-util = "0.3"` is already under `[dependencies]` (`ultimo/Cargo.toml:30`). Use `futures_util::{Stream, TryStreamExt}`; the spec's "add `futures-core`" is unnecessary.
+2. **`ctx.stream` is `async fn stream<S>(&self, s: S) -> Result<Response>`** (not sync `-> Response`). This mirrors every sibling (`text`/`json`/`html`) so handler code stays uniform (`ctx.stream(s).await`), and lets it apply queued `ctx.header(...)`/`ctx.status(...)` before streaming. It is infallible in practice; the `Result` is for API symmetry.
+3. **Real blast radius is 5 files, not 9.** `websocket/connection.rs`, `websocket/pubsub.rs` matched `TrySendError::Full` (unrelated). `error.rs` matches are comments. `testing/client.rs` uses `Full<Bytes>` only on the *request* side (unchanged). Files that actually change: `response.rs`, `app.rs`, `static_files.rs`, `middleware.rs`, `websocket/upgrade.rs`.
+
+## Global Constraints
+
+- **100% safe Rust** — crate is `#![forbid(unsafe_code)]`. No `unsafe`.
+- **Public items need doc comments**; doctests must compile.
+- **Breaking change → minor bump.** `Response`'s public body type changes → **0.9.0**. Use a `feat!` commit; `semver-checks` will flag it (expected — admin-merge override at PR time).
+- **Feature gating:** the `UltimoBody` type change is core/unconditional (a type alias can't be cleanly feature-gated). `ctx.stream` is always available (only pulls the existing `futures-util`).
+- **Verification gate** (run before PR), from `.claude/skills/ship-feature`:
+  ```bash
+  cargo fmt --all --check
+  cargo clippy -p ultimo --features "websocket,test-helpers,testing,session,csrf" --all-targets -- -D warnings
+  cargo test -p ultimo --lib
+  cargo test -p ultimo --features "websocket,test-helpers,testing,session,csrf"
+  cargo test -p ultimo --doc --features "websocket,testing,session,csrf"
+  ```
+- **Never hand-edit `CHANGELOG.md`** — release-plz generates it from conventional commits.
+
+---
+
+### Task 1: Define `UltimoBody` + migrate all buffered sites (crate compiles, no behavior change)
+
+The `Response` body type is atomic — flipping the alias forces every construction site to change in the same commit. This task introduces the type and migrates all 5 files so the crate compiles and the existing suite passes unchanged. No streaming is produced yet, so behavior is identical to today.
+
+**Files:**
+- Modify: `ultimo/src/response.rs` (type + `BoxError` + `Body` impl + `full`/`empty` + `build()`)
+- Modify: `ultimo/src/app.rs:36` (WebSocket handler type)
+- Modify: `ultimo/src/static_files.rs:70,90`
+- Modify: `ultimo/src/middleware.rs:192,572,729` and compression `Full::new` sites (~858–929)
+- Modify: `ultimo/src/websocket/upgrade.rs` (return types + body construction)
+
+**Interfaces:**
+- Produces:
+  - `pub type BoxError = Box<dyn std::error::Error + Send + Sync>;`
+  - `pub enum UltimoBody { Full(http_body_util::Full<Bytes>), Stream(http_body_util::combinators::BoxBody<Bytes, BoxError>) }`
+  - `impl UltimoBody { pub fn empty() -> Self; pub fn full(bytes: impl Into<Bytes>) -> Self; }`
+  - `impl hyper::body::Body for UltimoBody { type Data = Bytes; type Error = BoxError; }`
+  - `pub type Response = hyper::Response<UltimoBody>;`
+
+- [ ] **Step 1: Write failing unit tests for the new type**
+
+Add to the `#[cfg(test)] mod tests` block in `ultimo/src/response.rs`:
+
+```rust
+    #[tokio::test]
+    async fn ultimo_body_full_round_trips() {
+        use http_body_util::BodyExt;
+        let body = UltimoBody::full("hello world");
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(&bytes[..], b"hello world");
+    }
+
+    #[tokio::test]
+    async fn ultimo_body_empty_is_zero_length() {
+        use http_body_util::BodyExt;
+        use hyper::body::Body as _;
+        let body = UltimoBody::empty();
+        assert!(body.is_end_stream());
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(bytes.len(), 0);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p ultimo --lib response:: 2>&1 | tail -20`
+Expected: FAIL — `cannot find function/type UltimoBody` (not yet defined).
+
+- [ ] **Step 3: Define `UltimoBody`, `BoxError`, the `Body` impl, and constructors**
+
+In `ultimo/src/response.rs`, replace the imports and `Response` alias (lines 6–12):
+
+```rust
+use crate::error::{Result, UltimoError};
+use http_body_util::combinators::BoxBody;
+use http_body_util::Full;
+use hyper::body::{Body as HttpBody, Bytes, Frame, SizeHint};
+use hyper::{header::HeaderValue, Response as HyperResponse, StatusCode};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+
+/// Boxed error carried by a streaming response body. A stream item that yields
+/// `Err(_)` aborts the response connection.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The response body used throughout Ultimo.
+///
+/// `Full` is the buffered fast path — the overwhelmingly common case, with no
+/// per-response boxing. `Stream` carries an incrementally produced body (see
+/// [`Context::stream`](crate::context::Context::stream)).
+pub enum UltimoBody {
+    /// A fully-buffered body.
+    Full(Full<Bytes>),
+    /// A streaming body.
+    Stream(BoxBody<Bytes, BoxError>),
+}
+
+impl UltimoBody {
+    /// An empty buffered body.
+    pub fn empty() -> Self {
+        UltimoBody::Full(Full::new(Bytes::new()))
+    }
+
+    /// A buffered body from any bytes-like value.
+    pub fn full(bytes: impl Into<Bytes>) -> Self {
+        UltimoBody::Full(Full::new(bytes.into()))
+    }
+}
+
+impl HttpBody for UltimoBody {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
+        match self.get_mut() {
+            // `Full`'s error is `Infallible`; box it to unify the error type.
+            UltimoBody::Full(f) => match Pin::new(f).poll_frame(cx) {
+                Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+                Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(Box::new(e) as BoxError))),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            },
+            UltimoBody::Stream(s) => Pin::new(s).poll_frame(cx),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        match self {
+            UltimoBody::Full(f) => f.is_end_stream(),
+            UltimoBody::Stream(s) => s.is_end_stream(),
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        match self {
+            UltimoBody::Full(f) => f.size_hint(),
+            UltimoBody::Stream(s) => s.size_hint(),
+        }
+    }
+}
+
+/// HTTP Response type used throughout Ultimo
+pub type Response = HyperResponse<UltimoBody>;
+```
+
+> Note: `Bytes` now comes from `hyper::body::Bytes` in the import list above (previously imported inline); the rest of the file uses `Bytes` unchanged.
+
+- [ ] **Step 4: Migrate `ResponseBuilder::build()`**
+
+In `ultimo/src/response.rs`, change the body construction in `build()` (was `.body(Full::new(Bytes::from(body)))`):
+
+```rust
+        // Set body
+        let body = self.body.unwrap_or_default();
+        response
+            .body(UltimoBody::full(body))
+            .map_err(|e| UltimoError::Internal(format!("Failed to build response: {}", e)))
+```
+
+- [ ] **Step 5: Migrate `app.rs` WebSocket handler type**
+
+In `ultimo/src/app.rs`, change the type at line 36:
+
+```rust
+type BoxedWebSocketHandler =
+    Arc<dyn Fn(WebSocketUpgrade<()>) -> crate::response::Response + Send + Sync>;
+```
+
+(The `oneshot` request signature at line 610 stays `HyperRequest<http_body_util::Full<Bytes>>` — request side is unchanged. The test-module request bodies at lines 862/875 also stay `Full::new(...)`.)
+
+- [ ] **Step 6: Migrate `static_files.rs`**
+
+In `ultimo/src/static_files.rs`, line 70 (`.body(Full::new(Bytes::new()))`) → `.body(crate::response::UltimoBody::empty())`, and line 90 (`.body(Full::new(Bytes::from(content)))`) → `.body(crate::response::UltimoBody::full(content))`. Remove the now-unused `use http_body_util::Full;` at line 7 if the compiler flags it.
+
+- [ ] **Step 7: Migrate `middleware.rs` early-return bodies**
+
+In `ultimo/src/middleware.rs`:
+- line ~192: `.body(Full::new(Bytes::new()))` → `.body(crate::response::UltimoBody::empty())`
+- line ~572: `.body(Full::new(Bytes::from("Forbidden")))` → `.body(crate::response::UltimoBody::full("Forbidden"))`
+- line ~729: `.body(Full::new(Bytes::from("Too Many Requests")))` → `.body(crate::response::UltimoBody::full("Too Many Requests"))`
+
+- [ ] **Step 8: Migrate `middleware.rs` compression `Full::new` sites (keep buffering for now)**
+
+In the compression block, replace every `Full::new(body_bytes)` and `Full::new(Bytes::from(compressed))` with `crate::response::UltimoBody::full(...)`. Leave the `body.collect().await.unwrap()` line as-is for now (still correct — `UltimoBody: Body`; `.unwrap()` now unwraps a `BoxError` result but streams don't exist yet). The stream-skip is Task 4.
+
+Specifically:
+- `Ok(hyper::Response::from_parts(parts, Full::new(body_bytes)))` → `Ok(hyper::Response::from_parts(parts, crate::response::UltimoBody::full(body_bytes)))` (all three occurrences: below-min-size, skip-binary, no-encoding)
+- `hyper::Response::from_parts(parts, Full::new(Bytes::from(compressed)))` → `hyper::Response::from_parts(parts, crate::response::UltimoBody::full(compressed))` (brotli + gzip arms)
+
+Remove the now-unused `Full` import in `middleware.rs` if flagged.
+
+- [ ] **Step 9: Migrate `websocket/upgrade.rs`**
+
+In `ultimo/src/websocket/upgrade.rs`:
+- Change the three method return types (lines ~95, ~198, ~301) from `HyperResponse<Full<Bytes>>` to `crate::response::Response`.
+- Error bodies `Full::new(Bytes::from("..."))` → `crate::response::UltimoBody::full("...")` (the "Invalid WebSocket upgrade request", "Origin not allowed", "Missing Sec-WebSocket-Key header" cases).
+- Empty upgrade bodies `Full::new(Bytes::new())` (lines ~143, ~252) → `crate::response::UltimoBody::empty()`.
+- Remove the `use http_body_util::Full;` at line 8 if flagged (keep `Bytes` if still used elsewhere; drop if not).
+
+- [ ] **Step 10: Run the new unit tests + full lib suite**
+
+Run: `cargo test -p ultimo --lib 2>&1 | tail -20`
+Expected: PASS — new `ultimo_body_*` tests pass; all pre-existing tests still pass.
+
+- [ ] **Step 11: Compile the feature surface (ensures ws/static/compression migrated cleanly)**
+
+Run: `cargo clippy -p ultimo --features "websocket,test-helpers,testing,session,csrf" --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no errors, no warnings.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add ultimo/src/response.rs ultimo/src/app.rs ultimo/src/static_files.rs ultimo/src/middleware.rs ultimo/src/websocket/upgrade.rs
+git commit -m "feat!: introduce UltimoBody response body (buffered fast-path)
+
+Replace the hardwired Full<Bytes> response body with an UltimoBody enum
+that keeps a zero-boxing Full fast-path and adds a boxed streaming variant.
+No behavior change yet — all bodies are Full. Breaking: Response body type."
+```
+
+---
+
+### Task 2: `UltimoBody::stream()` constructor
+
+**Files:**
+- Modify: `ultimo/src/response.rs` (add `stream` constructor + test)
+
+**Interfaces:**
+- Consumes: `UltimoBody`, `BoxError` (Task 1).
+- Produces: `impl UltimoBody { pub fn stream<S>(s: S) -> Self where S: futures_util::Stream<Item = Result<Bytes, BoxError>> + Send + 'static; }`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ultimo/src/response.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn ultimo_body_stream_concatenates_chunks() {
+        use http_body_util::BodyExt;
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![
+            Ok(Bytes::from("foo")),
+            Ok(Bytes::from("bar")),
+            Ok(Bytes::from("baz")),
+        ];
+        let body = UltimoBody::stream(futures_util::stream::iter(chunks));
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(&bytes[..], b"foobarbaz");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ultimo --lib ultimo_body_stream 2>&1 | tail -20`
+Expected: FAIL — `no function stream on UltimoBody`.
+
+- [ ] **Step 3: Implement `stream`**
+
+Add to the `impl UltimoBody` block in `ultimo/src/response.rs`:
+
+```rust
+    /// A streaming body produced from a `Stream` of byte chunks.
+    ///
+    /// Each `Ok(bytes)` becomes a data frame; an `Err(_)` aborts the connection.
+    /// The response is sent chunked (no `Content-Length`).
+    pub fn stream<S>(stream: S) -> Self
+    where
+        S: futures_util::Stream<Item = std::result::Result<Bytes, BoxError>> + Send + 'static,
+    {
+        use futures_util::TryStreamExt;
+        use http_body_util::{BodyExt, StreamBody};
+        let body = StreamBody::new(stream.map_ok(Frame::data));
+        UltimoBody::Stream(body.boxed())
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ultimo --lib ultimo_body_stream 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/src/response.rs
+git commit -m "feat: add UltimoBody::stream constructor"
+```
+
+---
+
+### Task 3: `Context::stream()` + integration test
+
+**Files:**
+- Modify: `ultimo/src/context.rs` (add `stream` method)
+- Create: `ultimo/tests/streaming.rs`
+
+**Interfaces:**
+- Consumes: `UltimoBody::stream` (Task 2), `Response`, `BoxError`.
+- Produces: `impl Context { pub async fn stream<S>(&self, s: S) -> Result<Response> where S: futures_util::Stream<Item = Result<Bytes, BoxError>> + Send + 'static; }`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `ultimo/tests/streaming.rs`:
+
+```rust
+//! Integration tests for streaming response bodies.
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::Request as HyperRequest;
+use ultimo::prelude::*;
+use ultimo::response::BoxError;
+
+fn empty_req(uri: &str) -> HyperRequest<Full<Bytes>> {
+    HyperRequest::builder()
+        .uri(uri)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn ctx_stream_sends_chunks_without_content_length() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/stream", |ctx: Context| async move {
+        let chunks: Vec<Result<Bytes, BoxError>> = vec![
+            Ok(Bytes::from("chunk-1;")),
+            Ok(Bytes::from("chunk-2;")),
+            Ok(Bytes::from("chunk-3")),
+        ];
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let resp = app.oneshot(empty_req("/stream")).await;
+    assert_eq!(resp.status(), 200);
+    assert!(
+        resp.headers().get(hyper::header::CONTENT_LENGTH).is_none(),
+        "streamed responses must not carry Content-Length"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"chunk-1;chunk-2;chunk-3");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ultimo --features "testing" --test streaming 2>&1 | tail -20`
+Expected: FAIL — `no method stream on Context`.
+
+- [ ] **Step 3: Implement `Context::stream`**
+
+Add the import and method to `ultimo/src/context.rs`. In the `impl Context` block that holds `text`/`json`/`html` (near line 570), add:
+
+```rust
+    /// Return a streaming response body.
+    ///
+    /// Each `Ok(bytes)` item is sent as a chunk; the response has no
+    /// `Content-Length` (chunked transfer). Any queued `header`/`status` set on
+    /// the context is applied. An `Err(_)` item aborts the connection.
+    ///
+    /// ```no_run
+    /// # use ultimo::prelude::*;
+    /// # use ultimo::response::BoxError;
+    /// # use hyper::body::Bytes;
+    /// # async fn h(ctx: Context) -> ultimo::error::Result<Response> {
+    /// let chunks: Vec<Result<Bytes, BoxError>> = vec![Ok(Bytes::from("hi"))];
+    /// ctx.stream(futures_util::stream::iter(chunks)).await
+    /// # }
+    /// ```
+    pub async fn stream<S>(&self, body: S) -> Result<Response>
+    where
+        S: futures_util::Stream<Item = std::result::Result<Bytes, crate::response::BoxError>>
+            + Send
+            + 'static,
+    {
+        let status = self.response_status.read().await.unwrap_or(200);
+        let mut builder = hyper::Response::builder()
+            .status(hyper::StatusCode::from_u16(status).unwrap_or(hyper::StatusCode::OK));
+        let headers = self.response_headers.read().await;
+        for (name, value) in headers.iter() {
+            builder = builder.header(name.clone(), value.clone());
+        }
+        builder
+            .body(crate::response::UltimoBody::stream(body))
+            .map_err(|e| UltimoError::Internal(format!("Failed to build response: {}", e)))
+    }
+```
+
+> `Bytes` is already imported in `context.rs` (line 10: `use bytes::Bytes;`). `response_status` / `response_headers` are the same `RwLock` fields used by `build_response` and `redirect`. If field names differ, mirror what `redirect`/`build_response` read.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ultimo --features "testing" --test streaming 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the doctest compiles**
+
+Run: `cargo test -p ultimo --doc --features "websocket,testing,session,csrf" 2>&1 | tail -15`
+Expected: PASS (the `no_run` doctest on `stream` compiles).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultimo/src/context.rs ultimo/tests/streaming.rs
+git commit -m "feat: add Context::stream for chunked response bodies"
+```
+
+---
+
+### Task 4: Compression skips streaming bodies
+
+**Files:**
+- Modify: `ultimo/src/middleware.rs` (compression body handling)
+- Modify: `ultimo/tests/streaming.rs` (add compression tests)
+
+**Interfaces:**
+- Consumes: `UltimoBody` variants, `Context::stream` (Task 3), `compression()` middleware.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ultimo/tests/streaming.rs`:
+
+```rust
+#[tokio::test]
+async fn compression_passes_streaming_bodies_through() {
+    use ultimo::middleware::builtin::compression;
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(compression());
+    app.get("/stream", |ctx: Context| async move {
+        // A large streamed body that would otherwise be well over min_size.
+        let chunks: Vec<Result<Bytes, BoxError>> =
+            (0..100).map(|_| Ok(Bytes::from("x".repeat(64)))).collect();
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let req = HyperRequest::builder()
+        .uri("/stream")
+        .header("Accept-Encoding", "br, gzip")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let resp = app.oneshot(req).await;
+    assert!(
+        resp.headers().get(hyper::header::CONTENT_ENCODING).is_none(),
+        "streaming bodies must not be compressed"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body.len(), 100 * 64);
+}
+
+#[tokio::test]
+async fn compression_still_compresses_buffered_bodies() {
+    use ultimo::middleware::builtin::compression;
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(compression());
+    app.get("/buffered", |ctx: Context| async move {
+        ctx.text("y".repeat(4096)).await
+    });
+
+    let req = HyperRequest::builder()
+        .uri("/buffered")
+        .header("Accept-Encoding", "gzip")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let resp = app.oneshot(req).await;
+    assert_eq!(
+        resp.headers()
+            .get(hyper::header::CONTENT_ENCODING)
+            .and_then(|v| v.to_str().ok()),
+        Some("gzip"),
+        "buffered bodies over min_size must still be compressed"
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify the streaming one fails**
+
+Run: `cargo test -p ultimo --features "testing,compression" --test streaming 2>&1 | tail -25`
+Expected: `compression_passes_streaming_bodies_through` FAILS (the current `body.collect()` buffers the stream, and it may either compress it or panic) — while `compression_still_compresses_buffered_bodies` passes. The failing streaming assertion is the target.
+
+- [ ] **Step 3: Make compression skip streaming bodies**
+
+In `ultimo/src/middleware.rs`, replace the buffering line (`let body_bytes = body.collect().await.unwrap().to_bytes();`) and its preceding decompose comment with a variant match that short-circuits streams:
+
+```rust
+                    // Decompose response so we can inspect and replace the body.
+                    let (parts, body) = res.into_parts();
+
+                    // Never buffer a streaming body — pass it through untouched.
+                    let body_bytes = match body {
+                        crate::response::UltimoBody::Stream(_) => {
+                            return Ok(hyper::Response::from_parts(parts, body));
+                        }
+                        crate::response::UltimoBody::Full(full) => {
+                            full.collect().await.unwrap().to_bytes()
+                        }
+                    };
+```
+
+> The `Full` arm uses `http_body_util::BodyExt::collect` on the inner `Full<Bytes>` (its error is `Infallible`, so `.unwrap()` is safe). `BodyExt` is already in scope in this module; if not, add `use http_body_util::BodyExt;` at the top.
+
+- [ ] **Step 4: Run tests to verify both pass**
+
+Run: `cargo test -p ultimo --features "testing,compression" --test streaming 2>&1 | tail -25`
+Expected: PASS — both compression tests and the two earlier streaming tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultimo/src/middleware.rs ultimo/tests/streaming.rs
+git commit -m "feat: compression passes streaming bodies through uncompressed"
+```
+
+---
+
+### Task 5: Documentation surfaces + runnable example
+
+Per `.claude/skills/ship-feature`, every user-facing feature lands its docs and an example in the same PR.
+
+**Files:**
+- Modify: `docs-site/docs/pages/api-reference.mdx`
+- Create: `docs-site/docs/pages/streaming.mdx`
+- Modify: `docs-site/vocs.config.ts` (sidebar entry)
+- Modify: `docs-site/docs/pages/roadmap.mdx` (move Streaming Responses → shipped 0.9.0)
+- Modify: `README.md` (add to Available Now)
+- Create: `examples/streaming/{Cargo.toml,src/main.rs}`
+- Modify: `Cargo.toml` (workspace `members`)
+
+- [ ] **Step 1: Add the `Context::stream` + `UltimoBody` entries to api-reference**
+
+In `docs-site/docs/pages/api-reference.mdx`, under `#### Response Methods` (after the `html` entry, ~line 197), add:
+
+````markdown
+##### `stream<S>(&self, body: S) -> Result<Response>`
+
+Return a chunked/streaming response body from a `Stream<Item = Result<Bytes, BoxError>>`.
+No `Content-Length` is set. Queued `header`/`status` are applied.
+
+```rust
+use hyper::body::Bytes;
+use ultimo::response::BoxError;
+
+async fn download(ctx: Context) -> Result<Response> {
+    let chunks: Vec<Result<Bytes, BoxError>> = vec![
+        Ok(Bytes::from("part-1")),
+        Ok(Bytes::from("part-2")),
+    ];
+    ctx.stream(futures_util::stream::iter(chunks)).await
+}
+```
+````
+
+Under `## Core Types` (near the `Ultimo` type), add a short subsection:
+
+````markdown
+### `UltimoBody`
+
+The response body type (`type Response = hyper::Response<UltimoBody>`). Two
+variants: `Full` (buffered — the fast path, produced by `text`/`json`/`html`) and
+`Stream` (produced by `Context::stream`). `BoxError` is the streaming error type
+(`Box<dyn std::error::Error + Send + Sync>`).
+````
+
+- [ ] **Step 2: Write `streaming.mdx`**
+
+Create `docs-site/docs/pages/streaming.mdx`:
+
+````markdown
+# Streaming Responses
+
+Return a response body incrementally instead of buffering it all in memory.
+Useful for large downloads, proxied bodies, and as the foundation for
+Server-Sent Events.
+
+Streaming is always available — no Cargo feature required.
+
+## `ctx.stream(...)`
+
+`ctx.stream` takes a `Stream` of byte chunks and sends them as they arrive. The
+response is chunked (no `Content-Length`).
+
+```rust
+use hyper::body::Bytes;
+use ultimo::prelude::*;
+use ultimo::response::BoxError;
+
+async fn numbers(ctx: Context) -> Result<Response> {
+    // Any `Stream<Item = Result<Bytes, BoxError>>` works.
+    let chunks: Vec<Result<Bytes, BoxError>> =
+        (0..5).map(|n| Ok(Bytes::from(format!("line {n}\n")))).collect();
+    ctx.stream(futures_util::stream::iter(chunks)).await
+}
+```
+
+Set a content type first if you need one:
+
+```rust
+async fn csv(ctx: Context) -> Result<Response> {
+    ctx.header("Content-Type", "text/csv").await;
+    let rows: Vec<Result<Bytes, BoxError>> = vec![
+        Ok(Bytes::from("a,b,c\n")),
+        Ok(Bytes::from("1,2,3\n")),
+    ];
+    ctx.stream(futures_util::stream::iter(rows)).await
+}
+```
+
+## Errors
+
+If a stream item yields `Err(_)`, the response connection is aborted. Emit
+`Ok(_)` chunks for normal data and reserve `Err(_)` for genuine failures.
+
+## Interaction with compression
+
+The `compression` middleware **skips streaming bodies** — it never buffers a
+stream (that would defeat streaming and risk unbounded memory). Buffered
+responses (`text`/`json`/`html`) are still compressed as usual.
+
+## The body type
+
+`Response` is `hyper::Response<UltimoBody>`. `UltimoBody::Full` is the buffered
+fast path (what `text`/`json`/`html` produce); `UltimoBody::Stream` is what
+`ctx.stream` produces. You rarely construct it directly.
+
+## Full example
+
+See [`examples/streaming`](https://github.com/ultimo-rs/ultimo/tree/main/examples/streaming):
+`cargo run -p streaming-example`, then open `http://127.0.0.1:3000`.
+````
+
+- [ ] **Step 3: Add the sidebar entry**
+
+In `docs-site/vocs.config.ts`, inside the "Features" sidebar group's `items` array (near the Static Files / WebSocket entries, ~line 91), add:
+
+```ts
+        {
+          text: "Streaming Responses",
+          link: "/streaming",
+        },
+```
+
+- [ ] **Step 4: Update the roadmap**
+
+In `docs-site/docs/pages/roadmap.mdx`:
+- Remove the "Streaming responses" bullet under "Real-time & streaming" (line ~31).
+- In the status table, change the `Streaming Responses` row (line ~137) from `📋 Planned | 0.7.0` to `✅ Shipped | 0.9.0` (match the format of other shipped rows in the file).
+
+- [ ] **Step 5: Update the README**
+
+In `README.md`, add to the feature list (near the "Testing utilities" bullet, ~line 45):
+
+```markdown
+- 🌊 **Streaming responses** — chunked/streaming bodies via `ctx.stream(...)`.
+```
+
+- [ ] **Step 6: Create the example crate**
+
+Create `examples/streaming/Cargo.toml`:
+
+```toml
+[package]
+name = "streaming-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ultimo = { path = "../../ultimo" }
+tokio = { version = "1", features = ["full"] }
+futures-util = "0.3"
+hyper = "1"
+```
+
+Create `examples/streaming/src/main.rs`:
+
+```rust
+//! Streaming response demo: a route that streams numbered lines, served with a
+//! tiny HTML page that reads the stream via `fetch`.
+use hyper::body::Bytes;
+use std::time::Duration;
+use ultimo::prelude::*;
+use ultimo::response::BoxError;
+
+const PAGE: &str = r#"<!doctype html>
+<meta charset="utf-8"><title>Ultimo streaming demo</title>
+<h1>Streaming demo</h1>
+<button onclick="go()">Stream</button>
+<pre id="out"></pre>
+<script>
+async function go() {
+  const out = document.getElementById('out');
+  out.textContent = '';
+  const res = await fetch('/numbers');
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out.textContent += dec.decode(value);
+  }
+}
+</script>"#;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut app = Ultimo::new();
+
+    app.get("/", |ctx: Context| async move { ctx.html(PAGE).await });
+
+    app.get("/numbers", |ctx: Context| async move {
+        // A stream that yields a line every 300ms, ten times.
+        let s = futures_util::stream::unfold(0u32, |n| async move {
+            if n >= 10 {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let chunk: std::result::Result<Bytes, BoxError> =
+                Ok(Bytes::from(format!("line {n}\n")));
+            Some((chunk, n + 1))
+        });
+        ctx.stream(s).await
+    });
+
+    println!("→ http://127.0.0.1:3000");
+    app.listen("127.0.0.1:3000").await
+}
+```
+
+- [ ] **Step 7: Register the example in the workspace**
+
+In the root `Cargo.toml`, add `"examples/streaming"` to the `members` array.
+
+- [ ] **Step 8: Build the example + docs sanity**
+
+Run: `cargo build -p streaming-example 2>&1 | tail -15`
+Expected: compiles cleanly.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs-site/docs/pages/api-reference.mdx docs-site/docs/pages/streaming.mdx docs-site/vocs.config.ts docs-site/docs/pages/roadmap.mdx README.md examples/streaming Cargo.toml
+git commit -m "docs: streaming responses (api-reference, guide, roadmap, README, example)"
+```
+
+---
+
+### Task 6: Final gate + PR
+
+- [ ] **Step 1: Run the full verification gate**
+
+```bash
+cd /Users/ruslanelishaev/Desktop/projects/ultimo
+cargo fmt --all --check
+cargo clippy -p ultimo --features "websocket,test-helpers,testing,session,csrf" --all-targets -- -D warnings
+cargo test -p ultimo --lib
+cargo test -p ultimo --features "websocket,test-helpers,testing,session,csrf,compression"
+cargo test -p ultimo --doc --features "websocket,testing,session,csrf"
+cargo build -p streaming-example
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push --no-verify -u origin feat/streaming-responses
+gh pr create --fill
+```
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+`semver-checks` will flag the `Response` body-type change — expected for a `feat!`. Everything else must be green.
+
+- [ ] **Step 4: Merge (admin squash) + link issue #2**
+
+```bash
+gh pr merge --squash --admin --delete-branch
+git switch main && git pull
+```
+
+Comment on #2 (SSE) that streaming primitives are now available (`ctx.stream`), leaving #2 open for the SSE layer.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `UltimoBody` enum (Full + Stream) → Task 1. ✔
+- `BoxError` → Task 1. ✔
+- `Body` impl (poll_frame/is_end_stream/size_hint) → Task 1. ✔
+- `Response` alias change → Task 1. ✔
+- Buffered helpers unchanged → Task 1 (regression suite). ✔
+- `UltimoBody::{empty,full}` → Task 1; `stream` → Task 2. ✔
+- `ctx.stream` (no Content-Length) → Task 3. ✔
+- Compression skips streams → Task 4. ✔
+- Blast-radius migration (5 files) → Task 1. ✔
+- Dependency: uses existing `futures-util` (spec's `futures-core` moot — noted). ✔
+- SemVer 0.9.0 / `feat!` → Task 1 commit + Task 6. ✔
+- Testing (unit + integration + compression) → Tasks 1–4. ✔
+- Docs surfaces + example → Task 5. ✔
+- Follow-up SSE (#2) noted, out of scope → Task 6 step 4. ✔
+
+**Placeholder scan:** none — every code step has concrete code.
+
+**Type consistency:** `UltimoBody`, `BoxError`, `Response`, `UltimoBody::{empty,full,stream}`, `Context::stream` signatures are identical across Tasks 1–5. `futures_util::Stream<Item = Result<Bytes, BoxError>>` bound is uniform in Tasks 2 and 3. ✔

--- a/docs/superpowers/specs/2026-08-16-streaming-responses-design.md
+++ b/docs/superpowers/specs/2026-08-16-streaming-responses-design.md
@@ -1,0 +1,183 @@
+# Streaming Responses — Design
+
+**Date:** 2026-08-16
+**Status:** Approved (design)
+**Target release:** 0.9.0 (breaking — `Response` body type changes)
+
+## Goal
+
+Let handlers return **chunked / streaming response bodies** — data emitted
+incrementally over the connection instead of buffered fully in memory before the
+first byte is sent. This unlocks large downloads, proxy/pass-through bodies, and
+is the required foundation for **typed SSE / subscriptions** (the next roadmap
+item, built on top of the primitive introduced here).
+
+Today every response is fully buffered: `pub type Response =
+HyperResponse<Full<Bytes>>` (`ultimo/src/response.rs:12`). There is no way to
+send a body the framework doesn't hold entirely in memory.
+
+## Non-goals (v1)
+
+- Typed SSE / event framing — separate follow-up feature, layered on `ctx.stream`.
+- Streaming *file* serving (`static_files.rs` keeps buffering whole files for now).
+- Trailers, custom backpressure tuning, HTTP/2 flow-control knobs.
+- A channel/sink helper — may be added later; v1 exposes the `Stream` form only.
+
+## Architecture
+
+### The body type: `UltimoBody`
+
+Replace the hardwired `Full<Bytes>` body with a small enum that keeps a
+**zero-boxing fast path** for the common buffered case and adds a streaming
+variant:
+
+```rust
+/// Error type carried by a streaming body. A stream item error aborts the
+/// response connection.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+pub enum UltimoBody {
+    /// Buffered — the hot path. No per-response allocation beyond the bytes.
+    Full(Full<Bytes>),
+    /// Streaming — a boxed `http_body::Body` produced from a `Stream`.
+    Stream(BoxBody<Bytes, BoxError>),
+}
+
+pub type Response = HyperResponse<UltimoBody>;
+```
+
+`UltimoBody` implements `http_body::Body<Data = Bytes, Error = BoxError>`:
+
+- `poll_frame`: delegates to the inner body. The `Full` arm maps its
+  `Infallible` error into `BoxError`; the `Stream` arm passes through.
+- `is_end_stream` / `size_hint`: delegate to the inner body (so buffered
+  responses still report an exact size → `Content-Length`, streaming ones don't).
+
+**Why an enum over erasing everything to `BoxBody`:** boxing every response —
+including the overwhelmingly common buffered one — would add an allocation and a
+dynamic dispatch to the hot path the benchmarks guard. The enum keeps buffered
+responses allocation-identical to today while allowing streams.
+
+### Constructors
+
+```rust
+impl UltimoBody {
+    pub fn empty() -> Self;                              // Full(Full::new(Bytes::new()))
+    pub fn full(bytes: impl Into<Bytes>) -> Self;        // buffered
+    pub fn stream<S>(s: S) -> Self                        // streaming
+    where
+        S: Stream<Item = Result<Bytes, BoxError>> + Send + 'static;
+}
+```
+
+`stream` wraps the caller's `Stream` in a tiny adapter that maps each
+`Ok(bytes)` into `http_body::Frame::data(bytes)`, feeds it through
+`http_body_util::StreamBody`, and boxes the result (`BodyExt::boxed`) into
+`UltimoBody::Stream`. The adapter is ~15 lines and needs only the `Stream` trait
+(new dep `futures-core`, see below) — it deliberately avoids pulling
+`futures-util` into the runtime.
+
+### Handler-facing API
+
+```rust
+impl Context {
+    /// 200 OK, no Content-Length, body streamed from `s`.
+    pub fn stream<S>(&self, s: S) -> Response
+    where
+        S: Stream<Item = Result<Bytes, BoxError>> + Send + 'static;
+}
+```
+
+`ctx.stream(...)` builds a `Response` whose body is `UltimoBody::stream(s)`,
+status `200`, and **no `Content-Length`** (hyper emits `Transfer-Encoding:
+chunked` on HTTP/1.1). Headers can be adjusted on the returned `Response` before
+returning it (e.g. `Content-Type`). The existing buffered helpers
+(`text`/`json`/`html`, `ResponseBuilder::build`) are unchanged in behavior — they
+now produce `UltimoBody::Full`.
+
+## Compression interaction (must-handle)
+
+The compression middleware currently buffers the whole body:
+`middleware.rs:854` does `body.collect().await...`. For a streaming body that
+would drain the entire stream into memory — defeating streaming and risking
+unbounded memory. So compression **only compresses `UltimoBody::Full`; streaming
+bodies pass through untouched**:
+
+```rust
+let (parts, body) = res.into_parts();
+match body {
+    UltimoBody::Stream(_) => return Ok(Response::from_parts(parts, body)), // pass through
+    UltimoBody::Full(full) => { /* existing collect + gzip/brotli path */ }
+}
+```
+
+`Vary: Accept-Encoding` handling is unchanged for the buffered path.
+
+## Blast radius
+
+`Full` appears across 9 files (~41 sites). Each buffered construction becomes
+`UltimoBody::Full(...)` / `UltimoBody::full(...)` / `UltimoBody::empty()`:
+
+| File | Sites | Change |
+|---|---|---|
+| `response.rs` | 3 | Define `UltimoBody`, `BoxError`; `Response` alias; `build()` → `UltimoBody::full` |
+| `middleware.rs` | 10 | Error/early-return bodies → `UltimoBody::full`; compression skips `Stream` |
+| `app.rs` | 5 | dispatch/`oneshot` body type; service returns `UltimoBody` |
+| `websocket/upgrade.rs` | 12 | Upgrade (101) empty body → `UltimoBody::empty()`; handler fn type |
+| `websocket/connection.rs` | 3 | Body construction → `UltimoBody` |
+| `static_files.rs` | 3 | File/404 bodies → `UltimoBody::full` (still buffered) |
+| `error.rs` | 2 | Error response bodies → `UltimoBody::full` |
+| `testing/client.rs` | 2 | Response side reads `UltimoBody` (`.collect()` still works); request side stays `Full<Bytes>` |
+| `websocket/pubsub.rs` | 1 | Body construction → `UltimoBody` |
+
+**Request side is unchanged:** `oneshot(req: HyperRequest<Full<Bytes>>)` and the
+testing client keep `Full<Bytes>` on the *request* body.
+
+## Dependencies
+
+- Add **`futures-core`** (runtime, tiny, `no_std`) — only for the `Stream` trait
+  bound in the public API. No `futures-util` at runtime.
+- `http_body_util` (already a dep) provides `StreamBody`, `BodyExt::boxed`,
+  `BoxBody`, `Full`.
+- Must pass `cargo-deny` / `cargo-audit` — `futures-core` is standard and audited.
+
+## Backward compatibility & SemVer
+
+Breaking: `Response`'s public body type changes from `Full<Bytes>` to
+`UltimoBody`.
+
+- `res.into_body()` now yields `UltimoBody` (still `impl Body`, so `.collect()`
+  keeps working).
+- User code that names `HyperResponse<Full<Bytes>>` or constructs a `Response`
+  with a `Full<Bytes>` body directly breaks and must switch to `UltimoBody`.
+- Pre-1.0 rule: breaking → **minor** bump → **0.9.0**. `semver-checks` will flag
+  it; land with a `feat!` commit and the admin squash-merge override.
+
+## Testing
+
+- **Unit:** `UltimoBody::full` round-trips via `.collect()`; `UltimoBody::stream`
+  over a `stream::iter` of chunks collects to the concatenation; `empty()` yields
+  zero bytes and `is_end_stream`.
+- **Integration:** a handler using `ctx.stream(...)` emits N chunks →
+  `oneshot` collects the concatenated bytes; assert **no `Content-Length`**
+  header on the streamed response.
+- **Compression:** a streamed body passes through with **no `Content-Encoding`**;
+  a buffered body over `min_size` is still compressed (guards the variant split).
+- Gate integration tests behind the existing feature combo the CI gate uses.
+
+## Open questions — resolved
+
+- **Enum vs box-everything?** Enum (fast path). ✔ (approved)
+- **v1 input type?** `Stream<Item = Result<Bytes, BoxError>>`; channel/SSE
+  helpers later. ✔ (approved)
+- **Feature-gate streaming?** No — the `Response` body-type change is core and
+  can't be cleanly gated; `ctx.stream` only pulls `futures-core`, so it's always
+  available.
+- **Error semantics?** A stream item `Err` aborts the connection (documented on
+  `ctx.stream`).
+
+## Follow-ups (not this spec)
+
+1. Typed SSE / subscriptions on top of `ctx.stream` (next roadmap item; closes #2).
+2. Optional channel/sink helper (`ctx.stream_channel()`).
+3. Streaming large static files.

--- a/examples/streaming/Cargo.toml
+++ b/examples/streaming/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "streaming-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ultimo = { path = "../../ultimo" }
+tokio = { version = "1", features = ["full"] }
+futures-util = "0.3"
+hyper = "1"

--- a/examples/streaming/src/main.rs
+++ b/examples/streaming/src/main.rs
@@ -1,0 +1,50 @@
+//! Streaming response demo: a route that streams numbered lines, served with a
+//! tiny HTML page that reads the stream via `fetch`.
+use hyper::body::Bytes;
+use std::time::Duration;
+use ultimo::prelude::*;
+use ultimo::response::BoxError;
+
+const PAGE: &str = r#"<!doctype html>
+<meta charset="utf-8"><title>Ultimo streaming demo</title>
+<h1>Streaming demo</h1>
+<button onclick="go()">Stream</button>
+<pre id="out"></pre>
+<script>
+async function go() {
+  const out = document.getElementById('out');
+  out.textContent = '';
+  const res = await fetch('/numbers');
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out.textContent += dec.decode(value);
+  }
+}
+</script>"#;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut app = Ultimo::new();
+
+    app.get("/", |ctx: Context| async move { ctx.html(PAGE).await });
+
+    app.get("/numbers", |ctx: Context| async move {
+        // A stream that yields a line every 300ms, ten times.
+        let s = futures_util::stream::unfold(0u32, |n| async move {
+            if n >= 10 {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let chunk: std::result::Result<Bytes, BoxError> =
+                Ok(Bytes::from(format!("line {n}\n")));
+            Some((chunk, n + 1))
+        });
+        ctx.stream(s).await
+    });
+
+    println!("→ http://127.0.0.1:3000");
+    app.listen("127.0.0.1:3000").await
+}

--- a/ultimo/src/app.rs
+++ b/ultimo/src/app.rs
@@ -32,11 +32,8 @@ use crate::websocket::{ChannelManager, WebSocketConfig, WebSocketHandler, WebSoc
 
 /// WebSocket handler function type
 #[cfg(feature = "websocket")]
-type BoxedWebSocketHandler = Arc<
-    dyn Fn(WebSocketUpgrade<()>) -> hyper::Response<http_body_util::Full<bytes::Bytes>>
-        + Send
-        + Sync,
->;
+type BoxedWebSocketHandler =
+    Arc<dyn Fn(WebSocketUpgrade<()>) -> crate::response::Response + Send + Sync>;
 
 /// Main Ultimo application
 pub struct Ultimo {

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -550,19 +550,28 @@ impl Context {
         headers.insert(name.into(), value.into());
     }
 
+    /// Snapshot the queued response status (defaulting to 200) and headers, so
+    /// the buffered (`build_response`) and streaming (`stream`) paths apply them
+    /// the same way and can't drift.
+    async fn response_meta(&self) -> (u16, Vec<(String, String)>) {
+        let status = self.response_status.read().await.unwrap_or(200);
+        let headers = self
+            .response_headers
+            .read()
+            .await
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        (status, headers)
+    }
+
     /// Build response with collected status and headers
     async fn build_response(&self, mut builder: ResponseBuilder) -> ResponseBuilder {
-        // Apply status if set
-        if let Some(status) = *self.response_status.read().await {
-            builder = builder.status(status);
+        let (status, headers) = self.response_meta().await;
+        builder = builder.status(status);
+        for (name, value) in headers {
+            builder = builder.header(name, value);
         }
-
-        // Apply headers
-        let headers = self.response_headers.read().await;
-        for (name, value) in headers.iter() {
-            builder = builder.header(name.clone(), value.clone());
-        }
-
         builder
     }
 
@@ -586,9 +595,12 @@ impl Context {
 
     /// Return a streaming response body.
     ///
-    /// Each `Ok(bytes)` item is sent as a chunk; the response has no
-    /// `Content-Length` (chunked transfer). Any queued `header`/`status` set on
-    /// the context is applied. An `Err(_)` item aborts the connection.
+    /// Each `Ok(bytes)` item is sent as a chunk; the response is chunked (no
+    /// `Content-Length`). Any queued `header`/`status` set on the context is
+    /// applied, except `Content-Length`/`Transfer-Encoding` (which would
+    /// conflict with the chunked framing and are dropped). If no `Content-Type`
+    /// was set, it defaults to `application/octet-stream`. An `Err(_)` item
+    /// aborts the connection.
     ///
     /// ```no_run
     /// # use ultimo::prelude::*;
@@ -605,12 +617,25 @@ impl Context {
             + Send
             + 'static,
     {
-        let status = self.response_status.read().await.unwrap_or(200);
+        let (status, headers) = self.response_meta().await;
         let mut builder = hyper::Response::builder()
             .status(hyper::StatusCode::from_u16(status).unwrap_or(hyper::StatusCode::OK));
-        let headers = self.response_headers.read().await;
-        for (name, value) in headers.iter() {
-            builder = builder.header(name.clone(), value.clone());
+        let mut has_content_type = false;
+        for (name, value) in headers {
+            // A streaming body is chunked with unknown length — never carry a
+            // Content-Length or Transfer-Encoding from the queued headers, or
+            // the framing conflicts with hyper's chunked encoding.
+            match name.to_ascii_lowercase().as_str() {
+                "content-length" | "transfer-encoding" => continue,
+                "content-type" => has_content_type = true,
+                _ => {}
+            }
+            builder = builder.header(name, value);
+        }
+        // Default a content type so intermediaries don't content-sniff (which
+        // can buffer the whole body and defeat streaming).
+        if !has_content_type {
+            builder = builder.header("Content-Type", "application/octet-stream");
         }
         builder
             .body(crate::response::UltimoBody::stream(body))

--- a/ultimo/src/context.rs
+++ b/ultimo/src/context.rs
@@ -584,6 +584,39 @@ impl Context {
         builder.html(html).build()
     }
 
+    /// Return a streaming response body.
+    ///
+    /// Each `Ok(bytes)` item is sent as a chunk; the response has no
+    /// `Content-Length` (chunked transfer). Any queued `header`/`status` set on
+    /// the context is applied. An `Err(_)` item aborts the connection.
+    ///
+    /// ```no_run
+    /// # use ultimo::prelude::*;
+    /// # use ultimo::response::BoxError;
+    /// # use hyper::body::Bytes;
+    /// # async fn h(ctx: Context) -> ultimo::error::Result<ultimo::response::Response> {
+    /// let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![Ok(Bytes::from("hi"))];
+    /// ctx.stream(futures_util::stream::iter(chunks)).await
+    /// # }
+    /// ```
+    pub async fn stream<S>(&self, body: S) -> Result<Response>
+    where
+        S: futures_util::Stream<Item = std::result::Result<Bytes, crate::response::BoxError>>
+            + Send
+            + 'static,
+    {
+        let status = self.response_status.read().await.unwrap_or(200);
+        let mut builder = hyper::Response::builder()
+            .status(hyper::StatusCode::from_u16(status).unwrap_or(hyper::StatusCode::OK));
+        let headers = self.response_headers.read().await;
+        for (name, value) in headers.iter() {
+            builder = builder.header(name.clone(), value.clone());
+        }
+        builder
+            .body(crate::response::UltimoBody::stream(body))
+            .map_err(|e| UltimoError::Internal(format!("Failed to build response: {}", e)))
+    }
+
     /// Return a redirect response
     pub async fn redirect(&self, location: &str) -> Result<Response> {
         let status = self.response_status.read().await.unwrap_or(302);

--- a/ultimo/src/middleware.rs
+++ b/ultimo/src/middleware.rs
@@ -865,7 +865,10 @@ pub mod builtin {
 
                     // Skip below min_size.
                     if body_bytes.len() < min_size {
-                        return Ok(hyper::Response::from_parts(parts, UltimoBody::full(body_bytes)));
+                        return Ok(hyper::Response::from_parts(
+                            parts,
+                            UltimoBody::full(body_bytes),
+                        ));
                     }
 
                     // Skip binary content types.
@@ -887,7 +890,10 @@ pub mod builtin {
                         || SKIP_EXACT.iter().any(|e| ct.starts_with(e));
 
                     if skip {
-                        return Ok(hyper::Response::from_parts(parts, UltimoBody::full(body_bytes)));
+                        return Ok(hyper::Response::from_parts(
+                            parts,
+                            UltimoBody::full(body_bytes),
+                        ));
                     }
 
                     // Choose algorithm: prefer brotli > gzip > identity.
@@ -936,7 +942,10 @@ pub mod builtin {
                         Ok(res)
                     } else {
                         // No matching encoding — pass through unmodified.
-                        Ok(hyper::Response::from_parts(parts, UltimoBody::full(body_bytes)))
+                        Ok(hyper::Response::from_parts(
+                            parts,
+                            UltimoBody::full(body_bytes),
+                        ))
                     }
                 })
             })

--- a/ultimo/src/middleware.rs
+++ b/ultimo/src/middleware.rs
@@ -853,8 +853,15 @@ pub mod builtin {
 
                     // Decompose response so we can inspect and replace the body.
                     let (parts, body) = res.into_parts();
-                    // Full<Bytes> is infallible — unwrap is safe.
-                    let body_bytes = body.collect().await.unwrap().to_bytes();
+
+                    // Never buffer a streaming body — pass it through untouched.
+                    let body_bytes = match body {
+                        UltimoBody::Stream(_) => {
+                            return Ok(hyper::Response::from_parts(parts, body));
+                        }
+                        // `Full<Bytes>` is infallible — unwrap is safe.
+                        UltimoBody::Full(full) => full.collect().await.unwrap().to_bytes(),
+                    };
 
                     // Skip below min_size.
                     if body_bytes.len() < min_size {

--- a/ultimo/src/middleware.rs
+++ b/ultimo/src/middleware.rs
@@ -3,9 +3,12 @@
 //! Middleware can execute before and after handlers, modify context,
 //! and short-circuit request handling.
 
-use crate::{context::Context, error::Result, response::Response};
-use http_body_util::Full;
-use hyper::{body::Bytes, Response as HyperResponse};
+use crate::{
+    context::Context,
+    error::Result,
+    response::{Response, UltimoBody},
+};
+use hyper::Response as HyperResponse;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -189,7 +192,7 @@ pub mod builtin {
                             .header("Access-Control-Allow-Origin", origin)
                             .header("Access-Control-Allow-Methods", methods)
                             .header("Access-Control-Allow-Headers", headers)
-                            .body(Full::new(Bytes::new()))
+                            .body(UltimoBody::empty())
                             .unwrap();
                         return Ok(response);
                     }
@@ -569,7 +572,7 @@ pub mod builtin {
                     } else {
                         Ok(HyperResponse::builder()
                             .status(403)
-                            .body(Full::new(Bytes::from("Forbidden")))
+                            .body(UltimoBody::full("Forbidden"))
                             .unwrap())
                     }
                 })
@@ -726,7 +729,7 @@ pub mod builtin {
                             .status(429)
                             .header("Retry-After", window_secs.to_string())
                             .header("Content-Type", "text/plain")
-                            .body(Full::new(Bytes::from("Too Many Requests")))
+                            .body(UltimoBody::full("Too Many Requests"))
                             .unwrap())
                     }
                 })
@@ -855,7 +858,7 @@ pub mod builtin {
 
                     // Skip below min_size.
                     if body_bytes.len() < min_size {
-                        return Ok(hyper::Response::from_parts(parts, Full::new(body_bytes)));
+                        return Ok(hyper::Response::from_parts(parts, UltimoBody::full(body_bytes)));
                     }
 
                     // Skip binary content types.
@@ -877,7 +880,7 @@ pub mod builtin {
                         || SKIP_EXACT.iter().any(|e| ct.starts_with(e));
 
                     if skip {
-                        return Ok(hyper::Response::from_parts(parts, Full::new(body_bytes)));
+                        return Ok(hyper::Response::from_parts(parts, UltimoBody::full(body_bytes)));
                     }
 
                     // Choose algorithm: prefer brotli > gzip > identity.
@@ -895,7 +898,7 @@ pub mod builtin {
                         }
                         let len = compressed.len();
                         let mut res =
-                            hyper::Response::from_parts(parts, Full::new(Bytes::from(compressed)));
+                            hyper::Response::from_parts(parts, UltimoBody::full(compressed));
                         res.headers_mut().insert(
                             CONTENT_ENCODING,
                             hyper::header::HeaderValue::from_static("br"),
@@ -914,7 +917,7 @@ pub mod builtin {
                         }
                         let len = compressed.len();
                         let mut res =
-                            hyper::Response::from_parts(parts, Full::new(Bytes::from(compressed)));
+                            hyper::Response::from_parts(parts, UltimoBody::full(compressed));
                         res.headers_mut().insert(
                             CONTENT_ENCODING,
                             hyper::header::HeaderValue::from_static("gzip"),
@@ -926,7 +929,7 @@ pub mod builtin {
                         Ok(res)
                     } else {
                         // No matching encoding — pass through unmodified.
-                        Ok(hyper::Response::from_parts(parts, Full::new(body_bytes)))
+                        Ok(hyper::Response::from_parts(parts, UltimoBody::full(body_bytes)))
                     }
                 })
             })

--- a/ultimo/src/response.rs
+++ b/ultimo/src/response.rs
@@ -3,7 +3,7 @@
 //! Internal response building that gets wrapped by Context methods.
 
 use crate::error::{Result, UltimoError};
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use http_body_util::Full;
 use hyper::body::{Body as HttpBody, Bytes, Frame, SizeHint};
 use hyper::{header::HeaderValue, Response as HyperResponse, StatusCode};
@@ -25,7 +25,7 @@ pub enum UltimoBody {
     /// A fully-buffered body.
     Full(Full<Bytes>),
     /// A streaming body.
-    Stream(BoxBody<Bytes, BoxError>),
+    Stream(UnsyncBoxBody<Bytes, BoxError>),
 }
 
 impl UltimoBody {
@@ -37,6 +37,20 @@ impl UltimoBody {
     /// A buffered body from any bytes-like value.
     pub fn full(bytes: impl Into<Bytes>) -> Self {
         UltimoBody::Full(Full::new(bytes.into()))
+    }
+
+    /// A streaming body produced from a `Stream` of byte chunks.
+    ///
+    /// Each `Ok(bytes)` becomes a data frame; an `Err(_)` aborts the connection.
+    /// The response is sent chunked (no `Content-Length`).
+    pub fn stream<S>(stream: S) -> Self
+    where
+        S: futures_util::Stream<Item = std::result::Result<Bytes, BoxError>> + Send + 'static,
+    {
+        use futures_util::TryStreamExt;
+        use http_body_util::{BodyExt, StreamBody};
+        let body = StreamBody::new(stream.map_ok(Frame::data));
+        UltimoBody::Stream(body.boxed_unsync())
     }
 }
 
@@ -268,5 +282,18 @@ mod tests {
         assert!(body.is_end_stream());
         let bytes = body.collect().await.unwrap().to_bytes();
         assert_eq!(bytes.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn ultimo_body_stream_concatenates_chunks() {
+        use http_body_util::BodyExt;
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![
+            Ok(Bytes::from("foo")),
+            Ok(Bytes::from("bar")),
+            Ok(Bytes::from("baz")),
+        ];
+        let body = UltimoBody::stream(futures_util::stream::iter(chunks));
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(&bytes[..], b"foobarbaz");
     }
 }

--- a/ultimo/src/response.rs
+++ b/ultimo/src/response.rs
@@ -3,13 +3,80 @@
 //! Internal response building that gets wrapped by Context methods.
 
 use crate::error::{Result, UltimoError};
+use http_body_util::combinators::BoxBody;
 use http_body_util::Full;
-use hyper::{body::Bytes, header::HeaderValue, Response as HyperResponse, StatusCode};
+use hyper::body::{Body as HttpBody, Bytes, Frame, SizeHint};
+use hyper::{header::HeaderValue, Response as HyperResponse, StatusCode};
 use serde::Serialize;
 use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+
+/// Boxed error carried by a streaming response body. A stream item that yields
+/// `Err(_)` aborts the response connection.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The response body used throughout Ultimo.
+///
+/// `Full` is the buffered fast path — the overwhelmingly common case, with no
+/// per-response boxing. `Stream` carries an incrementally produced body (see
+/// [`Context::stream`](crate::context::Context::stream)).
+pub enum UltimoBody {
+    /// A fully-buffered body.
+    Full(Full<Bytes>),
+    /// A streaming body.
+    Stream(BoxBody<Bytes, BoxError>),
+}
+
+impl UltimoBody {
+    /// An empty buffered body.
+    pub fn empty() -> Self {
+        UltimoBody::Full(Full::new(Bytes::new()))
+    }
+
+    /// A buffered body from any bytes-like value.
+    pub fn full(bytes: impl Into<Bytes>) -> Self {
+        UltimoBody::Full(Full::new(bytes.into()))
+    }
+}
+
+impl HttpBody for UltimoBody {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
+        match self.get_mut() {
+            // `Full`'s error is `Infallible`; box it to unify the error type.
+            UltimoBody::Full(f) => match Pin::new(f).poll_frame(cx) {
+                Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+                Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(Box::new(e) as BoxError))),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            },
+            UltimoBody::Stream(s) => Pin::new(s).poll_frame(cx),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        match self {
+            UltimoBody::Full(f) => f.is_end_stream(),
+            UltimoBody::Stream(s) => s.is_end_stream(),
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        match self {
+            UltimoBody::Full(f) => f.size_hint(),
+            UltimoBody::Stream(s) => s.size_hint(),
+        }
+    }
+}
 
 /// HTTP Response type used throughout Ultimo
-pub type Response = HyperResponse<Full<Bytes>>;
+pub type Response = HyperResponse<UltimoBody>;
 
 /// Response builder for constructing HTTP responses
 #[derive(Debug)]
@@ -83,7 +150,7 @@ impl ResponseBuilder {
         // Set body
         let body = self.body.unwrap_or_default();
         response
-            .body(Full::new(Bytes::from(body)))
+            .body(UltimoBody::full(body))
             .map_err(|e| UltimoError::Internal(format!("Failed to build response: {}", e)))
     }
 }
@@ -183,5 +250,23 @@ mod tests {
         assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn ultimo_body_full_round_trips() {
+        use http_body_util::BodyExt;
+        let body = UltimoBody::full("hello world");
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(&bytes[..], b"hello world");
+    }
+
+    #[tokio::test]
+    async fn ultimo_body_empty_is_zero_length() {
+        use http_body_util::BodyExt;
+        use hyper::body::Body as _;
+        let body = UltimoBody::empty();
+        assert!(body.is_end_stream());
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(bytes.len(), 0);
     }
 }

--- a/ultimo/src/static_files.rs
+++ b/ultimo/src/static_files.rs
@@ -2,9 +2,10 @@
 //!
 //! Enabled by the `static-files` Cargo feature.
 
-use crate::{error::UltimoError, response::Response};
-use bytes::Bytes;
-use http_body_util::Full;
+use crate::{
+    error::UltimoError,
+    response::{Response, UltimoBody},
+};
 use hyper::{header, StatusCode};
 use std::path::Path;
 
@@ -67,7 +68,7 @@ pub(crate) async fn serve_file(
         if inm.trim() == etag.as_str() {
             return Ok(hyper::Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
-                .body(Full::new(Bytes::new()))
+                .body(UltimoBody::empty())
                 .unwrap());
         }
     }
@@ -87,6 +88,6 @@ pub(crate) async fn serve_file(
         .header(header::CONTENT_TYPE, mime)
         .header(header::ETAG, etag)
         .header(header::CONTENT_LENGTH, content.len())
-        .body(Full::new(Bytes::from(content)))
+        .body(UltimoBody::full(content))
         .unwrap())
 }

--- a/ultimo/src/websocket/upgrade.rs
+++ b/ultimo/src/websocket/upgrade.rs
@@ -4,8 +4,6 @@ use super::connection::{ConnectionHandler, WebSocket};
 use super::frame::Message;
 use super::pubsub::ChannelManager;
 use super::WebSocketConfig;
-use bytes::Bytes;
-use http_body_util::Full;
 use hyper::header::{
     CONNECTION, ORIGIN, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION, UPGRADE,
 };
@@ -92,7 +90,7 @@ where
     }
 
     /// Set callback to be executed when WebSocket is upgraded
-    pub fn on_upgrade<F, Fut>(self, callback: F) -> HyperResponse<Full<Bytes>>
+    pub fn on_upgrade<F, Fut>(self, callback: F) -> crate::response::Response
     where
         F: FnOnce(WebSocket<T>) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send + 'static,
@@ -102,7 +100,7 @@ where
         if !is_valid_upgrade_request(&self.request) {
             return HyperResponse::builder()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Full::new(Bytes::from("Invalid WebSocket upgrade request")))
+                .body(crate::response::UltimoBody::full("Invalid WebSocket upgrade request"))
                 .unwrap();
         }
 
@@ -110,7 +108,7 @@ where
         if !origin_allowed(&self.allowed_origins, request_origin(&self.request)) {
             return HyperResponse::builder()
                 .status(StatusCode::FORBIDDEN)
-                .body(Full::new(Bytes::from("Origin not allowed")))
+                .body(crate::response::UltimoBody::full("Origin not allowed"))
                 .unwrap();
         }
 
@@ -120,7 +118,7 @@ where
             None => {
                 return HyperResponse::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(Full::new(Bytes::from("Missing Sec-WebSocket-Key header")))
+                    .body(crate::response::UltimoBody::full("Missing Sec-WebSocket-Key header"))
                     .unwrap();
             }
         };
@@ -140,7 +138,7 @@ where
             response = response.header(key, value);
         }
 
-        let response = response.body(Full::new(Bytes::new())).unwrap();
+        let response = response.body(crate::response::UltimoBody::empty()).unwrap();
 
         // Spawn upgrade handler
         let data = self.data.expect("WebSocket data not set");
@@ -195,7 +193,7 @@ where
     }
 
     /// Set callback that receives incoming messages through a channel
-    pub fn on_upgrade_with_receiver<F, Fut>(self, callback: F) -> HyperResponse<Full<Bytes>>
+    pub fn on_upgrade_with_receiver<F, Fut>(self, callback: F) -> crate::response::Response
     where
         F: FnOnce(
                 WebSocket<T>,
@@ -211,7 +209,7 @@ where
         if !is_valid_upgrade_request(&self.request) {
             return HyperResponse::builder()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Full::new(Bytes::from("Invalid WebSocket upgrade request")))
+                .body(crate::response::UltimoBody::full("Invalid WebSocket upgrade request"))
                 .unwrap();
         }
 
@@ -219,7 +217,7 @@ where
         if !origin_allowed(&self.allowed_origins, request_origin(&self.request)) {
             return HyperResponse::builder()
                 .status(StatusCode::FORBIDDEN)
-                .body(Full::new(Bytes::from("Origin not allowed")))
+                .body(crate::response::UltimoBody::full("Origin not allowed"))
                 .unwrap();
         }
 
@@ -229,7 +227,7 @@ where
             None => {
                 return HyperResponse::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(Full::new(Bytes::from("Missing Sec-WebSocket-Key header")))
+                    .body(crate::response::UltimoBody::full("Missing Sec-WebSocket-Key header"))
                     .unwrap();
             }
         };
@@ -249,7 +247,7 @@ where
             response = response.header(key, value);
         }
 
-        let response = response.body(Full::new(Bytes::new())).unwrap();
+        let response = response.body(crate::response::UltimoBody::empty()).unwrap();
 
         // Spawn upgrade handler
         let data = self.data.expect("WebSocket data not set");
@@ -298,7 +296,7 @@ where
     }
 
     /// Build the upgrade response without a callback (for manual handling)
-    pub fn build(self) -> HyperResponse<Full<Bytes>>
+    pub fn build(self) -> crate::response::Response
     where
         T: Default,
     {

--- a/ultimo/src/websocket/upgrade.rs
+++ b/ultimo/src/websocket/upgrade.rs
@@ -100,7 +100,9 @@ where
         if !is_valid_upgrade_request(&self.request) {
             return HyperResponse::builder()
                 .status(StatusCode::BAD_REQUEST)
-                .body(crate::response::UltimoBody::full("Invalid WebSocket upgrade request"))
+                .body(crate::response::UltimoBody::full(
+                    "Invalid WebSocket upgrade request",
+                ))
                 .unwrap();
         }
 
@@ -118,7 +120,9 @@ where
             None => {
                 return HyperResponse::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(crate::response::UltimoBody::full("Missing Sec-WebSocket-Key header"))
+                    .body(crate::response::UltimoBody::full(
+                        "Missing Sec-WebSocket-Key header",
+                    ))
                     .unwrap();
             }
         };
@@ -209,7 +213,9 @@ where
         if !is_valid_upgrade_request(&self.request) {
             return HyperResponse::builder()
                 .status(StatusCode::BAD_REQUEST)
-                .body(crate::response::UltimoBody::full("Invalid WebSocket upgrade request"))
+                .body(crate::response::UltimoBody::full(
+                    "Invalid WebSocket upgrade request",
+                ))
                 .unwrap();
         }
 
@@ -227,7 +233,9 @@ where
             None => {
                 return HyperResponse::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(crate::response::UltimoBody::full("Missing Sec-WebSocket-Key header"))
+                    .body(crate::response::UltimoBody::full(
+                        "Missing Sec-WebSocket-Key header",
+                    ))
                     .unwrap();
             }
         };

--- a/ultimo/tests/compression.rs
+++ b/ultimo/tests/compression.rs
@@ -97,7 +97,7 @@ async fn image_content_type_not_compressed() {
         Ok(hyper::Response::builder()
             .status(200)
             .header("content-type", "image/png")
-            .body(Full::new(Bytes::from(vec![0u8; 2048])))
+            .body(ultimo::response::UltimoBody::full(vec![0u8; 2048]))
             .unwrap())
     });
 
@@ -151,7 +151,7 @@ async fn already_encoded_response_not_double_compressed() {
             .status(200)
             .header("content-type", "text/plain")
             .header("content-encoding", "gzip") // already encoded
-            .body(Full::new(Bytes::from(vec![0u8; 2048])))
+            .body(ultimo::response::UltimoBody::full(vec![0u8; 2048]))
             .unwrap())
     });
 

--- a/ultimo/tests/streaming.rs
+++ b/ultimo/tests/streaming.rs
@@ -34,6 +34,7 @@ async fn ctx_stream_sends_chunks_without_content_length() {
     assert_eq!(&body[..], b"chunk-1;chunk-2;chunk-3");
 }
 
+#[cfg(feature = "compression")]
 #[tokio::test]
 async fn compression_passes_streaming_bodies_through() {
     use ultimo::middleware::builtin::compression;
@@ -62,6 +63,7 @@ async fn compression_passes_streaming_bodies_through() {
     assert_eq!(body.len(), 100 * 64);
 }
 
+#[cfg(feature = "compression")]
 #[tokio::test]
 async fn compression_still_compresses_buffered_bodies() {
     use ultimo::middleware::builtin::compression;

--- a/ultimo/tests/streaming.rs
+++ b/ultimo/tests/streaming.rs
@@ -53,7 +53,9 @@ async fn compression_passes_streaming_bodies_through() {
         .unwrap();
     let resp = app.oneshot(req).await;
     assert!(
-        resp.headers().get(hyper::header::CONTENT_ENCODING).is_none(),
+        resp.headers()
+            .get(hyper::header::CONTENT_ENCODING)
+            .is_none(),
         "streaming bodies must not be compressed"
     );
     let body = resp.into_body().collect().await.unwrap().to_bytes();

--- a/ultimo/tests/streaming.rs
+++ b/ultimo/tests/streaming.rs
@@ -34,6 +34,62 @@ async fn ctx_stream_sends_chunks_without_content_length() {
     assert_eq!(&body[..], b"chunk-1;chunk-2;chunk-3");
 }
 
+#[tokio::test]
+async fn ctx_stream_drops_queued_content_length() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/stream", |ctx: Context| async move {
+        // A stale/incorrect length that must not survive onto a chunked body.
+        ctx.header("Content-Length", "1024").await;
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![Ok(Bytes::from("abc"))];
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let resp = app.oneshot(empty_req("/stream")).await;
+    assert!(
+        resp.headers().get(hyper::header::CONTENT_LENGTH).is_none(),
+        "a queued Content-Length must be dropped for a chunked streaming body"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"abc");
+}
+
+#[tokio::test]
+async fn ctx_stream_defaults_content_type_to_octet_stream() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/stream", |ctx: Context| async move {
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![Ok(Bytes::from("x"))];
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let resp = app.oneshot(empty_req("/stream")).await;
+    assert_eq!(
+        resp.headers()
+            .get(hyper::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/octet-stream"),
+        "a streamed body with no explicit type should default to octet-stream"
+    );
+}
+
+#[tokio::test]
+async fn ctx_stream_preserves_explicit_content_type() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/stream", |ctx: Context| async move {
+        ctx.header("Content-Type", "text/csv").await;
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![Ok(Bytes::from("a,b\n1,2\n"))];
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let resp = app.oneshot(empty_req("/stream")).await;
+    assert_eq!(
+        resp.headers()
+            .get(hyper::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("text/csv"),
+        "an explicit Content-Type must not be overridden by the default"
+    );
+}
+
 #[cfg(feature = "compression")]
 #[tokio::test]
 async fn compression_passes_streaming_bodies_through() {

--- a/ultimo/tests/streaming.rs
+++ b/ultimo/tests/streaming.rs
@@ -1,0 +1,35 @@
+//! Integration tests for streaming response bodies.
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::Request as HyperRequest;
+use ultimo::prelude::*;
+use ultimo::response::BoxError;
+
+fn empty_req(uri: &str) -> HyperRequest<Full<Bytes>> {
+    HyperRequest::builder()
+        .uri(uri)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn ctx_stream_sends_chunks_without_content_length() {
+    let mut app = Ultimo::new_without_defaults();
+    app.get("/stream", |ctx: Context| async move {
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> = vec![
+            Ok(Bytes::from("chunk-1;")),
+            Ok(Bytes::from("chunk-2;")),
+            Ok(Bytes::from("chunk-3")),
+        ];
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let resp = app.oneshot(empty_req("/stream")).await;
+    assert_eq!(resp.status(), 200);
+    assert!(
+        resp.headers().get(hyper::header::CONTENT_LENGTH).is_none(),
+        "streamed responses must not carry Content-Length"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"chunk-1;chunk-2;chunk-3");
+}

--- a/ultimo/tests/streaming.rs
+++ b/ultimo/tests/streaming.rs
@@ -33,3 +33,53 @@ async fn ctx_stream_sends_chunks_without_content_length() {
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     assert_eq!(&body[..], b"chunk-1;chunk-2;chunk-3");
 }
+
+#[tokio::test]
+async fn compression_passes_streaming_bodies_through() {
+    use ultimo::middleware::builtin::compression;
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(compression());
+    app.get("/stream", |ctx: Context| async move {
+        // A large streamed body that would otherwise be well over min_size.
+        let chunks: Vec<std::result::Result<Bytes, BoxError>> =
+            (0..100).map(|_| Ok(Bytes::from("x".repeat(64)))).collect();
+        ctx.stream(futures_util::stream::iter(chunks)).await
+    });
+
+    let req = HyperRequest::builder()
+        .uri("/stream")
+        .header("Accept-Encoding", "br, gzip")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let resp = app.oneshot(req).await;
+    assert!(
+        resp.headers().get(hyper::header::CONTENT_ENCODING).is_none(),
+        "streaming bodies must not be compressed"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body.len(), 100 * 64);
+}
+
+#[tokio::test]
+async fn compression_still_compresses_buffered_bodies() {
+    use ultimo::middleware::builtin::compression;
+    let mut app = Ultimo::new_without_defaults();
+    app.use_middleware(compression());
+    app.get("/buffered", |ctx: Context| async move {
+        ctx.text("y".repeat(4096)).await
+    });
+
+    let req = HyperRequest::builder()
+        .uri("/buffered")
+        .header("Accept-Encoding", "gzip")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let resp = app.oneshot(req).await;
+    assert_eq!(
+        resp.headers()
+            .get(hyper::header::CONTENT_ENCODING)
+            .and_then(|v| v.to_str().ok()),
+        Some("gzip"),
+        "buffered bodies over min_size must still be compressed"
+    );
+}


### PR DESCRIPTION
## Summary

Adds chunked/streaming response bodies via `ctx.stream(...)` — the foundation for typed SSE (#2). Replaces the hardwired `Full<Bytes>` response body with an `UltimoBody` enum that keeps a **zero-boxing fast path** for buffered responses and adds a streaming variant.

- `UltimoBody::{Full, Stream}` implementing `hyper::body::Body<Data = Bytes, Error = BoxError>`; `type Response = hyper::Response<UltimoBody>`.
- `ctx.stream(s)` where `s: Stream<Item = Result<Bytes, BoxError>>` → chunked, no `Content-Length`; applies queued headers/status.
- Compression **skips streaming bodies** (only buffers/compresses `Full`), so a stream is never drained into memory.
- Buffered responses (`text`/`json`/`html`) are unchanged — same allocation profile as before.

## Breaking change → 0.9.0

`Response`'s public body type changes from `Full<Bytes>` to `UltimoBody`. `res.into_body()` still `impl Body` (`.collect()` works); code that names `HyperResponse<Full<Bytes>>` on the *response* side must switch to `UltimoBody`. Request side is unchanged. `semver-checks` will flag this — expected for a `feat!`.

## Notes

- No new dependency: uses the already-present `futures-util`. The design spec's `futures-core` addition proved unnecessary.
- Streaming variant uses `UnsyncBoxBody` (hyper only requires `Send`, not `Sync`), so non-`Sync` streams work.

## Tests

- Unit: `UltimoBody::{full,empty,stream}` round-trips.
- Integration (`tests/streaming.rs`): `ctx.stream` emits chunks with no `Content-Length`; compression passes streaming bodies through uncompressed while still compressing buffered bodies.
- Docs + runnable `examples/streaming` (browser `fetch` reader).

## Docs

api-reference, new `streaming.mdx` + sidebar, roadmap moved to ✅ 0.9.0, README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)