### PR TITLE
docs: guide for using Ultimo with AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     <a href="https://github.com/ultimo-rs/ultimo/blob/main/SECURITY.md"><img src="https://img.shields.io/badge/unsafe-forbidden-success.svg?style=flat-square" alt="Unsafe forbidden" /></a>
     <a href="https://deps.rs/repo/github/ultimo-rs/ultimo"><img src="https://deps.rs/repo/github/ultimo-rs/ultimo/status.svg?style=flat-square" alt="Dependency status" /></a>
     <img src="https://img.shields.io/badge/MSRV-1.86-blue.svg?style=flat-square" alt="MSRV 1.86" />
+    <a href="https://context7.com/ultimo-rs/ultimo"><img src="https://img.shields.io/badge/Context7-indexed-4B32C3.svg?style=flat-square" alt="Context7 indexed" /></a>
   </p>
 
   <p>
@@ -45,6 +46,7 @@ the framework is 100% safe Rust (`#![forbid(unsafe_code)]`).
 - ⚡ **Fast** — native Rust on the Hyper + Tokio core, O(1) constant-time routing, benchmarks regression-guarded in CI ([details](https://docs.ultimo.dev/performance)).
 - 🗄️ **Databases** — first-class SQLx and Diesel integration (PostgreSQL / MySQL / SQLite).
 - 🧪 **Testing utilities** — in-process `TestClient`, response assertions, and fixtures.
+- 🤖 **Built for coding agents** — typed Rust→TS codegen, scaffolds that build, [`llms.txt`](https://docs.ultimo.dev/llms.txt) docs, and [Context7](https://context7.com/ultimo-rs/ultimo). See [Using Ultimo with AI coding agents](https://docs.ultimo.dev/ai-agents).
 
 ## Quick start
 

--- a/docs-site/docs/pages/ai-agents.mdx
+++ b/docs-site/docs/pages/ai-agents.mdx
@@ -1,0 +1,69 @@
+# Using Ultimo with AI coding agents
+
+Ultimo is built to be **easy for coding agents to build with** — Cursor, Claude
+Code, GitHub Copilot, and friends. This page shows how to point your agent at
+Ultimo's machine-readable docs, drop in a project ruleset, and (soon) connect the
+Ultimo MCP server.
+
+## Why Ultimo is agent-friendly
+
+- **Typed contracts, generated clients.** You write your API once in Rust
+  (`RpcRegistry`), and the TypeScript client — types and all — is generated from
+  it. The agent never hand-writes or guesses client types; they're derived. See
+  [TypeScript Clients](/typescript) and the [RPC System](/rpc).
+- **Scaffolds that build.** `ultimo new` produces projects that compile out of the
+  box, with dependency pins that track the current release — no stale-version
+  dead ends.
+- **One obvious way.** Convention-over-config and opt-in Cargo features mean fewer
+  choices for an agent to get wrong.
+
+## 1. Point your agent at the docs
+
+Ultimo's docs are published in the machine-readable
+[llms.txt](https://llmstxt.org) format, which agents fetch to ground themselves
+in the current API instead of stale training data:
+
+- **Index:** [`https://docs.ultimo.dev/llms.txt`](https://docs.ultimo.dev/llms.txt) — every page with a one-line summary.
+- **Full corpus:** [`https://docs.ultimo.dev/llms-full.txt`](https://docs.ultimo.dev/llms-full.txt) — the complete docs in one file.
+
+Most agents pick these up automatically when you add the docs site as a
+documentation source. In Cursor, add `https://docs.ultimo.dev` under
+**Settings → Indexing → Docs**; in Claude Code, reference the URL in your prompt
+or `CLAUDE.md`.
+
+## 2. Use Context7
+
+Ultimo is indexed on [Context7](https://context7.com/ultimo-rs/ultimo), which
+serves version-accurate snippets to agents on demand. If your agent supports the
+Context7 MCP server, it can pull Ultimo examples mid-task. Point it at the library
+id `ultimo-rs/ultimo`.
+
+## 3. Add a project ruleset
+
+Every project scaffolded with `ultimo new` includes an **`AGENTS.md`** — working
+notes that orient an agent to that project's conventions (how to add a route or
+RPC procedure, the feature flags, the run/test/generate commands). It follows the
+[AGENTS.md](https://agents.md) open standard, which Cursor, Claude Code, and
+others read automatically.
+
+If you started from an existing project, drop an `AGENTS.md` at its root with the
+same content — see the scaffolded file for a template.
+
+## 4. The Ultimo MCP server (coming soon)
+
+An `ultimo mcp` server is in development. It will give your agent live, typed
+tools instead of guesswork — searching the docs, listing runnable examples,
+scaffolding projects, and **introspecting your project's RPC surface** (so the
+agent can ask "what's my typed API?" and get an exact answer). Tracked on the
+[roadmap](/roadmap); this page will document the setup when it ships.
+
+## Prompting tips
+
+- Ask the agent to **regenerate the client** (`ultimo generate -o ./client.ts`)
+  after changing any RPC type — the generated client is the source of truth for
+  the frontend.
+- Handlers return `Result<Response>`; nudge the agent to return
+  `Err(UltimoError::…)` for error cases rather than panicking.
+- Point it at the specific docs page for the feature it's using (e.g.
+  [Authentication](/jwt), [Sessions](/sessions), [WebSocket](/websocket),
+  [SSE](/sse)) — each page's examples are self-contained and compile.

--- a/docs-site/docs/public/_headers
+++ b/docs-site/docs/public/_headers
@@ -5,3 +5,10 @@
   Permissions-Policy: interest-cohort=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Access-Control-Allow-Origin: https://ultimo.dev
+
+# Machine-readable docs are meant to be fetched from anywhere (coding agents,
+# in-browser tools), so allow cross-origin reads of just these files.
+/llms.txt
+  Access-Control-Allow-Origin: *
+/llms-full.txt
+  Access-Control-Allow-Origin: *

--- a/docs-site/docs/public/robots.txt
+++ b/docs-site/docs/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# Machine-readable documentation for LLMs and coding agents:
+#   https://docs.ultimo.dev/llms.txt        — index of docs pages with summaries
+#   https://docs.ultimo.dev/llms-full.txt   — the full documentation corpus

--- a/docs-site/vocs.config.ts
+++ b/docs-site/vocs.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
           link: "/api-reference",
         },
         {
+          text: "AI Coding Agents",
+          link: "/ai-agents",
+        },
+        {
           text: "Performance",
           link: "/performance",
         },


### PR DESCRIPTION
WS2 of the **AI-native initiative** — make Ultimo's docs best-in-class for coding agents.

- **New page** `AI Coding Agents` (`/ai-agents`, in the sidebar): how to point Cursor / Claude Code / Copilot at Ultimo's `llms.txt` + Context7, use the scaffolded `AGENTS.md` ruleset, and (stubbed until it ships) the `ultimo mcp` server. Plus why Ultimo is agent-friendly (typed codegen, scaffolds that build) and prompting tips.
- **Discoverability**: `robots.txt` advertising the auto-generated `llms.txt` / `llms-full.txt`, and a permissive CORS header on just those two files so agent tools can fetch them cross-origin.
- **README**: Context7 badge + a "Built for coding agents" line linking the new page.

Docs-only; the Vocs/Vercel build validates the MDX + sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)