### PR TITLE
feat(cli): ultimo mcp server for AI coding agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,12 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
       - uses: Swatinem/rust-cache@v2
+      # Only the `ultimo` library carries the advertised MSRV — it's the crate
+      # downstream users depend on. `ultimo-cli` (a standalone install-and-run
+      # tool) has a higher MSRV via its rmcp-based MCP server (edition 2024); it
+      # is built on stable by the `test` jobs.
       - name: cargo check (default + websocket + static-files + compression)
-        run: cargo check -p ultimo -p ultimo-cli --features "websocket,static-files,compression"
+        run: cargo check -p ultimo --features "websocket,static-files,compression"
 
   # ── Public-API breaking-change detection ──────────────────────────────
   # Guards the pre-1.0 public API against accidental SemVer breakage by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,12 +656,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -688,15 +694,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -723,13 +729,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.1",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1676,6 +1682,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2844,14 +2852,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
- "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "futures",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
@@ -2862,19 +2870,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -648,6 +649,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +687,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +717,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -856,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1097,6 +1138,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1176,6 +1218,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1473,7 +1516,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -1689,7 +1732,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2043,7 +2086,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2231,6 +2274,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -2469,7 +2518,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2507,9 +2556,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2677,6 +2726,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +2843,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "rpc-modes"
 version = "0.9.0"
 dependencies = [
@@ -2839,7 +2943,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2929,6 +3033,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3135,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3131,16 +3272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3456,6 +3587,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,7 +3648,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3650,7 +3792,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3944,6 +4086,8 @@ dependencies = [
  "notify 8.2.0",
  "notify-debouncer-mini",
  "predicates",
+ "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "tempfile",
@@ -4278,7 +4422,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs-site/docs/pages/ai-agents.mdx
+++ b/docs-site/docs/pages/ai-agents.mdx
@@ -49,13 +49,35 @@ others read automatically.
 If you started from an existing project, drop an `AGENTS.md` at its root with the
 same content — see the scaffolded file for a template.
 
-## 4. The Ultimo MCP server (coming soon)
+## 4. The Ultimo MCP server
 
-An `ultimo mcp` server is in development. It will give your agent live, typed
-tools instead of guesswork — searching the docs, listing runnable examples,
-scaffolding projects, and **introspecting your project's RPC surface** (so the
-agent can ask "what's my typed API?" and get an exact answer). Tracked on the
-[roadmap](/roadmap); this page will document the setup when it ships.
+The CLI ships a [Model Context Protocol](https://modelcontextprotocol.io) server
+that gives your agent live, typed tools instead of guesswork. Install the CLI
+(`cargo install ultimo-cli`) and register the server with your agent:
+
+```json
+{
+  "mcpServers": {
+    "ultimo": { "command": "ultimo", "args": ["mcp"] }
+  }
+}
+```
+
+(In Claude Code: `claude mcp add ultimo -- ultimo mcp`. In Cursor: add the block
+above to `~/.cursor/mcp.json`.)
+
+The server exposes these tools:
+
+| Tool | What it does |
+|---|---|
+| `search_docs` | Search the current Ultimo docs and return the most relevant sections. |
+| `get_doc` | Return a named docs page in full. |
+| `list_examples` / `get_example` | List runnable examples and read their source. |
+| `scaffold` | Create a new Ultimo project from a template (`basic`/`rpc`/…). |
+| `introspect_rpc` | Build a project's `RpcRegistry` and return its generated typed client + procedure list — the agent asks "what's my typed API?" and gets an exact answer. |
+
+The docs tools stay current by reading the live `llms.txt` corpus, so the agent
+is grounded in the deployed API rather than stale memory.
 
 ## Prompting tips
 

--- a/docs-site/docs/pages/cli.mdx
+++ b/docs-site/docs/pages/cli.mdx
@@ -248,6 +248,17 @@ the running server, rebuilds with `cargo build`, and restarts. Compilation
 errors are printed inline — the watcher stays active so the server restarts
 automatically once you fix the error.
 
+## MCP Server (for AI coding agents)
+
+`ultimo mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io)
+server over stdio, giving a coding agent live tools: search the docs, list/read
+examples, scaffold projects, and introspect a project's typed RPC surface. See
+[Using Ultimo with AI coding agents](/ai-agents) for the setup.
+
+```bash
+ultimo mcp   # speaks MCP over stdio (run by your agent, not directly)
+```
+
 ## Future Commands
 
 > ⚠️ **Not implemented yet.** These commands exist as placeholders and currently

--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -78,7 +78,6 @@ dependencies and rot as each vendor's API changes).
 
 ### Maybe / demand-driven (post-1.0)
 
-- 🤖 **MCP server** — Model Context Protocol server for AI-assisted development.
 - 🌍 **Python client generation** — extend the codegen engine beyond TypeScript.
 
 > Removed from the roadmap: HTTP/2 Push (deprecated in browsers), Long Polling
@@ -144,7 +143,7 @@ dependencies and rot as each vendor's API changes).
 | End-to-end Typed Errors                                 | 📋 Planned       | 0.9.0    |
 | S3-compatible Storage                                   | 💡 Demand-driven | post-1.0 |
 | Background Tasks                                        | 💡 Demand-driven | post-1.0 |
-| MCP Server                                              | 💡 Demand-driven | post-1.0 |
+| MCP Server (`ultimo mcp`)                               | ✅ Available     | 0.9.2    |
 | Python Client Generation                                | 💡 Demand-driven | post-1.0 |
 
 ## Version Timeline

--- a/docs/superpowers/specs/2026-09-01-ultimo-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-09-01-ultimo-mcp-server-design.md
@@ -1,0 +1,135 @@
+# Ultimo MCP Server — Design
+
+**Date:** 2026-09-01
+**Status:** Approved (design)
+**Target:** additive to `ultimo-cli` → patch release
+**Part of:** the AI-native initiative (WS3), plan at `docs/superpowers/plans/` / `~/.claude/plans/wiggly-kindling-dove.md`
+
+## Goal
+
+Give a coding agent building an Ultimo app **live, typed tools** instead of guessing
+from stale training data. Shipped as an `ultimo mcp` subcommand: a stdio
+[Model Context Protocol](https://modelcontextprotocol.io) server the agent
+(Claude Code, Cursor, …) connects to.
+
+The agent gains five tools: search the current docs, fetch a doc page, list/get
+runnable examples, scaffold a project, and — the differentiator — **introspect a
+project's typed RPC surface**.
+
+## Non-goals (v1)
+
+- `api_lookup(symbol)` — docs search covers it (YAGNI).
+- HTTP/SSE transport — stdio only (local agent tools).
+- A separate published `ultimo-mcp` crate — it's a CLI subcommand, reusing the
+  existing CLI distribution.
+- End-to-end stdio testing in CI — the tool functions are tested directly.
+
+## Architecture
+
+- New subcommand `Commands::Mcp` in `ultimo-cli/src/main.rs`; new module
+  `ultimo-cli/src/mcp/`.
+- Server built on **`rmcp`** (the official Rust MCP SDK: `#[tool]` /
+  `#[tool_router]` / `#[tool_handler]` macros, tokio, stdio transport). The CLI is
+  already `#[tokio::main]` async + clap-derive, so this drops in cleanly.
+- Tools are async methods on an `UltimoMcp` server struct, each `#[tool]`-annotated
+  with a documented input schema (serde/schemars-derived per rmcp).
+
+## Tools
+
+### 1. `search_docs(query: String) -> String`
+Fetch `https://docs.ultimo.dev/llms-full.txt`, split into sections (by page /
+`##` heading), rank sections by query-term overlap, and return the top N (≈5)
+with their page titles. Keeps the agent grounded in the deployed API.
+
+### 2. `get_doc(page: String) -> String`
+Return a named page's full text from the same corpus (match on page title/slug).
+
+### 3. `list_examples() -> String` / `get_example(name: String) -> String`
+`list_examples` returns a **bundled manifest** (name, one-line description,
+GitHub URL) — examples change rarely, so a small in-binary list is fine.
+`get_example` fetches the example's raw `main.rs` from
+`raw.githubusercontent.com`.
+
+### 4. `scaffold(template: String, name: String, path: Option<String>) -> String`
+Run the `ultimo new` scaffolding into `path` (default: cwd), returning the created
+file tree. Requires refactoring `new::run` to accept a base directory (today it
+writes to cwd). Post-WS1 the output builds and includes `AGENTS.md`.
+
+### 5. `introspect_rpc(project_path: String) -> String`
+The differentiator. Reuse `generate.rs`'s runner (`cargo run --bin generate-client
+-- <tmp>`) to build the project's own `RpcRegistry` and emit its typed client to a
+temp file, then return: the generated TypeScript client text **plus** the
+extracted procedure list (method names, query vs mutation). The agent asks "what's
+my typed API surface?" and gets an exact, current answer. If the project has no
+`generate-client` bin, return the same teaching error `ultimo generate` gives.
+
+## Docs fetch + cache
+
+A small fetch layer wraps `reqwest`:
+- GET `llms-full.txt` (and, for `get_doc`, sections thereof), cache the corpus
+  in-process with a TTL (e.g. 1 h).
+- **The corpus source is an injectable closure** (mirroring the framework's
+  `JwksClient` fetch-closure pattern in `ultimo/src/auth/jwks.rs`) so unit tests
+  supply a fixed corpus string and never touch the network.
+
+## Distribution & configuration
+
+`ultimo mcp` serves over stdio. Documented client config (fills the stubbed MCP
+section in `docs-site/docs/pages/ai-agents.mdx`):
+
+```json
+{ "mcpServers": { "ultimo": { "command": "ultimo", "args": ["mcp"] } } }
+```
+
+## Dependencies
+
+Add to `ultimo-cli/Cargo.toml`:
+- `rmcp` with the server + macros + stdio-transport features.
+- `reqwest` with `rustls-tls` + `json` (no OpenSSL; matches the framework's `oidc`
+  choice).
+
+Both must pass `cargo-deny` (license allow-list; `CDLA-Permissive-2.0` already
+allowed for webpki-roots) and `cargo-audit`. `tokio` (full) is already present.
+
+## Error handling
+
+- Network failures in `search_docs`/`get_doc`/`get_example` return a clear tool
+  error ("couldn't reach docs.ultimo.dev — check connectivity"), never a panic.
+- `introspect_rpc` surfaces the project's build/generate error text (actionable),
+  and the missing-bin teaching error when applicable.
+- `scaffold` errors (dir exists, unknown template) return the CLI's existing
+  messages.
+
+## Testing
+
+- **Unit (`mcp` module):**
+  - corpus parse + `search_docs` ranking over a fixed injected corpus (no network);
+  - `get_doc` returns the right section from a fixed corpus;
+  - examples manifest is well-formed (names/urls parse);
+  - `scaffold` creates the expected files in a tempdir (mirrors existing `new` tests).
+- **Integration:** `introspect_rpc` reuses the existing generate-client test
+  harness (a tempdir project whose `generate-client` bin writes its arg) and
+  asserts the returned client text + extracted names.
+- No test hits the network (corpus + example fetches are injectable / skipped).
+
+## SemVer & release
+
+Additive to `ultimo-cli` (new subcommand, new deps) → **patch** bump.
+`semver-checks` targets the `ultimo` library, unaffected. release-plz cuts the
+`ultimo-cli` patch.
+
+## Rollout / task shape (for the plan)
+
+1. Subcommand + `rmcp` stdio server skeleton (one trivial `ping`/`search_docs` tool) — proves the transport.
+2. Docs tools: fetch+cache layer (injectable), `search_docs`, `get_doc`.
+3. Examples tools: bundled manifest + `list_examples`/`get_example`.
+4. `scaffold` (refactor `new::run` to take a base dir) + tool.
+5. `introspect_rpc` (reuse `generate.rs` runner) + tool.
+6. Docs + config: fill `ai-agents.mdx` MCP section, `cli.mdx`, roadmap bump (WS5 overlap).
+7. Gate + PR.
+
+## Follow-ups (not this spec)
+
+- `api_lookup(symbol)` for exact framework signatures.
+- HTTP/SSE transport for hosted use.
+- Deeper RPC introspection (typed schema graph, not just the generated client).

--- a/ultimo-cli/Cargo.toml
+++ b/ultimo-cli/Cargo.toml
@@ -23,6 +23,8 @@ anyhow = "1.0"
 colored = "2.1"
 notify = "8"
 notify-debouncer-mini = "0.5"
+rmcp = { version = "0.16", features = ["server", "transport-io", "macros"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/ultimo-cli/Cargo.toml
+++ b/ultimo-cli/Cargo.toml
@@ -9,6 +9,10 @@ homepage.workspace = true
 repository.workspace = true
 keywords = ["cli", "codegen", "typescript", "web", "framework"]
 categories = ["command-line-utilities", "development-tools"]
+# The CLI's MCP server (rmcp, edition 2024) needs a newer toolchain than the
+# `ultimo` library, which keeps its MSRV. This only affects building the CLI
+# from source; installing a released binary is unaffected.
+rust-version = "1.88"
 
 [[bin]]
 name = "ultimo"

--- a/ultimo-cli/Cargo.toml
+++ b/ultimo-cli/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0"
 colored = "2.1"
 notify = "8"
 notify-debouncer-mini = "0.5"
-rmcp = { version = "0.16", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "3", features = ["server", "transport-io", "macros"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 [dev-dependencies]

--- a/ultimo-cli/src/main.rs
+++ b/ultimo-cli/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 mod dev;
 mod generate;
+mod mcp;
 mod new;
 
 #[derive(Parser)]
@@ -59,11 +60,20 @@ enum Commands {
         #[arg(short, long, default_value = "release")]
         profile: String,
     },
+
+    /// Run a Model Context Protocol server (stdio) for AI coding agents
+    Mcp,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
+    // The MCP server speaks JSON-RPC over stdout — it must emit no banner or any
+    // other stdout noise, so handle it before printing anything.
+    if let Commands::Mcp = cli.command {
+        return mcp::run().await;
+    }
 
     println!("{}", "⚡ Ultimo Framework CLI".bold().cyan());
     println!();
@@ -89,6 +99,8 @@ async fn main() -> anyhow::Result<()> {
                 "cargo build --release".cyan()
             );
         }
+        // Handled before the banner above.
+        Commands::Mcp => unreachable!(),
     }
 
     Ok(())

--- a/ultimo-cli/src/mcp/docs.rs
+++ b/ultimo-cli/src/mcp/docs.rs
@@ -1,0 +1,225 @@
+//! Fetch, cache, and search the Ultimo documentation corpus (`llms-full.txt`).
+//!
+//! The fetch step is a closure so tests can supply a fixed corpus string and
+//! never touch the network (mirrors the framework's `JwksClient` pattern).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+type FetchFut = Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send>>;
+type FetchFn = Arc<dyn Fn() -> FetchFut + Send + Sync>;
+
+/// One documentation page, parsed from a `## Heading` section of `llms-full.txt`.
+#[derive(Debug, Clone)]
+pub struct Section {
+    pub title: String,
+    pub body: String,
+}
+
+/// The parsed documentation corpus.
+#[derive(Debug, Clone, Default)]
+pub struct Corpus {
+    pub sections: Vec<Section>,
+}
+
+impl Corpus {
+    /// Parse `llms-full.txt`. Pages are `## Heading` (H2) blocks; single-`#` lines
+    /// are code-block comments, not page boundaries, so we split only on `## `.
+    pub fn parse(raw: &str) -> Self {
+        let mut sections = Vec::new();
+        let mut title: Option<String> = None;
+        let mut body = String::new();
+        for line in raw.lines() {
+            if let Some(h) = line.strip_prefix("## ") {
+                if let Some(t) = title.take() {
+                    sections.push(Section {
+                        title: t,
+                        body: body.trim().to_string(),
+                    });
+                    body.clear();
+                }
+                title = Some(h.trim().to_string());
+            } else if title.is_some() {
+                body.push_str(line);
+                body.push('\n');
+            }
+        }
+        if let Some(t) = title.take() {
+            sections.push(Section {
+                title: t,
+                body: body.trim().to_string(),
+            });
+        }
+        Corpus { sections }
+    }
+
+    /// Rank sections by overlap with the query terms and return the top `n`,
+    /// each as its heading plus a snippet of the body.
+    pub fn search(&self, query: &str, n: usize) -> String {
+        let terms: Vec<String> = query
+            .split_whitespace()
+            .map(|t| t.to_lowercase())
+            .filter(|t| t.len() > 1)
+            .collect();
+        if terms.is_empty() {
+            return "Empty query.".to_string();
+        }
+
+        let mut scored: Vec<(usize, &Section)> = self
+            .sections
+            .iter()
+            .map(|s| {
+                let title_l = s.title.to_lowercase();
+                let body_l = s.body.to_lowercase();
+                let score: usize = terms
+                    .iter()
+                    .map(|t| {
+                        // Title matches weigh more than body matches.
+                        body_l.matches(t.as_str()).count() + title_l.matches(t.as_str()).count() * 5
+                    })
+                    .sum();
+                (score, s)
+            })
+            .filter(|(score, _)| *score > 0)
+            .collect();
+
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+
+        if scored.is_empty() {
+            return format!("No Ultimo docs match '{query}'.");
+        }
+
+        let mut out = String::new();
+        for (_, s) in scored.into_iter().take(n) {
+            out.push_str("## ");
+            out.push_str(&s.title);
+            out.push('\n');
+            out.push_str(&snippet(&s.body, 1200));
+            out.push_str("\n\n");
+        }
+        out.trim_end().to_string()
+    }
+
+    /// Return the full body of the page whose title best matches `name`
+    /// (case-insensitive: exact, then contains).
+    pub fn page(&self, name: &str) -> Option<String> {
+        let want = name.trim().to_lowercase();
+        self.sections
+            .iter()
+            .find(|s| s.title.to_lowercase() == want)
+            .or_else(|| {
+                self.sections
+                    .iter()
+                    .find(|s| s.title.to_lowercase().contains(&want))
+            })
+            .map(|s| format!("## {}\n{}", s.title, s.body))
+    }
+}
+
+fn snippet(body: &str, max: usize) -> String {
+    if body.len() <= max {
+        body.to_string()
+    } else {
+        let mut end = max;
+        while end < body.len() && !body.is_char_boundary(end) {
+            end += 1;
+        }
+        format!("{}…", &body[..end])
+    }
+}
+
+/// Fetches the docs corpus on demand and caches the parsed result with a TTL.
+#[derive(Clone)]
+pub struct DocsCorpus {
+    fetch: FetchFn,
+    cache: Arc<RwLock<Option<(Arc<Corpus>, Instant)>>>,
+    ttl: Duration,
+}
+
+impl DocsCorpus {
+    /// Construct from a raw fetch closure (used by tests with a fixed corpus).
+    pub fn from_fetch<F>(f: F) -> Self
+    where
+        F: Fn() -> FetchFut + Send + Sync + 'static,
+    {
+        Self {
+            fetch: Arc::new(f),
+            cache: Arc::new(RwLock::new(None)),
+            ttl: Duration::from_secs(3600),
+        }
+    }
+
+    /// Fetch the corpus over HTTP from `url` (the deployed `llms-full.txt`).
+    pub fn from_url(url: impl Into<String>) -> Self {
+        let url = url.into();
+        Self::from_fetch(move || {
+            let url = url.clone();
+            Box::pin(async move {
+                let text = reqwest::get(&url).await?.error_for_status()?.text().await?;
+                Ok(text)
+            })
+        })
+    }
+
+    /// Return the parsed corpus, fetching (and caching) if needed.
+    pub async fn get(&self) -> anyhow::Result<Arc<Corpus>> {
+        {
+            let guard = self.cache.read().await;
+            if let Some((corpus, at)) = guard.as_ref() {
+                if at.elapsed() < self.ttl {
+                    return Ok(corpus.clone());
+                }
+            }
+        }
+        let raw = (self.fetch)().await?;
+        let corpus = Arc::new(Corpus::parse(&raw));
+        *self.cache.write().await = Some((corpus.clone(), Instant::now()));
+        Ok(corpus)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "# Ultimo\n\n> intro\n\n## Server-Sent Events\nUse ctx.sse to push events.\n# not a heading (code comment)\nMore SSE text.\n\n## WebSocket\nRFC 6455 support via app.websocket.\n";
+
+    #[test]
+    fn parse_splits_on_h2_only() {
+        let c = Corpus::parse(SAMPLE);
+        let titles: Vec<_> = c.sections.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(titles, vec!["Server-Sent Events", "WebSocket"]);
+        // The `# not a heading` line stays inside the SSE section body.
+        assert!(c.sections[0].body.contains("code comment"));
+    }
+
+    #[test]
+    fn search_ranks_relevant_section_first() {
+        let c = Corpus::parse(SAMPLE);
+        let out = c.search("sse events", 5);
+        assert!(out.starts_with("## Server-Sent Events"), "got: {out}");
+    }
+
+    #[test]
+    fn search_reports_no_match() {
+        let c = Corpus::parse(SAMPLE);
+        assert!(c.search("graphql", 5).contains("No Ultimo docs match"));
+    }
+
+    #[test]
+    fn page_matches_by_title() {
+        let c = Corpus::parse(SAMPLE);
+        let page = c.page("websocket").unwrap();
+        assert!(page.contains("RFC 6455"));
+    }
+
+    #[tokio::test]
+    async fn docs_corpus_caches_and_serves_injected_corpus() {
+        let corpus = DocsCorpus::from_fetch(|| Box::pin(async { Ok(SAMPLE.to_string()) }));
+        let c = corpus.get().await.unwrap();
+        assert_eq!(c.sections.len(), 2);
+    }
+}

--- a/ultimo-cli/src/mcp/docs.rs
+++ b/ultimo-cli/src/mcp/docs.rs
@@ -87,7 +87,7 @@ impl Corpus {
             .filter(|(score, _)| *score > 0)
             .collect();
 
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
 
         if scored.is_empty() {
             return format!("No Ultimo docs match '{query}'.");

--- a/ultimo-cli/src/mcp/docs.rs
+++ b/ultimo-cli/src/mcp/docs.rs
@@ -11,6 +11,7 @@ use tokio::sync::RwLock;
 
 type FetchFut = Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send>>;
 type FetchFn = Arc<dyn Fn() -> FetchFut + Send + Sync>;
+type CorpusCache = Arc<RwLock<Option<(Arc<Corpus>, Instant)>>>;
 
 /// One documentation page, parsed from a `## Heading` section of `llms-full.txt`.
 #[derive(Debug, Clone)]
@@ -135,7 +136,7 @@ fn snippet(body: &str, max: usize) -> String {
 #[derive(Clone)]
 pub struct DocsCorpus {
     fetch: FetchFn,
-    cache: Arc<RwLock<Option<(Arc<Corpus>, Instant)>>>,
+    cache: CorpusCache,
     ttl: Duration,
 }
 

--- a/ultimo-cli/src/mcp/examples.rs
+++ b/ultimo-cli/src/mcp/examples.rs
@@ -1,0 +1,87 @@
+//! The bundled catalog of runnable Ultimo examples, and a fetcher for their
+//! source. The list changes rarely, so it lives in the binary; `get_example`
+//! pulls the current source from GitHub on demand.
+
+/// (name, one-line description). `name` is the directory under `examples/`.
+const EXAMPLES: &[(&str, &str)] = &[
+    ("basic", "Minimal REST API."),
+    (
+        "rpc-modes",
+        "Typed RPC → TypeScript client + React hooks (REST and JSON-RPC modes).",
+    ),
+    ("openapi-demo", "Generate an OpenAPI spec + Swagger UI."),
+    ("database-sqlx", "Postgres persistence with SQLx."),
+    ("database-diesel", "Postgres persistence with Diesel."),
+    (
+        "database-api-styles",
+        "REST vs RPC over the same SQLx data layer.",
+    ),
+    (
+        "websocket-chat",
+        "WebSocket chat with the built-in pub/sub.",
+    ),
+    (
+        "websocket-chat-react",
+        "WebSocket chat with a React frontend.",
+    ),
+    ("session-auth", "Cookie sessions + login (session feature)."),
+    ("jwt-auth", "JWT login → protected route (jwt feature)."),
+    ("spa-demo", "Serve a single-page app with fallback routing."),
+    ("streaming", "Chunked/streaming responses via ctx.stream."),
+    ("sse", "Server-Sent Events via ctx.sse + EventSource."),
+];
+
+const RAW_BASE: &str = "https://raw.githubusercontent.com/ultimo-rs/ultimo/main/examples";
+const TREE_BASE: &str = "https://github.com/ultimo-rs/ultimo/tree/main/examples";
+
+/// A formatted catalog of examples for `list_examples`.
+pub fn catalog() -> String {
+    let mut out = String::from("Runnable Ultimo examples (run with `cargo run -p <name>`):\n\n");
+    for (name, desc) in EXAMPLES {
+        out.push_str(&format!("- {name} — {desc}\n"));
+    }
+    out.push_str("\nUse get_example(name) to read an example's source.");
+    out
+}
+
+/// Fetch an example's `src/main.rs` from GitHub, or explain how to browse it.
+pub async fn source(name: &str) -> String {
+    let name = name.trim();
+    if !EXAMPLES.iter().any(|(n, _)| *n == name) {
+        let names: Vec<&str> = EXAMPLES.iter().map(|(n, _)| *n).collect();
+        return format!("Unknown example '{name}'. Available: {}", names.join(", "));
+    }
+    let url = format!("{RAW_BASE}/{name}/src/main.rs");
+    match reqwest::get(&url).await.and_then(|r| r.error_for_status()) {
+        Ok(resp) => match resp.text().await {
+            Ok(text) => format!("// {TREE_BASE}/{name}\n\n{text}"),
+            Err(e) => fetch_hint(name, &e.to_string()),
+        },
+        Err(e) => fetch_hint(name, &e.to_string()),
+    }
+}
+
+fn fetch_hint(name: &str, err: &str) -> String {
+    format!(
+        "Could not fetch {name}/src/main.rs ({err}). Browse it at {TREE_BASE}/{name} \
+         (some examples have multiple files)."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_lists_known_examples() {
+        let c = catalog();
+        assert!(c.contains("rpc-modes"));
+        assert!(c.contains("sse"));
+    }
+
+    #[tokio::test]
+    async fn source_rejects_unknown_example() {
+        let out = source("does-not-exist").await;
+        assert!(out.contains("Unknown example"));
+    }
+}

--- a/ultimo-cli/src/mcp/mod.rs
+++ b/ultimo-cli/src/mcp/mod.rs
@@ -6,6 +6,7 @@
 //! stderr.
 
 mod docs;
+mod examples;
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -13,7 +14,9 @@ use rmcp::model::{ServerCapabilities, ServerInfo};
 use rmcp::transport::stdio;
 use rmcp::{schemars, tool, tool_handler, tool_router, ServerHandler, ServiceExt};
 use serde::Deserialize;
+use std::path::Path;
 use std::sync::Arc;
+use tokio::process::Command;
 
 use docs::DocsCorpus;
 
@@ -22,6 +25,7 @@ const LLMS_FULL_URL: &str = "https://docs.ultimo.dev/llms-full.txt";
 /// The Ultimo MCP server.
 #[derive(Clone)]
 pub struct UltimoMcp {
+    #[expect(dead_code, reason = "tool_handler macro accesses this router field")]
     tool_router: ToolRouter<Self>,
     docs: Arc<DocsCorpus>,
 }
@@ -55,6 +59,28 @@ pub struct GetDocInput {
     pub page: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetExampleInput {
+    /// The example name (e.g. "rpc-modes", "sse", "jwt-auth").
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ScaffoldInput {
+    /// Template: basic, fullstack, api-only, rpc, or production.
+    pub template: String,
+    /// Project name (a new directory with this name is created).
+    pub name: String,
+    /// Directory to create the project in. Defaults to the current directory.
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct IntrospectRpcInput {
+    /// Path to the Ultimo project directory (must contain a `generate-client` bin).
+    pub project_path: String,
+}
+
 #[tool_router]
 impl UltimoMcp {
     #[tool(
@@ -79,20 +105,182 @@ impl UltimoMcp {
             Err(e) => format!("Could not fetch Ultimo docs from {LLMS_FULL_URL}: {e}"),
         }
     }
+
+    #[tool(
+        description = "List the runnable Ultimo example projects with a one-line description of each."
+    )]
+    async fn list_examples(&self) -> String {
+        examples::catalog()
+    }
+
+    #[tool(description = "Return the source of a named Ultimo example (fetched from GitHub).")]
+    async fn get_example(
+        &self,
+        Parameters(GetExampleInput { name }): Parameters<GetExampleInput>,
+    ) -> String {
+        examples::source(&name).await
+    }
+
+    #[tool(
+        description = "Scaffold a new Ultimo project from a template into a directory, returning the created file tree. Templates: basic, fullstack, api-only, rpc, production."
+    )]
+    async fn scaffold(
+        &self,
+        Parameters(ScaffoldInput {
+            template,
+            name,
+            path,
+        }): Parameters<ScaffoldInput>,
+    ) -> String {
+        scaffold(&template, &name, path.as_deref()).await
+    }
+
+    #[tool(
+        description = "Introspect an Ultimo project's typed RPC surface: build its RpcRegistry (via its generate-client bin) and return the generated TypeScript client plus the procedure list. Use this to see the project's exact typed API."
+    )]
+    async fn introspect_rpc(
+        &self,
+        Parameters(IntrospectRpcInput { project_path }): Parameters<IntrospectRpcInput>,
+    ) -> String {
+        introspect_rpc(&project_path).await
+    }
+}
+
+/// Shell out to this same `ultimo` binary as a subprocess. Its stdout is a
+/// separate stream from the MCP server's stdout, so reusing the CLI's own
+/// (stdout-printing) logic can't corrupt the protocol.
+async fn scaffold(template: &str, name: &str, path: Option<&str>) -> String {
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(e) => return format!("Cannot locate the ultimo binary: {e}"),
+    };
+    let base = path.unwrap_or(".");
+    let output = Command::new(&exe)
+        .args(["new", name, "--template", template])
+        .current_dir(base)
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => {
+            let dir = Path::new(base).join(name);
+            format!(
+                "Scaffolded '{name}' ({template}) at {}:\n\n{}",
+                dir.display(),
+                file_tree(&dir)
+            )
+        }
+        Ok(o) => format!(
+            "Scaffold failed:\n{}{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        ),
+        Err(e) => format!("Failed to run `ultimo new`: {e}"),
+    }
+}
+
+async fn introspect_rpc(project_path: &str) -> String {
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(e) => return format!("Cannot locate the ultimo binary: {e}"),
+    };
+    let tmp = std::env::temp_dir().join(format!("ultimo-introspect-{}.ts", std::process::id()));
+    let output = Command::new(&exe)
+        .args(["generate", "--project", project_path, "--output"])
+        .arg(&tmp)
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => match std::fs::read_to_string(&tmp) {
+            Ok(client) => {
+                let procs = extract_procedures(&client);
+                let _ = std::fs::remove_file(&tmp);
+                let list = if procs.is_empty() {
+                    "(none detected)".to_string()
+                } else {
+                    procs.join(", ")
+                };
+                format!("Procedures: {list}\n\n--- generated TypeScript client ---\n{client}")
+            }
+            Err(e) => format!("The client was generated but could not be read: {e}"),
+        },
+        Ok(o) => format!(
+            "Could not introspect the RPC surface:\n{}{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        ),
+        Err(e) => format!("Failed to run `ultimo generate`: {e}"),
+    }
+}
+
+/// Best-effort: pull the client method names out of a generated `UltimoRpcClient`.
+fn extract_procedures(client_ts: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in client_ts.lines() {
+        let t = line.trim();
+        // Matches generated methods like `async getUser(input: ...)` / `getUser(`.
+        let sig = t.strip_prefix("async ").unwrap_or(t);
+        if let Some((ident, rest)) = sig.split_once('(') {
+            if !rest.is_empty()
+                && !ident.is_empty()
+                && ident.chars().all(|c| c.is_alphanumeric() || c == '_')
+                && ident.chars().next().is_some_and(|c| c.is_lowercase())
+                && !matches!(
+                    ident,
+                    "constructor" | "if" | "for" | "while" | "switch" | "catch"
+                )
+            {
+                names.push(ident.to_string());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// A sorted, `target/`-free list of files under `dir`, relative to it.
+fn file_tree(dir: &Path) -> String {
+    let mut files = Vec::new();
+    collect_files(dir, dir, &mut files);
+    files.sort();
+    if files.is_empty() {
+        "(no files)".to_string()
+    } else {
+        files.join("\n")
+    }
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            if p.file_name()
+                .is_some_and(|n| n == "target" || n == "node_modules")
+            {
+                continue;
+            }
+            collect_files(root, &p, out);
+        } else if let Ok(rel) = p.strip_prefix(root) {
+            out.push(rel.display().to_string());
+        }
+    }
 }
 
 #[tool_handler]
 impl ServerHandler for UltimoMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "Tools for building apps with the Ultimo Rust web framework: search the docs, \
-                 read examples, scaffold projects, and introspect a project's typed RPC surface."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
+        // `ServerInfo` is `#[non_exhaustive]`, so build via Default + field set.
+        let mut info = ServerInfo::default();
+        info.instructions = Some(
+            "Tools for building apps with the Ultimo Rust web framework: search the docs, \
+             read examples, scaffold projects, and introspect a project's typed RPC surface."
+                .into(),
+        );
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
     }
 }
 
