### PR TITLE
docs(blog): MCP server has shipped, not 'next'

### DIFF
--- a/website/content/posts/ultimo-is-ai-native.mdx
+++ b/website/content/posts/ultimo-is-ai-native.mdx
@@ -53,9 +53,9 @@ Ultimo's documentation is published in the [`llms.txt`](https://llmstxt.org) for
 
 Ultimo is also indexed on [Context7](https://context7.com/ultimo-rs/ultimo), which serves version-accurate snippets to agents on demand. Every docs example is self-contained and compiles — because agents copy them verbatim.
 
-## What's next: the Ultimo MCP server
+## The Ultimo MCP server
 
-The next step is an `ultimo mcp` server that gives an agent *live, typed tools* instead of guesswork: search the docs, list runnable examples, scaffold a project, and — the differentiator — **introspect your project's RPC surface**, so the agent can ask "what's my typed API?" and get an exact answer. It's on the [roadmap](https://docs.ultimo.dev/roadmap).
+The CLI ships an `ultimo mcp` [Model Context Protocol](https://modelcontextprotocol.io) server that gives an agent *live, typed tools* instead of guesswork: search the docs, list runnable examples, scaffold a project, and — the differentiator — **introspect your project's RPC surface**, so the agent can ask "what's my typed API?" and get an exact answer. Install the CLI (`cargo install ultimo-cli`) and register it with your agent — see [Using Ultimo with AI coding agents](https://docs.ultimo.dev/ai-agents).
 
 ## Try it
 


### PR DESCRIPTION
The `ultimo mcp` server shipped in 0.9.1, but the AI-native blog post still framed it as the upcoming next step. Updated to reflect it's shipped, with install (`cargo install ultimo-cli`) + a link to the AI-agents guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)