### PR TITLE
ci: auto-sync derived version surfaces on the release PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -51,11 +51,44 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use the PAT so commits this job pushes to the release PR branch
+          # (the version sync below) re-trigger CI, same rationale as the PR itself.
+          token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz (release-pr)
+        id: release-pr
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      # release-plz bumps only the Cargo workspace version + per-crate changelog.
+      # Propagate that to the repo's derived version surfaces (docs/website
+      # package.json, hero badge, install snippets, CLAUDE.md/AGENTS.md/blog) and
+      # promote the root + docs changelogs — the surfaces the version-sync gate
+      # checks — then push them onto the release PR branch. Without this, every
+      # release PR fails version-sync. Self-healing: re-runs re-apply the sync.
+      - name: Sync derived version surfaces onto the release PR
+        if: ${{ steps.release-pr.outputs.pr != '' }}
+        env:
+          RELEASE_PR: ${{ steps.release-pr.outputs.pr }}
+        run: |
+          set -euo pipefail
+          BRANCH=$(printf '%s' "$RELEASE_PR" | jq -r '.head_branch // empty')
+          if [ -z "$BRANCH" ]; then
+            echo "No release PR branch reported; nothing to sync."
+            exit 0
+          fi
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          bash scripts/sync-versions.sh
+          if git diff --quiet; then
+            echo "Derived surfaces already in sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: sync derived version surfaces + changelogs"
+          git push origin "$BRANCH"

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -87,4 +87,59 @@ if [ -f "$ROADMAP" ]; then
   echo "  updated $ROADMAP — (Current) → v$VERSION"
 fi
 
+# Promote the hand-maintained root changelogs (CHANGELOG.md + the docs-site
+# changelog page) to the release version. release-plz maintains the per-crate
+# `ultimo/CHANGELOG.md` from Conventional Commits but never touches these two
+# files, yet `check-versions.sh` requires their newest released heading to match
+# the workspace version. Mirror the newest per-crate section into them so a
+# release PR passes the version-sync gate without hand editing.
+CRATE_CHANGELOG="ultimo/CHANGELOG.md"
+promote_changelog() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  [ -f "$CRATE_CHANGELOG" ] || return 0
+  # Idempotent: skip if this version is already the newest released entry.
+  if grep -q "^## \[$VERSION\]" "$file"; then
+    return 0
+  fi
+
+  # Extract the newest released section from the per-crate changelog (from its
+  # first non-Unreleased `## [` heading up to the next `## [` heading), and
+  # rewrite the heading `## [x.y.z](compare-url) - DATE` → `## [x.y.z] - DATE`.
+  local block
+  block=$(awk '
+    /^## \[/ {
+      if ($0 ~ /Unreleased/) next
+      sec++
+      grab = (sec == 1) ? 1 : 0
+    }
+    grab { print }
+  ' "$CRATE_CHANGELOG" | sed -E "s/^## \[$VERSION\]\([^)]*\)/## [$VERSION]/")
+
+  if [ -z "$block" ] || ! printf '%s' "$block" | grep -q "^## \[$VERSION\]"; then
+    echo "  ⚠️  could not extract v$VERSION section from $CRATE_CHANGELOG; skipping $file"
+    return 0
+  fi
+
+  # Insert the block right after the `## [Unreleased]` heading.
+  local tmp
+  tmp=$(mktemp)
+  printf '%s\n' "$block" > "$tmp"
+  awk -v blockfile="$tmp" '
+    /^## \[Unreleased\]/ && !done {
+      print
+      print ""
+      while ((getline line < blockfile) > 0) print line
+      done = 1
+      next
+    }
+    { print }
+  ' "$file" > "$file.new" && mv "$file.new" "$file"
+  rm -f "$tmp"
+  echo "  promoted $file — [Unreleased] → [$VERSION]"
+}
+
+promote_changelog CHANGELOG.md
+promote_changelog docs-site/docs/pages/changelog.mdx
+
 echo "✅ Done. Review with: git diff"


### PR DESCRIPTION
## Problem

release-plz bumps only the Cargo workspace version and the per-crate `ultimo/CHANGELOG.md`. It never touches the repo's *other* version surfaces — docs/website `package.json`, the hero badge, `ultimo = "x.y"` install snippets, `CLAUDE.md`/`AGENTS.md`/blog, and the hand-maintained root `CHANGELOG.md` + docs `changelog.mdx` — yet the `version-sync` CI gate requires all of them to match. Result: **every release PR fails `version-sync`** (most recently #172, which had to be fixed by hand).

## Fix

- **`scripts/sync-versions.sh`** now also promotes the two root changelogs, mirroring the newest section of the release-plz-maintained `ultimo/CHANGELOG.md` (`## [x.y.z](compare-url) - DATE` → `## [x.y.z] - DATE`, inserted after `[Unreleased]`). Single source of truth: commits → release-plz per-crate changelog → root changelogs. Idempotent (skips if the version is already the newest entry).
- **`.github/workflows/release-plz.yml`** — the `release-plz-pr` job now runs `sync-versions.sh` on the release PR branch after release-plz creates it and pushes the result (via the PAT so CI re-triggers). Self-healing: re-runs re-apply the sync.

## Verification

- Idempotent on an already-synced tree (no-op).
- Changelog promotion verified on a fixture (URL stripped, inserted after `[Unreleased]`, prior entries preserved).
- `check-versions.sh` green; workflow YAML parses.
- release-plz output passed via `env:` (injection-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)