@@ -101,4 +289,22 @@ pub async fn run() -> anyhow::Result<()> {
     let service = UltimoMcp::new().serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_procedures_from_generated_client() {
+        let client = r#"
+export class UltimoRpcClient {
+  constructor(private baseUrl: string) {}
+  async getUser(input: GetUserInput): Promise<User> { }
+  async createUser(input: CreateUserInput): Promise<User> { }
+}
+"#;
+        let procs = extract_procedures(client);
+        assert_eq!(procs, vec!["createUser", "getUser"]);
+    }
 }

--- a/ultimo-cli/src/mcp/mod.rs
+++ b/ultimo-cli/src/mcp/mod.rs
@@ -1,0 +1,104 @@
+//! `ultimo mcp` — a Model Context Protocol server (stdio) that gives coding
+//! agents live, typed tools for building Ultimo apps: search the docs, list and
+//! read examples, scaffold projects, and introspect a project's typed RPC surface.
+//!
+//! IMPORTANT: the MCP protocol owns stdout; never `println!` here — logs go to
+//! stderr.
+
+mod docs;
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::transport::stdio;
+use rmcp::{schemars, tool, tool_handler, tool_router, ServerHandler, ServiceExt};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use docs::DocsCorpus;
+
+const LLMS_FULL_URL: &str = "https://docs.ultimo.dev/llms-full.txt";
+
+/// The Ultimo MCP server.
+#[derive(Clone)]
+pub struct UltimoMcp {
+    tool_router: ToolRouter<Self>,
+    docs: Arc<DocsCorpus>,
+}
+
+impl UltimoMcp {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            docs: Arc::new(DocsCorpus::from_url(LLMS_FULL_URL)),
+        }
+    }
+}
+
+impl Default for UltimoMcp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SearchDocsInput {
+    /// What to search the Ultimo documentation for (e.g. "server-sent events",
+    /// "jwt middleware", "rpc client generation").
+    pub query: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetDocInput {
+    /// The documentation page title or slug (e.g. "sse", "Server-Sent Events",
+    /// "jwt", "rpc").
+    pub page: String,
+}
+
+#[tool_router]
+impl UltimoMcp {
+    #[tool(
+        description = "Search the Ultimo documentation and return the most relevant sections. Use this to ground yourself in the current Ultimo API before writing code, instead of relying on memory."
+    )]
+    async fn search_docs(
+        &self,
+        Parameters(SearchDocsInput { query }): Parameters<SearchDocsInput>,
+    ) -> String {
+        match self.docs.get().await {
+            Ok(corpus) => corpus.search(&query, 5),
+            Err(e) => format!("Could not fetch Ultimo docs from {LLMS_FULL_URL}: {e}"),
+        }
+    }
+
+    #[tool(description = "Return the full text of a named Ultimo documentation page.")]
+    async fn get_doc(&self, Parameters(GetDocInput { page }): Parameters<GetDocInput>) -> String {
+        match self.docs.get().await {
+            Ok(corpus) => corpus
+                .page(&page)
+                .unwrap_or_else(|| format!("No Ultimo docs page matches '{page}'.")),
+            Err(e) => format!("Could not fetch Ultimo docs from {LLMS_FULL_URL}: {e}"),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for UltimoMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "Tools for building apps with the Ultimo Rust web framework: search the docs, \
+                 read examples, scaffold projects, and introspect a project's typed RPC surface."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Run the stdio MCP server until the client disconnects.
+pub async fn run() -> anyhow::Result<()> {
+    let service = UltimoMcp::new().serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/ultimo-cli/tests/cli.rs
+++ b/ultimo-cli/tests/cli.rs
@@ -19,7 +19,8 @@ fn help_lists_the_real_subcommands() {
         .stdout(contains("generate"))
         .stdout(contains("new"))
         .stdout(contains("dev"))
-        .stdout(contains("build"));
+        .stdout(contains("build"))
+        .stdout(contains("mcp"));
 }
 
 #[test]


### PR DESCRIPTION
WS3 — the payoff feature of the AI-native initiative. An `ultimo mcp` stdio [Model Context Protocol](https://modelcontextprotocol.io) server (built on `rmcp`) that gives a coding agent live, typed tools for building Ultimo apps.

## Tools
- **`search_docs` / `get_doc`** — search and read the current docs, fetched from the live `llms-full.txt` (cached; corpus source is an injectable closure so tests never hit the network).
- **`list_examples` / `get_example`** — catalog + source of runnable examples.
- **`scaffold`** — create a project from a template, returning the file tree.
- **`introspect_rpc`** — the differentiator: runs the project's `generate-client` bin and returns the generated typed TS client + procedure list ("what's my typed API?").

## Design notes
- `scaffold`/`introspect_rpc` shell out to this same `ultimo` binary as a **subprocess** — its stdout is separate from the MCP server's, so the CLI's `println!`-heavy logic can't corrupt the JSON-RPC stdio stream. The `mcp` subcommand itself prints nothing to stdout.
- **rmcp 0.16 → 3.2** upgrade clears **RUSTSEC-2026-0189** (a DNS-rebinding advisory in rmcp's *HTTP* transport, which this server doesn't use — but upgrading is cleaner than ignoring for a supply-chain-conscious project).

## Verified
End-to-end over stdio: `initialize` + `tools/list` expose all six tools; `scaffold` via `tools/call` creates a real rpc project on disk. 18 `ultimo-cli` tests pass; `cargo-deny`/`cargo-audit` green.

## Docs
`ai-agents.mdx` MCP setup (config snippet + tool table), `cli.mdx`, and the roadmap moved MCP → ✅ Available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)