### PR TITLE
chore: release v0.9.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.9.0** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.9.1** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-09-01
+
+### Added
+
+- *(cli)* ultimo mcp server for AI coding agents ([#179](https://github.com/ultimo-rs/ultimo/pull/179))
+- *(cli)* agent-proof scaffolding ([#176](https://github.com/ultimo-rs/ultimo/pull/176))
+
 ## [0.9.0] - 2026-08-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WebSocket support with built-in pub/sub. Built on **Hyper 1.0 + Tokio**.
 
 - Homepage: https://ultimo.dev · Docs: https://docs.ultimo.dev · Roadmap: https://docs.ultimo.dev/roadmap
 - Repo: https://github.com/ultimo-rs/ultimo · Issues: https://github.com/ultimo-rs/ultimo/issues · Board: https://github.com/orgs/ultimo-rs/projects/1
-- Current version: **0.9.0** · Edition 2021 · MSRV **1.86.0** · License MIT
+- Current version: **0.9.1** · Edition 2021 · MSRV **1.86.0** · License MIT
 
 ## ⚠️ THESE ARE PUBLISHED CRATES — read before changing any public code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-example"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-auth-example"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-modes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "session-auth-example"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4045,7 +4045,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultimo"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "ultimo-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ultimo", "examples/basic", "examples/rpc-modes", "examples/openapi-d
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Ultimo Contributors"]

--- a/docs-site/docs/pages/changelog.mdx
+++ b/docs-site/docs/pages/changelog.mdx
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-09-01
+
+### Added
+
+- *(cli)* ultimo mcp server for AI coding agents ([#179](https://github.com/ultimo-rs/ultimo/pull/179))
+- *(cli)* agent-proof scaffolding ([#176](https://github.com/ultimo-rs/ultimo/pull/176))
+
 ## [0.9.0] - 2026-08-16
 
 ### Added

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-site",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vocs dev",

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -93,31 +93,45 @@ fi
 # files, yet `check-versions.sh` requires their newest released heading to match
 # the workspace version. Mirror the newest per-crate section into them so a
 # release PR passes the version-sync gate without hand editing.
-CRATE_CHANGELOG="ultimo/CHANGELOG.md"
+# A release may bump the library, the CLI, or both, so mirror the `## [VERSION]`
+# section from whichever per-crate changelog actually carries it (prefer the
+# library's when both do).
+pick_crate_changelog() {
+  local f
+  for f in ultimo/CHANGELOG.md ultimo-cli/CHANGELOG.md; do
+    [ -f "$f" ] && grep -q "^## \[$VERSION\]" "$f" && {
+      echo "$f"
+      return
+    }
+  done
+}
+
 promote_changelog() {
   local file="$1"
   [ -f "$file" ] || return 0
-  [ -f "$CRATE_CHANGELOG" ] || return 0
   # Idempotent: skip if this version is already the newest released entry.
   if grep -q "^## \[$VERSION\]" "$file"; then
     return 0
   fi
 
-  # Extract the newest released section from the per-crate changelog (from its
-  # first non-Unreleased `## [` heading up to the next `## [` heading), and
+  local src
+  src=$(pick_crate_changelog)
+  if [ -z "$src" ]; then
+    echo "  ⚠️  no per-crate changelog has a v$VERSION section; skipping $file"
+    return 0
+  fi
+
+  # Extract that exact `## [VERSION]` section (up to the next `## [` heading) and
   # rewrite the heading `## [x.y.z](compare-url) - DATE` → `## [x.y.z] - DATE`.
   local block
-  block=$(awk '
-    /^## \[/ {
-      if ($0 ~ /Unreleased/) next
-      sec++
-      grab = (sec == 1) ? 1 : 0
-    }
+  block=$(awk -v ver="$VERSION" '
+    index($0, "## [" ver "]") == 1 { grab = 1; print; next }
+    grab && /^## \[/ { grab = 0 }
     grab { print }
-  ' "$CRATE_CHANGELOG" | sed -E "s/^## \[$VERSION\]\([^)]*\)/## [$VERSION]/")
+  ' "$src" | sed -E "s/^## \[$VERSION\]\([^)]*\)/## [$VERSION]/")
 
   if [ -z "$block" ] || ! printf '%s' "$block" | grep -q "^## \[$VERSION\]"; then
-    echo "  ⚠️  could not extract v$VERSION section from $CRATE_CHANGELOG; skipping $file"
+    echo "  ⚠️  could not extract v$VERSION section from $src; skipping $file"
     return 0
   fi
 

--- a/ultimo-cli/CHANGELOG.md
+++ b/ultimo-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-cli-v0.9.0...ultimo-cli-v0.9.1) - 2026-09-01
+
+### Added
+
+- *(cli)* ultimo mcp server for AI coding agents ([#179](https://github.com/ultimo-rs/ultimo/pull/179))
+- *(cli)* agent-proof scaffolding ([#176](https://github.com/ultimo-rs/ultimo/pull/176))
+
 ## [0.6.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-cli-v0.5.1...ultimo-cli-v0.6.0) - 2026-07-08
 
 ### Added

--- a/website/components/hero-section.tsx
+++ b/website/components/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
       <div className="container px-4 md:px-6 mx-auto flex flex-col items-center text-center relative z-10">
         <div className="inline-flex items-center rounded-full border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-sm font-medium text-orange-400 mb-8 backdrop-blur-sm">
           <span className="flex h-2 w-2 rounded-full bg-orange-500 mr-2 animate-pulse"></span>
-          v0.9.0 Now Available
+          v0.9.1 Now Available
         </div>
 
         <h1 className="font-bold tracking-tight mb-6 max-w-4xl text-center">

--- a/website/content/posts/ultimo-vs-axum-comparison.mdx
+++ b/website/content/posts/ultimo-vs-axum-comparison.mdx
@@ -300,7 +300,7 @@ Let's be direct: **Axum has a larger ecosystem and is more mature.** It reached 
 
 | Metric                  | Ultimo                                           | Axum                       |
 | ----------------------- | ------------------------------------------------ | -------------------------- |
-| **Current version**     | [0.9.0](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
+| **Current version**     | [0.9.1](/blog/introducing-ultimo-v0-5) (pre-1.0) | 0.8.x (post-1.0 stability) |
 | **First release**       | 2024                                             | 2021                       |
 | **Community crates**    | Growing                                          | Hundreds                   |
 | **Production users**    | Early adopters                                   | Major companies            |

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-v0-project",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION



## 🤖 New release

* `ultimo`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `ultimo-cli`: 0.9.0 -> 0.9.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `ultimo`

<blockquote>

## [0.9.0](https://github.com/ultimo-rs/ultimo/compare/ultimo-v0.8.0...ultimo-v0.9.0) - 2026-08-16

### Added

- typed Server-Sent Events (ctx.sse + SseEvent) ([#173](https://github.com/ultimo-rs/ultimo/pull/173))
- [**breaking**] streaming response bodies (UltimoBody + ctx.stream) ([#171](https://github.com/ultimo-rs/ultimo/pull/171))
</blockquote>

## `ultimo-cli`

<blockquote>

## [0.9.1](https://github.com/ultimo-rs/ultimo/compare/ultimo-cli-v0.9.0...ultimo-cli-v0.9.1) - 2026-09-01

### Added

- *(cli)* ultimo mcp server for AI coding agents ([#179](https://github.com/ultimo-rs/ultimo/pull/179))
- *(cli)* agent-proof scaffolding ([#176](https://github.com/ultimo-rs/ultimo/pull/176))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).