### PR TITLE
feat(website): add AI-native positioning pillar

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,3 +1,4 @@
+import { AiNativeSection } from "@/components/ai-native-section";
 import { BlogSection } from "@/components/blog-section";
 import { ComparisonSection } from "@/components/comparison-section";
 import { CTASection } from "@/components/cta-section";
@@ -15,6 +16,7 @@ export default function Home() {
         <HeroSection />
         <UseCasesSection />
         <FeaturesSection />
+        <AiNativeSection />
         <StatsSection />
         <SecuritySection />
         <TypeSafeSection />

--- a/website/components/ai-native-section.tsx
+++ b/website/components/ai-native-section.tsx
@@ -1,0 +1,85 @@
+import { Bot, FileType, PackageCheck, Plug } from "lucide-react";
+
+const pillars = [
+  {
+    icon: FileType,
+    title: "Typed codegen",
+    description:
+      "Write your API once in Rust; the typed TypeScript client is generated from it. Agents never guess client types — they're derived.",
+  },
+  {
+    icon: PackageCheck,
+    title: "Scaffolds that build",
+    description:
+      "`ultimo new` produces projects that compile out of the box, with dependency pins that track the current release. No stale-version dead ends.",
+  },
+  {
+    icon: Bot,
+    title: "Docs agents can read",
+    description:
+      "Machine-readable llms.txt docs and a Context7-indexed corpus keep agents grounded in the current API. Every scaffold ships an AGENTS.md ruleset.",
+  },
+  {
+    icon: Plug,
+    title: "MCP server (soon)",
+    description:
+      "An `ultimo mcp` server will give your agent live, typed tools — search docs, scaffold, and introspect your project's RPC surface.",
+  },
+];
+
+export function AiNativeSection() {
+  return (
+    <section className="py-24 overflow-hidden relative">
+      <div className="absolute top-0 left-0 w-full h-full overflow-hidden -z-10 pointer-events-none">
+        <div className="absolute top-[-100px] right-[10%] w-[500px] h-[600px] bg-gradient-to-b from-orange-500/12 to-transparent blur-[100px]" />
+      </div>
+
+      <div className="container px-4 md:px-6 mx-auto">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1 mb-6 rounded-full border border-orange-500/20 bg-orange-500/10 text-orange-500 text-sm font-medium">
+            <Bot className="h-4 w-4" />
+            AI-native
+          </div>
+          <h2 className="text-3xl md:text-5xl font-bold mb-6 tracking-tight">
+            Built for you and your{" "}
+            <span className="text-gradient">coding agent</span>
+          </h2>
+          <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
+            Most software is now written with AI coding agents. Ultimo is designed
+            to be the easiest Rust framework for them to build with — typed
+            contracts, deterministic scaffolds, and docs made to be read by
+            machines.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-6xl mx-auto">
+          {pillars.map((pillar) => (
+            <div
+              key={pillar.title}
+              className="rounded-xl border border-border bg-card p-6 shadow-lg flex flex-col"
+            >
+              <div className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-lg bg-gradient-to-br from-orange-500 to-amber-500">
+                <pillar.icon className="h-5 w-5 text-white" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2 text-foreground">
+                {pillar.title}
+              </h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {pillar.description}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 text-center">
+          <a
+            href="https://docs.ultimo.dev/ai-agents"
+            className="inline-flex items-center gap-2 text-orange-500 hover:text-orange-400 font-medium transition-colors"
+          >
+            Using Ultimo with AI coding agents →
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/features-section.tsx
+++ b/website/components/features-section.tsx
@@ -2,6 +2,7 @@
 
 import {
   BookOpen,
+  Bot,
   Code2,
   FileType,
   Globe,
@@ -117,6 +118,18 @@ const featureCategories = [
           "Project scaffolding (ultimo new)",
           "Helpful error messages",
           "Great documentation",
+        ],
+      },
+      {
+        title: "AI-Native DX",
+        description:
+          "Built to be easy for coding agents to build with — Cursor, Claude Code, Copilot.",
+        icon: Bot,
+        details: [
+          "Typed Rust → TypeScript codegen",
+          "Scaffolds that build out of the box",
+          "llms.txt docs + Context7 indexed",
+          "AGENTS.md ruleset in every project",
         ],
       },
     ],

--- a/website/content/posts/ultimo-is-ai-native.mdx
+++ b/website/content/posts/ultimo-is-ai-native.mdx
@@ -1,0 +1,62 @@
+---
+title: "Ultimo is AI-Native: Building Rust Backends with Coding Agents"
+description: "Most software is now written with AI coding agents. Here's how Ultimo is designed to be the easiest Rust web framework for them to build with — typed codegen, scaffolds that build, and docs made to be read by machines."
+date: "2026-09-01"
+author: "Ultimo Team"
+tags: ["ai", "developer-experience", "typescript"]
+---
+
+# Ultimo is AI-Native: Building Rust Backends with Coding Agents
+
+The way software gets written has changed. A large and growing share of code is now produced by developers working *with* AI coding agents — Cursor, Claude Code, GitHub Copilot — rather than typed character by character. That shifts what makes a web framework good. The question is no longer only "is this ergonomic for a human?" but "can an agent build with this reliably, without dead ends?"
+
+Ultimo is built with that second question in mind. This post lays out what "AI-native" means for a framework, and the concrete things Ultimo does about it.
+
+## What makes a framework agent-friendly
+
+Agents fail in specific, predictable ways: they hallucinate APIs from stale training data, they copy examples that don't compile, they scaffold a project that won't build, and they lose the thread between the backend and the frontend types. An agent-native framework removes those failure modes.
+
+Three levers matter most:
+
+1. **Typed contracts the agent can't get wrong.** If types flow automatically from one source, the agent never has to hand-maintain a second copy.
+2. **Deterministic, buildable starting points.** Scaffolds and examples that compile the moment they're generated.
+3. **Docs written to be read by machines.** So the agent grounds itself in the *current* API, not last year's.
+
+## Typed codegen: write it once in Rust
+
+Ultimo's headline feature is also its most AI-native one. You define your API surface once as an `RpcRegistry` in Rust, and the fully typed TypeScript client — types and all — is *generated* from it:
+
+```rust
+rpc.query("getUser", |input: GetUserInput| async move {
+    Ok(User { /* ... */ })
+});
+```
+
+```bash
+ultimo generate -o ./client.ts
+```
+
+The agent writing the frontend never guesses the shape of `User` or the signature of `getUser` — they're derived from the Rust types. There's no second schema to drift out of sync, and a type change on the backend surfaces as a compile error on the frontend.
+
+## Scaffolds that build
+
+`ultimo new` produces projects that compile out of the box. Dependency pins track the current release automatically, so an agent never lands in the classic trap of a scaffold pinned to a version that no longer exists. The `rpc` template ships a real, working client generator wired to a shared registry — not a placeholder the agent has to reverse-engineer.
+
+Every scaffolded project also includes an **`AGENTS.md`** — a short ruleset, in the open [AGENTS.md](https://agents.md) format, that orients an agent to that project's conventions: how to add a route or an RPC procedure, which Cargo features exist, and the run/test/generate commands.
+
+## Docs made for machines
+
+Ultimo's documentation is published in the [`llms.txt`](https://llmstxt.org) format that coding agents fetch to ground themselves:
+
+- [`docs.ultimo.dev/llms.txt`](https://docs.ultimo.dev/llms.txt) — an index of every page with a summary.
+- [`docs.ultimo.dev/llms-full.txt`](https://docs.ultimo.dev/llms-full.txt) — the full corpus in one file.
+
+Ultimo is also indexed on [Context7](https://context7.com/ultimo-rs/ultimo), which serves version-accurate snippets to agents on demand. Every docs example is self-contained and compiles — because agents copy them verbatim.
+
+## What's next: the Ultimo MCP server
+
+The next step is an `ultimo mcp` server that gives an agent *live, typed tools* instead of guesswork: search the docs, list runnable examples, scaffold a project, and — the differentiator — **introspect your project's RPC surface**, so the agent can ask "what's my typed API?" and get an exact answer. It's on the [roadmap](https://docs.ultimo.dev/roadmap).
+
+## Try it
+
+If you build with a coding agent, point it at Ultimo's docs and let it go. The full guide is at [Using Ultimo with AI coding agents](https://docs.ultimo.dev/ai-agents).

--- a/website/lib/config.ts
+++ b/website/lib/config.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Ultimo",
   description:
-    "A modern, high-performance web framework for Rust. Type-safe, fast, and developer friendly.",
+    "A modern, high-performance web framework for Rust. Type-safe, fast, and built for you and your coding agent.",
   links: {
     docs: "https://docs.ultimo.dev",
     github: "https://github.com/ultimo-rs/ultimo",


### PR DESCRIPTION
WS4 of the **AI-native initiative** — augment the marketing site (keep the "Speed, Security & Efficiency" hero; add AI-native as a co-equal pillar, per the chosen direction).

- **New homepage section** `AiNativeSection` — "Built for you and your coding agent": typed Rust→TS codegen, scaffolds that build, machine-readable docs (llms.txt/Context7), and the MCP server (coming). Rendered after the features section, matching the site's design language.
- **Features tab**: an "AI-Native DX" card in Developer Tools.
- **`siteConfig.description`**: now names the agent audience.
- **Blog post**: "Ultimo is AI-Native: Building Rust Backends with Coding Agents".

Verified locally with `next build` — homepage and the new `/blog/ultimo-is-ai-native` post generate cleanly. Vercel preview will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)