### PR TITLE
docs: fix MCP roadmap version (0.9.2 → 0.9.1)

### DIFF
--- a/docs-site/docs/pages/roadmap.mdx
+++ b/docs-site/docs/pages/roadmap.mdx
@@ -143,7 +143,7 @@ dependencies and rot as each vendor's API changes).
 | End-to-end Typed Errors                                 | 📋 Planned       | 0.9.0    |
 | S3-compatible Storage                                   | 💡 Demand-driven | post-1.0 |
 | Background Tasks                                        | 💡 Demand-driven | post-1.0 |
-| MCP Server (`ultimo mcp`)                               | ✅ Available     | 0.9.2    |
+| MCP Server (`ultimo mcp`)                               | ✅ Available     | 0.9.1    |
 | Python Client Generation                                | 💡 Demand-driven | post-1.0 |
 
 ## Version Timeline


### PR DESCRIPTION
The MCP server ships in the pending **0.9.1** release (release-plz PR #174), alongside SSE and the rest of the post-0.9.0 work — the roadmap incorrectly said 0.9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)